### PR TITLE
Implement a contiguous downstream memory resource

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -25,5 +25,7 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/memory/host_memory_resource.hpp"
    "src/memory/binary_page_memory_resource.cpp"
    "include/vecmem/memory/binary_page_memory_resource.hpp"
+   "src/memory/contiguous_memory_resource.cpp"
+   "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -66,7 +66,6 @@ namespace vecmem {
         memory_resource & m_upstream;
         const std::size_t m_size;
         void * const m_begin;
-        void * const m_end;
         void * m_next;
     };
 }

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -1,0 +1,72 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+#include <cstddef>
+
+namespace vecmem {
+    /**
+     * @brief Downstream allocator that ensures that allocations are contiguous.
+     *
+     * When programming for co-processors, it is often desriable to keep
+     * allocations contiguous. This downstream allocator fills that need. When
+     * configured with an upstream memory resource, it will start out by
+     * allocating a single, large, chunk of memory from the upstream. Then, it
+     * will hand out pointers along that memory in a contiguous fashion. This
+     * allocator guarantees that each consecutive allocation will start right at
+     * the end of the previous.
+     *
+     * @note The allocation size on the upstream allocator is also the maximum
+     * amount of memory that can be allocated from the contiguous memory
+     * resource.
+     */
+    class contiguous_memory_resource : public memory_resource {
+    public:
+        /**
+         * @brief Constructs the contiguous memory resource.
+         *
+         * @param[in] upstream The upstream memory resource to use.
+         * @param[in] size The size of memory to allocate upstream.
+         */
+        contiguous_memory_resource(
+            memory_resource & upstream,
+            std::size_t size
+        );
+
+        /**
+         * @brief Deconstruct the contiguous memory resource.
+         *
+         * This method deallocates the arena memory on the upstream allocator.
+         */
+        ~contiguous_memory_resource();
+    private:
+        virtual void * do_allocate(
+            std::size_t,
+            std::size_t
+        ) override;
+
+        virtual void do_deallocate(
+            void * p,
+            std::size_t,
+            std::size_t
+        ) override;
+
+        virtual bool do_is_equal(
+            const memory_resource &
+        ) const noexcept override;
+
+        memory_resource & m_upstream;
+        const std::size_t m_size;
+        void * const m_begin;
+        void * const m_end;
+        void * m_next;
+    };
+}

--- a/core/src/memory/contiguous_memory_resource.cpp
+++ b/core/src/memory/contiguous_memory_resource.cpp
@@ -1,0 +1,88 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+#include "vecmem/memory/contiguous_memory_resource.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+
+namespace vecmem {
+    contiguous_memory_resource::contiguous_memory_resource(
+        memory_resource & upstream,
+        std::size_t size
+    ) :
+        m_upstream(upstream),
+        m_size(size),
+        m_begin(m_upstream.allocate(m_size)),
+        m_end(static_cast<void *>(static_cast<char *>(m_begin) + size)),
+        m_next(m_begin)
+    {
+    }
+
+    contiguous_memory_resource::~contiguous_memory_resource() {
+        /*
+         * Deallocate our memory arena upstream.
+         */
+        m_upstream.deallocate(m_begin, m_size);
+    }
+
+    void * contiguous_memory_resource::do_allocate(
+        std::size_t size,
+        std::size_t
+    ) {
+        /*
+         * Calculate where the end of this current allocation would be.
+         */
+        void * next = static_cast<void *>(static_cast<char *>(m_next) + size);
+
+        /*
+         * The start of this allocation, save it in a temporary variable as we
+         * will override it later before returning.
+         */
+        void * curr = m_next;
+
+        /*
+         * If the end of this allocation is past the end of our memory space,
+         * we can't allocate, and should throw an error.
+         */
+        if (next > m_end) {
+            throw std::bad_alloc();
+        }
+
+        /*
+         * Update the start of the next allocation and return.
+         */
+        m_next = next;
+
+        return curr;
+    }
+
+    void contiguous_memory_resource::do_deallocate(
+        void *,
+        std::size_t,
+        std::size_t
+    ) {
+        /*
+         * Deallocation is a no-op for this memory resource, so we do nothing.
+         */
+        return;
+    }
+
+    bool contiguous_memory_resource::do_is_equal(
+        const memory_resource & other
+    ) const noexcept {
+        /*
+         * These memory resources are equal if and only if they are the same
+         * object.
+         */
+        return this == &other;
+    }
+
+}

--- a/core/src/memory/contiguous_memory_resource.cpp
+++ b/core/src/memory/contiguous_memory_resource.cpp
@@ -21,7 +21,6 @@ namespace vecmem {
         m_upstream(upstream),
         m_size(size),
         m_begin(m_upstream.allocate(m_size)),
-        m_end(static_cast<void *>(static_cast<char *>(m_begin) + size)),
         m_next(m_begin)
     {
     }
@@ -52,7 +51,7 @@ namespace vecmem {
          * If the end of this allocation is past the end of our memory space,
          * we can't allocate, and should throw an error.
          */
-        if (next > m_end) {
+        if (next >= (static_cast<char*>(m_begin) + m_size)) {
             throw std::bad_alloc();
         }
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -17,3 +17,7 @@ vecmem_add_test( core_containers test_core_containers.cpp
 # Tests for the core library's binary page manager.
 vecmem_add_test( core_binary_page test_core_binary_page.cpp
    LINK_LIBRARIES vecmem::core )
+
+# Tests for the contiguous memory resource
+vecmem_add_test( core_contiguous_memory_resource test_core_contiguous_memory_resource.cpp
+   LINK_LIBRARIES vecmem::core )

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -1,0 +1,39 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/memory/contiguous_memory_resource.hpp"
+
+// System include(s).
+#undef NDEBUG
+#include <cassert>
+
+int main() {
+   vecmem::host_memory_resource upstream;
+   vecmem::contiguous_memory_resource resource(upstream, 1048576);
+
+   vecmem::vector<int> vec1(&resource);
+   vecmem::vector<char> vec2(&resource);
+   vecmem::vector<double> vec3(&resource);
+   vecmem::vector<float> vec4(&resource);
+   vecmem::vector<int> vec5(&resource);
+
+   vec1.reserve(100);
+   vec2.reserve(100);
+   vec3.reserve(100);
+   vec4.reserve(100);
+   vec5.reserve(100);
+
+   assert(static_cast<void *>(vec2.data()) == static_cast<void *>(static_cast<int *>(vec1.data()) + 100));
+   assert(static_cast<void *>(vec3.data()) == static_cast<void *>(static_cast<char *>(vec2.data()) + 100));
+   assert(static_cast<void *>(vec4.data()) == static_cast<void *>(static_cast<double *>(vec3.data()) + 100));
+   assert(static_cast<void *>(vec5.data()) == static_cast<void *>(static_cast<float *>(vec4.data()) + 100));
+
+   return 0;
+}

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -30,10 +30,10 @@ int main() {
    vec4.reserve(100);
    vec5.reserve(100);
 
-   assert(static_cast<void *>(vec2.data()) == static_cast<void *>(static_cast<int *>(vec1.data()) + 100));
-   assert(static_cast<void *>(vec3.data()) == static_cast<void *>(static_cast<char *>(vec2.data()) + 100));
-   assert(static_cast<void *>(vec4.data()) == static_cast<void *>(static_cast<double *>(vec3.data()) + 100));
-   assert(static_cast<void *>(vec5.data()) == static_cast<void *>(static_cast<float *>(vec4.data()) + 100));
+   assert(static_cast<void *>(vec2.data()) == static_cast<void *>(vec1.data() + 100));
+   assert(static_cast<void *>(vec3.data()) == static_cast<void *>(vec2.data() + 100));
+   assert(static_cast<void *>(vec4.data()) == static_cast<void *>(vec3.data() + 100));
+   assert(static_cast<void *>(vec5.data()) == static_cast<void *>(vec4.data() + 100));
 
    return 0;
 }


### PR DESCRIPTION
There are a lot of use cases in which you might want to allocate contiguous blocks of memory, but this is not supported by default by many allocators. This new downstream memory resource guarantees that consecutive allocations will be exactly contiguous in memory, which makes it easier to allocate memory with efficient data copies and locality in mind.