### PR TITLE
Link against and include the CUDA runtime library for C++ code

### DIFF
--- a/core/include/vecmem/utils/types.hpp
+++ b/core/include/vecmem/utils/types.hpp
@@ -6,13 +6,6 @@
  */
 #pragma once
 
-// CUDA include(s).
-#ifdef __CUDACC__
-#   include <cuda_runtime.h>
-#else
-typedef int cudaError_t; ///< Dummy type for @c cudaError_t in C++ code
-#endif // __CUDACC__
-
 // HIP include(s).
 #ifdef __HIP__
 #   include <hip/hip_runtime.h>

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -10,6 +10,8 @@ enable_language( CUDA )
 # Project include(s).
 include( vecmem-compiler-options-cuda )
 
+find_package( CUDAToolkit REQUIRED )
+
 # Set up the build of the VecMem CUDA library.
 vecmem_add_library( vecmem_cuda cuda SHARED
    # Memory management.
@@ -20,4 +22,8 @@ vecmem_add_library( vecmem_cuda cuda SHARED
    # Utilities.
    "include/vecmem/utils/cuda_error_handling.hpp"
    "src/utils/cuda_error_handling.cu" )
-target_link_libraries( vecmem_cuda PUBLIC vecmem::core )
+
+target_link_libraries( vecmem_cuda
+   PUBLIC vecmem::core
+   PRIVATE CUDA::cudart
+)

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -20,8 +20,8 @@ vecmem_add_library( vecmem_cuda cuda SHARED
    "include/vecmem/memory/cuda/direct_memory_manager.hpp"
    "src/memory/cuda/direct_memory_manager.cu"
    # Utilities.
-   "include/vecmem/utils/cuda_error_handling.hpp"
-   "src/utils/cuda_error_handling.cu" )
+   "src/utils/cuda_error_handling.cpp"
+   "src/utils/cuda_error_handling.hpp" )
 
 target_link_libraries( vecmem_cuda
    PUBLIC vecmem::core

--- a/cuda/src/memory/cuda/arena_memory_manager.cu
+++ b/cuda/src/memory/cuda/arena_memory_manager.cu
@@ -7,7 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/cuda/arena_memory_manager.hpp"
-#include "vecmem/utils/cuda_error_handling.hpp"
+#include "../../utils/cuda_error_handling.hpp"
 
 // CUDA include(s).
 #include <cuda_runtime.h>

--- a/cuda/src/memory/cuda/direct_memory_manager.cu
+++ b/cuda/src/memory/cuda/direct_memory_manager.cu
@@ -7,7 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/cuda/direct_memory_manager.hpp"
-#include "vecmem/utils/cuda_error_handling.hpp"
+#include "../../utils/cuda_error_handling.hpp"
 
 // CUDA include(s).
 #include <cuda_runtime.h>

--- a/cuda/src/utils/cuda_error_handling.cpp
+++ b/cuda/src/utils/cuda_error_handling.cpp
@@ -6,7 +6,7 @@
  */
 
 // Local include(s).
-#include "vecmem/utils/cuda_error_handling.hpp"
+#include "cuda_error_handling.hpp"
 
 // CUDA include(s).
 #include <cuda_runtime.h>

--- a/cuda/src/utils/cuda_error_handling.hpp
+++ b/cuda/src/utils/cuda_error_handling.hpp
@@ -6,12 +6,13 @@
  */
 #pragma once
 
+#include <cuda_runtime_api.h>
+
 // Detray Data Model include(s).
 #include "vecmem/utils/types.hpp"
 
 /// Helper macro used for checking @c cudaError_t type return values.
-#ifdef __CUDACC__
-#   define VECMEM_CUDA_ERROR_CHECK( EXP )                                      \
+#define VECMEM_CUDA_ERROR_CHECK( EXP )                                         \
    do {                                                                        \
       cudaError_t errorCode = EXP;                                             \
       if( errorCode != cudaSuccess ) {                                         \
@@ -19,19 +20,12 @@
                                             __LINE__ );                        \
       }                                                                        \
    } while( false )
-#else
-#   define VECMEM_CUDA_ERROR_CHECK( EXP ) do {} while( false )
-#endif // __CUDACC__
 
 /// Helper macro used for running a CUDA function when not caring about its results
-#ifdef __CUDACC__
-#   define VECMEM_CUDA_ERROR_IGNORE( EXP )                                     \
+#define VECMEM_CUDA_ERROR_IGNORE( EXP )                                        \
    do {                                                                        \
       EXP;                                                                     \
    } while( false )
-#else
-#   define VECMEM_CUDA_ERROR_IGNORE( EXP ) do {} while( false )
-#endif // __CUDACC__
 
 namespace vecmem { namespace cuda { namespace details {
 

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -7,9 +7,10 @@
 
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_vector.hpp"
-#include "vecmem/utils/cuda_error_handling.hpp"
+#include "../../cuda/src/utils/cuda_error_handling.hpp"
 
 #include <cstddef>
+#include <stdexcept>
 
 /// Kernel performing a linear transformation using the vector helper types
 __global__
@@ -33,6 +34,6 @@ void linearTransformKernel( std::size_t size, const int* input, int* output ) {
 void linearTransform( std::size_t size, const int* input, int* output ) {
    linearTransformKernel<<< 1, size >>>( size, input, output );
 
-   VECMEM_CUDA_ERROR_CHECK( cudaGetLastError() );
-   VECMEM_CUDA_ERROR_CHECK( cudaDeviceSynchronize() );
+   VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
+   VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 }


### PR DESCRIPTION
As we discussed several times before, compiling C++14 and C++17 code alongside each other is a bad idea, and we'd be best off minimizing the use of `nvcc` so we can rely on another compiler to compile the standard C++ code. However, we were previously relying a lot on `nvcc`'s ability to automatically include and link the CUDA runtime, which we now lose. This merge request remedies that situation by properly linking against and including the CUDA runtime in C++ host code where possible.