### PR TITLE
Add a very basic .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the common build directory
+build/


### PR DESCRIPTION
This `.gitignore` file really just ignores the `build/` directory which we are building into. I don't think we need more than that yet.