### PR TITLE
Migrate core CPU code to use memory resources

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -21,5 +21,7 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/memory/host_memory_manager.hpp"
    "src/memory/host_memory_manager.cpp"
    "include/vecmem/memory/resources/memory_resource.hpp"
+   "src/memory/host_memory_resource.cpp"
+   "include/vecmem/memory/host_memory_resource.hpp"
    # Utilities.
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -1,0 +1,41 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+#include <memory>
+#include <cstddef>
+
+namespace vecmem {
+    /**
+     * @brief Memory resource which wraps the malloc standard library call.
+     *
+     * This is probably the simplest memory resource you can possibly write. It
+     * is a terminal resource which does nothing but wrap malloc and free. It
+     * is state-free (on the relevant levels of abstraction).
+     */
+    class host_memory_resource : public vecmem::memory_resource {
+    private:
+        virtual void * do_allocate(
+            std::size_t,
+            std::size_t
+        ) override;
+
+        virtual void do_deallocate(
+            void * p,
+            std::size_t,
+            std::size_t
+        ) override;
+
+        virtual bool do_is_equal(
+            const memory_resource &
+        ) const noexcept override;
+    };
+}

--- a/core/src/memory/host_memory_resource.cpp
+++ b/core/src/memory/host_memory_resource.cpp
@@ -1,0 +1,44 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+
+#include <memory>
+
+namespace vecmem {
+    void * host_memory_resource::do_allocate(
+        std::size_t bytes,
+        std::size_t
+    ) {
+        return malloc(bytes);
+    }
+
+    void host_memory_resource::do_deallocate(
+        void * p,
+        std::size_t,
+        std::size_t
+    ) {
+        free(p);
+    }
+
+    bool host_memory_resource::do_is_equal(
+        const memory_resource & other
+    ) const noexcept {
+        /*
+         * All malloc resources are equal to each other, because they have no
+         * internal state. Of course they have a shared underlying state in the
+         * form of the underlying C library memory manager, but that is not
+         * relevant for us.
+         */
+        const host_memory_resource * c;
+        c = dynamic_cast<const host_memory_resource *>(&other);
+
+        return c != nullptr;
+    }
+}

--- a/tests/core/test_core_allocators.cpp
+++ b/tests/core/test_core_allocators.cpp
@@ -7,6 +7,9 @@
 
 // Local include(s).
 #include "vecmem/allocators/allocator.hpp"
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/memory/resources/memory_resource.hpp"
 
 // System include(s).
 #include <algorithm>
@@ -14,17 +17,16 @@
 #include <cassert>
 #include <vector>
 
-// Vector type using the generic vecmem allocator.
-template< typename T >
-using custom_vector = std::vector< T, vecmem::allocator< T > >;
 
 int main() {
-
    // Create a "custom vector" and a reference vector, and do some tests with
    // them.
    std::vector< int > reference_vector;
    reference_vector.reserve( 100 );
-   custom_vector< int > test_vector;
+
+   vecmem::host_memory_resource resource;
+
+   vecmem::vector<int> test_vector(&resource);
    test_vector.reserve( 100 );
 
    for( int i = 0; i < 20; ++i ) {


### PR DESCRIPTION
Now that the groundwork is laid, we can start to convert the different modules from the old memory management to the new memory resources. This merge request does exactly that for the `core` CPU code: it adds a single new memory resource, wrapping `malloc`, and it updates the tests to work with the new architecture.