### PR TITLE
Separate CUDA container test kernel from its driver

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -15,5 +15,6 @@ vecmem_add_test( cuda_allocators test_cuda_allocators.cpp
    LINK_LIBRARIES vecmem::core vecmem::cuda )
 
 # Tests for the core library's device vector types, using the CUDA backend.
-vecmem_add_test( cuda_containers test_cuda_containers.cu
+vecmem_add_test( cuda_containers test_cuda_containers.cpp
+   test_cuda_containers_kernels.cu test_cuda_containers_kernels.cuh
    LINK_LIBRARIES vecmem::core vecmem::cuda )

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -1,0 +1,38 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/containers/const_device_vector.hpp"
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/utils/cuda_error_handling.hpp"
+
+#include <cstddef>
+
+/// Kernel performing a linear transformation using the vector helper types
+__global__
+void linearTransformKernel( std::size_t size, const int* input, int* output ) {
+
+   // Find the current index.
+   const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+   if( i >= size ) {
+      return;
+   }
+
+   // Create the helper vectors.
+   const vecmem::const_device_vector< int > inputvec( size, input );
+   vecmem::device_vector< int > outputvec( size, output );
+
+   // Perform the linear transformation.
+   outputvec.at( i ) = 3 + inputvec.at( i ) * 2;
+   return;
+}
+
+void linearTransform( std::size_t size, const int* input, int* output ) {
+   linearTransformKernel<<< 1, size >>>( size, input, output );
+
+   VECMEM_CUDA_ERROR_CHECK( cudaGetLastError() );
+   VECMEM_CUDA_ERROR_CHECK( cudaDeviceSynchronize() );
+}

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -1,0 +1,12 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+void linearTransform(std::size_t size, const int* input, int* output);


### PR DESCRIPTION
As it is right now, the CUDA container test contains both device code and host driver code in the same translation unit, which forces us to compile both with `nvcc`. This is normally not a problem, but as discussed in #14 we need to compile our C++ code with the C++17 standard while we can only compile our CUDA code with the C++14 standard. It is therefore necessary to enforce a separation between these two contexts, and thus we split it into two translation units. The C++ TU will handle the driving of the kernel and interact with the C++17-based architecture of the `vecmem` library, while the kernel itself will be compiled with C++14 and be agnostic of whatever C++ standard is being used outside.