### PR TITLE
Add vecmem::host_memory_manager, main branch (2021.02.06.)

### DIFF
--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -60,7 +60,7 @@ function( vecmem_add_test name )
    endif()
    foreach( _config "" "_DEBUG" "_RELEASE" "_MINSIZEREL" "_RELWITHDEBINFO" )
       set_property( TARGET ${test_exe_name} PROPERTY
-         RUNTIME_OUTPUT_DIRECTORY_${_config} "${CMAKE_BINARY_DIR}/test-bin" )
+         RUNTIME_OUTPUT_DIRECTORY${_config} "${CMAKE_BINARY_DIR}/test-bin" )
    endforeach()
 
    # Run the executable as the test.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 # Set up the build of the VecMem core library.
 vecmem_add_library( vecmem_core core SHARED
+   # STL allocators.
+   "include/vecmem/allocators/allocator.hpp"
    # STL mimicking containers.
    "include/vecmem/containers/const_device_vector.hpp"
    "include/vecmem/containers/device_vector.hpp"
@@ -15,5 +17,7 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/memory/memory_manager_interface.hpp"
    "include/vecmem/memory/memory_manager.hpp"
    "src/memory/memory_manager.cpp"
+   "include/vecmem/memory/host_memory_manager.hpp"
+   "src/memory/host_memory_manager.cpp"
    # Utilities.
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/allocators/allocator.hpp
+++ b/core/include/vecmem/allocators/allocator.hpp
@@ -1,0 +1,75 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/memory_manager.hpp"
+#include "vecmem/memory/memory_manager_interface.hpp"
+
+// System include(s).
+#include <cstddef>
+#include <type_traits>
+
+namespace vecmem {
+
+   /// STL allocator using the "currently active" memory manager
+   template< typename TYPE >
+   class allocator {
+
+   public:
+      /// @name Type definitions that need to be provided by the allocator
+      /// @{
+      typedef std::size_t    size_type;
+      typedef std::ptrdiff_t difference_type;
+      typedef TYPE*          pointer;
+      typedef const TYPE*    const_pointer;
+      typedef TYPE&          reference;
+      typedef const TYPE&    const_reference;
+      typedef TYPE           value_type;
+      /// @}
+
+      /// @name "Behaviour declarations" for the allocator
+      /// @{
+      typedef std::true_type propagate_on_container_move_assignment;
+      typedef std::true_type is_always_equal;
+      /// @}
+
+      /// Allocate a requested amount of memory
+      pointer allocate( size_type n, const void* = nullptr ) {
+         memory_manager_interface& mmgr = memory_manager::instance().get();
+         return static_cast< pointer >(
+            mmgr.allocate( n * sizeof( value_type ) ) );
+      }
+
+      /// Deallocate a previously allocated block of memory
+      void deallocate( pointer ptr, size_type ) {
+         memory_manager_interface& mmgr = memory_manager::instance().get();
+         mmgr.deallocate( ptr );
+      }
+
+      /// Only initialise the memory if it is host-accessible.
+      template< typename U, typename... Args >
+      void construct( U* ptr, Args&&... args ) {
+         memory_manager_interface& mmgr = memory_manager::instance().get();
+         if( mmgr.is_host_accessible() ) {
+            new( ptr ) U( std::forward< Args >( args )... );
+         }
+         return;
+      }
+
+      /// Only destroy objects in host-accessible memory.
+      template< typename U >
+      void destroy( U* ptr ) {
+         memory_manager_interface& mmgr = memory_manager::instance().get();
+         if( mmgr.is_host_accessible() ) {
+            ptr->~U();
+         }
+      }
+
+   }; // class allocator
+
+} // namespace vecmem

--- a/core/include/vecmem/memory/host_memory_manager.hpp
+++ b/core/include/vecmem/memory/host_memory_manager.hpp
@@ -1,0 +1,53 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/memory_manager_interface.hpp"
+
+// System include(s).
+#include <list>
+
+namespace vecmem {
+
+   /// Simple memory manager for the host
+   class host_memory_manager : public memory_manager_interface {
+
+   public:
+      /// Destructor, freeing up all allocations
+      ~host_memory_manager();
+
+      /// @name Functions inherited from @c vecmem::memory_manager_interface
+      /// @{
+
+      /// Set the amount of memory to use on a particular device
+      void set_maximum_capacity( std::size_t sizeInBytes, int device ) override;
+
+      /// Get the amount of memory still available on a specific device
+      std::size_t available_memory( int device ) const override;
+
+      /// Get a pointer to an available memory block on a specific device
+      void* allocate( std::size_t sizeInBytes, int device ) override;
+
+      /// Deallocate a specific memory block
+      void deallocate( void* ptr ) override;
+
+      /// Reset all allocations on a given device
+      void reset( int device ) override;
+
+      /// Check whether the memory allocated is accessible from the host
+      bool is_host_accessible() const override;
+
+      /// @}
+
+   private:
+      /// All memory allocations managed by this object on the host
+      std::list< void* > m_memory;
+
+   }; // class host_memory_manager
+
+} // namespace vecmem

--- a/core/include/vecmem/memory/memory_manager_interface.hpp
+++ b/core/include/vecmem/memory/memory_manager_interface.hpp
@@ -34,6 +34,9 @@ namespace vecmem {
       /// Reset all allocations on a given device
       virtual void reset( int device = -1 ) = 0;
 
+      /// Check whether the memory allocated is accessible from the host
+      virtual bool is_host_accessible() const = 0;
+
    }; // class memory_manager_interface
 
 } // namespace vecmem

--- a/core/src/memory/host_memory_manager.cpp
+++ b/core/src/memory/host_memory_manager.cpp
@@ -1,0 +1,68 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/memory/host_memory_manager.hpp"
+
+// System include(s).
+#include <algorithm>
+#include <cstdlib>
+#include <unistd.h>
+
+namespace vecmem {
+
+   host_memory_manager::~host_memory_manager() {
+
+      // Free up all pending allocations.
+      for( void* ptr : m_memory ) {
+         free( ptr );
+      }
+   }
+
+   void host_memory_manager::set_maximum_capacity( std::size_t, int ) {}
+
+   std::size_t host_memory_manager::available_memory( int ) const {
+
+      // Get the available amount of memory in a POSIX way.
+      const long freePages = sysconf( _SC_AVPHYS_PAGES );
+      const long pageSize = sysconf( _SC_PAGE_SIZE );
+      return freePages * pageSize;
+   }
+
+   void* host_memory_manager::allocate( std::size_t sizeInBytes, int ) {
+
+      // Allocate the requested block, and note down its size.
+      void* result = malloc( sizeInBytes );
+      m_memory.push_back( result );
+      return result;
+   }
+
+   void host_memory_manager::deallocate( void* ptr ) {
+
+      // Remove the pointer from the internal list, and free up the memory.
+      m_memory.erase( std::remove( m_memory.begin(), m_memory.end(), ptr ),
+                      m_memory.end() );
+      free( ptr );
+      return;
+   }
+
+   void host_memory_manager::reset( int ) {
+
+      // Free up all known allocations.
+      for( void* ptr : m_memory ) {
+         free( ptr );
+      }
+      m_memory.clear();
+      return;
+   }
+
+   bool host_memory_manager::is_host_accessible() const {
+
+      return true;
+   }
+
+} // namespace vecmem

--- a/core/src/memory/memory_manager.cpp
+++ b/core/src/memory/memory_manager.cpp
@@ -8,6 +8,7 @@
 // Local include(s).
 #include "vecmem/memory/memory_manager.hpp"
 #include "vecmem/memory/memory_manager_interface.hpp"
+#include "vecmem/memory/host_memory_manager.hpp"
 
 namespace vecmem {
 
@@ -36,7 +37,7 @@ namespace vecmem {
    }
 
    memory_manager::memory_manager()
-   : m_mgr() {
+   : m_mgr( new host_memory_manager() ) {
 
    }
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -4,6 +4,10 @@
 #
 # Mozilla Public License Version 2.0
 
+# Tests for the core library's custom allocators.
+vecmem_add_test( core_allocators test_core_allocators.cpp
+   LINK_LIBRARIES vecmem::core )
+
 # Tests for the core library's container types.
 vecmem_add_test( core_containers test_core_containers.cpp
    LINK_LIBRARIES vecmem::core )

--- a/tests/core/test_core_allocators.cpp
+++ b/tests/core/test_core_allocators.cpp
@@ -1,0 +1,48 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/allocators/allocator.hpp"
+
+// System include(s).
+#include <algorithm>
+#undef NDEBUG
+#include <cassert>
+#include <vector>
+
+// Vector type using the generic vecmem allocator.
+template< typename T >
+using custom_vector = std::vector< T, vecmem::allocator< T > >;
+
+int main() {
+
+   // Create a "custom vector" and a reference vector, and do some tests with
+   // them.
+   std::vector< int > reference_vector;
+   reference_vector.reserve( 100 );
+   custom_vector< int > test_vector;
+   test_vector.reserve( 100 );
+
+   for( int i = 0; i < 20; ++i ) {
+      reference_vector.push_back( i * 2 );
+      test_vector.push_back( i * 2 );
+   }
+   assert( reference_vector.size() == test_vector.size() );
+   assert( std::equal( reference_vector.begin(), reference_vector.end(),
+                       test_vector.begin() ) );
+
+   for( int i : { 26, 38, 25 } ) {
+      std::remove( reference_vector.begin(), reference_vector.end(), i );
+      std::remove( test_vector.begin(), test_vector.end(), i );
+   }
+   assert( reference_vector.size() == test_vector.size() );
+   assert( std::equal( reference_vector.begin(), reference_vector.end(),
+                       test_vector.begin() ) );
+
+   // Return gracefully.
+   return 0;
+}


### PR DESCRIPTION
Added a host memory manager, and a generic STL allocator. It is only meant for testing of course, as it would only make any host-based code unnecessarily slow.

Created a generic STL-like allocator, which would use the "current" memory manager from `vecmem::memory_manager`. To be used for some more fancy code later on.

Added a simple unit test to make sure that everything works as expected.