### PR TITLE
Refactor memory types into single enum

### DIFF
--- a/cuda/include/vecmem/memory/cuda/arena_memory_manager.hpp
+++ b/cuda/include/vecmem/memory/cuda/arena_memory_manager.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/memory/memory_types.hpp"
 #include "vecmem/memory/memory_manager_interface.hpp"
 
 // System include(s).
@@ -18,15 +19,8 @@ namespace vecmem { namespace cuda {
    class arena_memory_manager : public memory_manager_interface {
 
    public:
-      /// Memory type managed by the object
-      enum class memory_type {
-         device  = 1, ///< Memory allocated in device memory
-         host    = 2, ///< Pinned memory allocated on the host
-         managed = 3  ///< CUDA managed memory allocated on the device and host
-      };
-
       /// Constructor, allocating the default amount of memory
-      arena_memory_manager( memory_type type = memory_type::managed,
+      arena_memory_manager(vecmem::memory::memory_type type = vecmem::memory::memory_type::MANAGED,
                             std::size_t sizeInBytes = 200 * 1024l * 1024l );
       /// Destructor, freeing up all allocations
       ~arena_memory_manager();
@@ -78,7 +72,7 @@ namespace vecmem { namespace cuda {
       device_memory& get_device_memory( int& device );
 
       /// The memory type managed by the object
-      memory_type m_type;
+      vecmem::memory::memory_type m_type;
       /// Object holding information about memory allocations on all devices
       std::vector< device_memory > m_memory;
 

--- a/cuda/include/vecmem/memory/cuda/direct_memory_manager.hpp
+++ b/cuda/include/vecmem/memory/cuda/direct_memory_manager.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/memory/memory_types.hpp"
 #include "vecmem/memory/memory_manager_interface.hpp"
 
 // System include(s).
@@ -19,15 +20,8 @@ namespace vecmem { namespace cuda {
    class direct_memory_manager : public memory_manager_interface {
 
    public:
-      /// Memory type managed by the object
-      enum class memory_type {
-         device  = 1, ///< Memory allocated in device memory
-         host    = 2, ///< Pinned memory allocated on the host
-         managed = 3  ///< CUDA managed memory allocated on the device and host
-      };
-
       /// Constructor, allocating the default amount of memory
-      direct_memory_manager( memory_type type = memory_type::managed,
+      direct_memory_manager( vecmem::memory::memory_type type = vecmem::memory::memory_type::MANAGED,
                              std::size_t sizeInBytes = 200 * 1024l * 1024l );
       /// Destructor, freeing up all allocations
       ~direct_memory_manager();
@@ -73,7 +67,7 @@ namespace vecmem { namespace cuda {
       device_memory& get_device_memory( int& device );
 
       /// The memory type managed by the object
-      memory_type m_type;
+      vecmem::memory::memory_type m_type;
       /// Object holding information about memory allocations on all devices
       std::vector< device_memory > m_memory;
 

--- a/cuda/include/vecmem/memory/memory_types.hpp
+++ b/cuda/include/vecmem/memory/memory_types.hpp
@@ -1,0 +1,18 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem::memory {
+   enum class memory_type {
+      //! Memory allocated in device memory
+      DEVICE,
+      //! Pinned memory allocated on the host
+      HOST,
+      //! CUDA managed memory allocated on the device and host
+      MANAGED
+   };
+}

--- a/cuda/src/memory/cuda/arena_memory_manager.cu
+++ b/cuda/src/memory/cuda/arena_memory_manager.cu
@@ -17,7 +17,7 @@
 
 namespace vecmem { namespace cuda {
 
-   arena_memory_manager::arena_memory_manager( memory_type type,
+   arena_memory_manager::arena_memory_manager( vecmem::memory::memory_type type,
                                                std::size_t sizeInBytes )
    : m_type( type ) {
 
@@ -35,7 +35,7 @@ namespace vecmem { namespace cuda {
          // Ignore the errors from these calls. The destruction of this object
          // may happen after the CUDA runtime has already "shut down". Leading
          // to a (silent) failure from these calls.
-         if( m_type == memory_type::host ) {
+         if( m_type == vecmem::memory::memory_type::HOST ) {
             VECMEM_CUDA_ERROR_IGNORE( cudaFreeHost( mem.m_ptr ) );
          } else {
             VECMEM_CUDA_ERROR_IGNORE( cudaFree( mem.m_ptr ) );
@@ -51,7 +51,7 @@ namespace vecmem { namespace cuda {
 
       // De-allocate any previously allocated memory.
       if( mem.m_ptr ) {
-         if( m_type == memory_type::host ) {
+         if( m_type == vecmem::memory::memory_type::HOST ) {
             VECMEM_CUDA_ERROR_CHECK( cudaFreeHost( mem.m_ptr ) );
          } else {
             VECMEM_CUDA_ERROR_CHECK( cudaFree( mem.m_ptr ) );
@@ -61,14 +61,14 @@ namespace vecmem { namespace cuda {
       // Allocate the newly requested amount.
       VECMEM_CUDA_ERROR_CHECK( cudaSetDevice( device ) );
       switch( m_type ) {
-      case memory_type::device:
+      case vecmem::memory::memory_type::DEVICE:
          VECMEM_CUDA_ERROR_CHECK( cudaMalloc( &( mem.m_ptr ), sizeInBytes ) );
          break;
-      case memory_type::host:
+      case vecmem::memory::memory_type::HOST:
          VECMEM_CUDA_ERROR_CHECK( cudaMallocHost( &( mem.m_ptr ),
                                                   sizeInBytes ) );
          break;
-      case memory_type::managed:
+      case vecmem::memory::memory_type::MANAGED:
          VECMEM_CUDA_ERROR_CHECK( cudaMallocManaged( &( mem.m_ptr ),
                                                      sizeInBytes ) );
          break;
@@ -145,7 +145,7 @@ namespace vecmem { namespace cuda {
 
    bool arena_memory_manager::is_host_accessible() const {
 
-      return ( m_type != memory_type::device );
+      return ( m_type != vecmem::memory::memory_type::DEVICE );
    }
 
    void arena_memory_manager::get_device( int& device ) {

--- a/cuda/src/memory/cuda/direct_memory_manager.cu
+++ b/cuda/src/memory/cuda/direct_memory_manager.cu
@@ -19,7 +19,7 @@
 
 namespace vecmem { namespace cuda {
 
-   direct_memory_manager::direct_memory_manager( memory_type type,
+   direct_memory_manager::direct_memory_manager( vecmem::memory::memory_type type,
                                                  std::size_t sizeInBytes )
    : m_type( type ) {
 
@@ -33,7 +33,7 @@ namespace vecmem { namespace cuda {
       // Ignore the errors from these calls. The destruction of this object
       // may happen after the CUDA runtime has already "shut down". Leading
       // to a (silent) failure from these calls.
-      if( m_type == memory_type::host ) {
+      if( m_type == vecmem::memory::memory_type::HOST ) {
          for( device_memory& dev : m_memory ) {
             for( void* ptr : dev.m_ptrs ) {
                VECMEM_CUDA_ERROR_IGNORE( cudaFree( ptr ) );
@@ -84,13 +84,13 @@ namespace vecmem { namespace cuda {
       void* result = nullptr;
       VECMEM_CUDA_ERROR_CHECK( cudaSetDevice( device ) );
       switch( m_type ) {
-      case memory_type::device:
+      case vecmem::memory::memory_type::DEVICE:
          VECMEM_CUDA_ERROR_CHECK( cudaMalloc( &result, sizeInBytes ) );
          break;
-      case memory_type::host:
+      case vecmem::memory::memory_type::HOST:
          VECMEM_CUDA_ERROR_CHECK( cudaMallocHost( &result, sizeInBytes ) );
          break;
-      case memory_type::managed:
+      case vecmem::memory::memory_type::MANAGED:
          VECMEM_CUDA_ERROR_CHECK( cudaMallocManaged( &result, sizeInBytes ) );
          break;
       default:
@@ -119,7 +119,7 @@ namespace vecmem { namespace cuda {
       }
 
       // De-allocate the memory.
-      if( m_type == memory_type::host ) {
+      if( m_type == vecmem::memory::memory_type::HOST ) {
          VECMEM_CUDA_ERROR_CHECK( cudaFreeHost( ptr ) );
       } else {
          VECMEM_CUDA_ERROR_CHECK( cudaFree( ptr ) );
@@ -140,7 +140,7 @@ namespace vecmem { namespace cuda {
       device_memory& mem = get_device_memory( device );
 
       // Deallocate all memory associated with the device.
-      if( m_type == memory_type::host ) {
+      if( m_type == vecmem::memory::memory_type::HOST ) {
          for( void* ptr : mem.m_ptrs ) {
             VECMEM_CUDA_ERROR_CHECK( cudaFreeHost( ptr ) );
          }
@@ -155,7 +155,7 @@ namespace vecmem { namespace cuda {
 
    bool direct_memory_manager::is_host_accessible() const {
 
-      return ( m_type != memory_type::device );
+      return ( m_type != vecmem::memory::memory_type::DEVICE );
    }
 
    void direct_memory_manager::get_device( int& device ) {

--- a/tests/cuda/test_cuda_allocators.cpp
+++ b/tests/cuda/test_cuda_allocators.cpp
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "vecmem/allocators/allocator.hpp"
+#include "vecmem/memory/memory_types.hpp"
 #include "vecmem/memory/memory_manager.hpp"
 #include "vecmem/memory/cuda/arena_memory_manager.hpp"
 #include "vecmem/memory/cuda/direct_memory_manager.hpp"
@@ -60,32 +61,32 @@ int main() {
    // the memory from the host.
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::arena_memory_manager >(
-         vecmem::cuda::arena_memory_manager::memory_type::host ) );
+         vecmem::memory::memory_type::HOST ) );
    run_host_tests();
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::arena_memory_manager >(
-         vecmem::cuda::arena_memory_manager::memory_type::managed ) );
+         vecmem::memory::memory_type::MANAGED ) );
    run_host_tests();
 
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::direct_memory_manager >(
-         vecmem::cuda::direct_memory_manager::memory_type::host ) );
+         vecmem::memory::memory_type::HOST ) );
    run_host_tests();
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::direct_memory_manager >(
-         vecmem::cuda::direct_memory_manager::memory_type::managed ) );
+         vecmem::memory::memory_type::MANAGED ) );
    run_host_tests();
 
    // Run much simpler tests with the memory managers that only allocate memory
    // on the device(s).
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::arena_memory_manager >(
-         vecmem::cuda::arena_memory_manager::memory_type::device ) );
+         vecmem::memory::memory_type::DEVICE ) );
    run_device_tests();
 
    vecmem::memory_manager::instance().set(
       std::make_unique< vecmem::cuda::direct_memory_manager >(
-         vecmem::cuda::direct_memory_manager::memory_type::device ) );
+         vecmem::memory::memory_type::DEVICE ) );
    run_device_tests();
 
    // Return gracefully.


### PR DESCRIPTION
Currently, each allocator has its own enum representing a memory type, but this seems redundant and confusing, and I think we will be better off having one single definition of that enum to use throughout all of the code.