### PR TITLE
Add basic definitions for memory resource architecture

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,11 +13,13 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/device_vector.hpp"
    "include/vecmem/containers/host_vector.hpp"
    "include/vecmem/containers/static_vector.hpp"
+   "include/vecmem/containers/vector.hpp"
    # Memory management.
    "include/vecmem/memory/memory_manager_interface.hpp"
    "include/vecmem/memory/memory_manager.hpp"
    "src/memory/memory_manager.cpp"
    "include/vecmem/memory/host_memory_manager.hpp"
    "src/memory/host_memory_manager.cpp"
+   "include/vecmem/memory/resources/memory_resource.hpp"
    # Utilities.
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/containers/vector.hpp
+++ b/core/include/vecmem/containers/vector.hpp
@@ -1,0 +1,26 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+#include <vector>
+
+namespace vecmem {
+   /**
+    * @brief Alias type for vectors with our polymorphic allocator
+    *
+    * This type serves as an alias for a common type pattern, namely a
+    * host-accessible vector with a memory resource which is not known at
+    * compile time, which could be host memory or shared memory.
+    *
+    * @warning This type should only be used with host-accessible memory
+    * resources.
+    */
+   template<typename T>
+   using vector = std::vector<T, vecmem::polymorphic_allocator<T>>;
+}

--- a/core/include/vecmem/memory/resources/memory_resource.hpp
+++ b/core/include/vecmem/memory/resources/memory_resource.hpp
@@ -1,0 +1,37 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+/*
+ * The purpose of this file is to provide uniform access (on a source-code
+ * level) to the memory_resource and polymorphic_allocator types from the
+ * standard library. These are either in the std::pmr namespace or in the
+ * std::experimental::pmr namespace depending on the GCC version used, so we try
+ * to unify them by aliassing depending on the compiler feature flags.
+ */
+#if __has_include(<memory_resource>)
+#include <memory_resource>
+
+namespace vecmem {
+    using memory_resource = std::pmr::memory_resource;
+
+    template<typename T>
+    using polymorphic_allocator = std::pmr::polymorphic_allocator<T>;
+}
+#elif __has_include(<experimental/memory_resource>)
+#include <experimental/memory_resource>
+
+namespace vecmem {
+    using memory_resource = std::experimental::pmr::memory_resource;
+
+    template<typename T>
+    using polymorphic_allocator = std::experimental::pmr::polymorphic_allocator<T>;
+}
+#else
+#error "vecmem requires C++17 LFTS V1 (P0220R1) component memory_resource!"
+#endif


### PR DESCRIPTION
I've decided to split up #14 into three separate merge requests for the sake of clarity. This is the first of three, upon which the others will build.

This commit lays the groundwork for the rest of the migration to a memory resource architecture. That is to say, it defines some of the common definitions and infrastructure on which we will build the memory resources for CPU code, CUDA, and other paradigms. More specifically it imports the required `std::pmr` types in a compiler agnostic way, and it defines our custom abstract subclass of `std::pmr::memory_resource`. It also defines a useful alias for creating vectors.