### PR TITLE
Add a front-end allocator to wrap memory resources

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -21,6 +21,10 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/static_vector.hpp"
    "include/vecmem/containers/vector.hpp"
    "include/vecmem/containers/vector.ipp"
+   # Allocator
+   "include/vecmem/memory/allocator.hpp"
+   "include/vecmem/memory/allocator.ipp"
+   "src/memory/allocator.cpp"
    # Memory management.
    "include/vecmem/memory/resources/memory_resource.hpp"
    "src/memory/host_memory_resource.cpp"

--- a/core/include/vecmem/memory/allocator.hpp
+++ b/core/include/vecmem/memory/allocator.hpp
@@ -1,0 +1,150 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+#include <cstddef>
+
+namespace vecmem {
+    /**
+     * @brief An allocator class that wraps a memory resource.
+     *
+     * Sometimes we want to construct objects outside of vectors, and for those
+     * cases we need a simpler allocator that uses a memory resource to set the
+     * allocation strategy. This class is inspired by
+     * @c std::pmr::polymorphic_allocator but changes some things about it.
+     * Firstly, this class is not templated at a class level, and the templating
+     * only happens at a method level. This makes the class significantly easier
+     * to use. Secondly, this class emulates some of the C++20 functionality
+     * offered by the polymorphic allocator in a C++17 context.
+     *
+     * @warning Deallocating memory allocated with a different allocator (or
+     * rather, with an allocator using a different upstream memory resource)
+     * than the one doing the deallocation is not well-defined and should be
+     * avoided.
+     */
+    class allocator {
+    public:
+        /**
+         * @brief Construct an allocator.
+         *
+         * Construct a new allocator on a given upstream memory resource.
+         *
+         * @param[in] mem The memory resource to use for allocations.
+         */
+        allocator(
+            memory_resource & mem
+        );
+
+        /**
+         * @brief Allocate a given number of bytes.
+         *
+         * The most low-level allocation method provided by the allocator simply
+         * allocates a number of untyped bytes, optionally with some alignment.
+         * This can be used directly, or by other allocation methods to build
+         * more high-level functionality.
+         *
+         * @param[in] bytes The number of bytes to allocate.
+         * @param[in] alignment The alignment boundary for the allocation.
+         */
+        void * allocate_bytes(
+            std::size_t bytes,
+            std::size_t alignment = alignof(std::max_align_t)
+        );
+
+        /**
+         * @brief Deallocate a given number of bytes.
+         *
+         * The most low-level deallocation method simply deallocates a number of
+         * bytes.
+         *
+         * @warning The onus is on the user to remember the size of each
+         * allocation, and this method might be too low-level for most purposes.
+         *
+         * @param[in] p The pointer to deallocate.
+         * @param[in] bytes The number of bytes to deallocate.
+         * @param[in] alignment The alignment boundary for the deallocation.
+         */
+        void deallocate_bytes(
+            void * p,
+            std::size_t bytes,
+            std::size_t alignment = alignof(std::max_align_t)
+        );
+
+        /**
+         * @brief Allocate space for (a number of) objects.
+         *
+         * A mid-level allocator which abstracts away calculating the size of
+         * their allocation. The user simply provides the type and the number
+         * of objects to allocate space for.
+         *
+         * @note The space allocated by this method is not initialized in any
+         * way.
+         *
+         * @tparam T The type of object to allocate space for.
+         * @param[in] n The number of objects of type T to allocate space for.
+         */
+        template<typename T>
+        T * allocate_object(
+            std::size_t n = 1
+        );
+
+        /**
+         * @brief Deallocate space for (a number of) objects.
+         *
+         * A mid-level deallocator which abstracts away calculating the size of
+         * the deallocation.
+         *
+         * @note The space deallocated by this method is not deconstructed.
+         *
+         * @tparam T The type of object to deallocater.
+         * @param[in] n The number of objects of type T to deallocate.
+         */
+        template<typename T>
+        void deallocate_object(
+            T * p,
+            std::size_t n = 1
+        );
+
+        /**
+         * @brief Allocate and construct a new object.
+         *
+         * The highest-level allocator we provide, this allocates memory for and
+         * then constructs an object of the given type. Parameters passed to
+         * this method are passed on to the constructor for the object.
+         *
+         * @tparam T The type to construct.
+         * @tparam Args The constructor parameter pack.
+         * @param[in] args The arguments to pass on to the class constructor.
+         */
+        template<typename T, typename ... Args>
+        T * new_object(
+            Args && ... args
+        );
+
+        /**
+         * @brief Deconstruct and deallocate an object.
+         *
+         * The highest-level deallocator we provide, this deconstructs and then
+         * deallocates an object.
+         *
+         * @tparam T The type of object to delete.
+         * @param[in] p The object to delete.
+         */
+        template<typename T>
+        void delete_object(
+            T * p
+        );
+    private:
+        memory_resource & m_mem;
+    };
+}
+
+#include "allocator.ipp"

--- a/core/include/vecmem/memory/allocator.ipp
+++ b/core/include/vecmem/memory/allocator.ipp
@@ -1,0 +1,77 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace vecmem {
+    template<typename T>
+    T * allocator::allocate_object(
+        std::size_t n
+    ) {
+        /*
+         * Since we know the object being allocated here, we can multiply the
+         * number of objects to allocate with the size of that class. We can
+         * also use the compiler's knowledge about the alignment requirements of
+         * the class.
+         */
+        return static_cast<T *>(m_mem.allocate(n * sizeof(T), alignof(T)));
+    }
+
+    template<typename T>
+    void allocator::deallocate_object(
+        T * p,
+        std::size_t n
+    ) {
+        /*
+         * Use the upstream allocator to deallocate the memory, again using the
+         * compiler's knowledge about the size and the alignment requirements of
+         * the class that is to be deallocated.
+         */
+        m_mem.deallocate(p, n * sizeof(T), alignof(T));
+    }
+
+    template<typename T, typename ... Args>
+    T * allocator::new_object(
+        Args && ... args
+    ) {
+        /*
+         * Firstly we need to allocate some space for the object which we are
+         * constructing. We use the allocate_object method for this, with the
+         * default argument of 1 for a single object.
+         */
+        void * p = allocate_object<T>();
+
+        /*
+         * Next, we use the placement new operation to construct the object in
+         * the memory which we have just allocated. For this, we also need to
+         * forward the arguments passed to this method so they can be used to
+         * call the constructor of the class.
+         */
+        return new (p) T(std::forward<Args>(args)...);
+    }
+
+    template<typename T>
+    void allocator::delete_object(
+        T * p
+    ) {
+        /*
+         * Before ruthlessly destroying the object, we will give it a few last
+         * words to deconstruct itself. This is to ensure it can safely
+         * do any clean-up it needs to do.
+         */
+        p->~T();
+
+        /*
+         * Once the deallocation is complete, we can get rid of the memory as
+         * well. For this, we call the higher-level deallocate_object method.
+         */
+        deallocate_object<T>(p);
+    }
+}

--- a/core/src/memory/allocator.cpp
+++ b/core/src/memory/allocator.cpp
@@ -1,0 +1,40 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/allocator.hpp"
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+namespace vecmem {
+    allocator::allocator(
+        memory_resource & mem
+    ) :
+        m_mem(mem)
+    {}
+
+    void * allocator::allocate_bytes(
+        std::size_t bytes,
+        std::size_t alignment
+    ) {
+        /*
+         * This allocation method simply wraps the upstream allocator's allocate
+         * method. Nothing special here.
+         */
+        return m_mem.allocate(bytes, alignment);
+    }
+
+    void allocator::deallocate_bytes(
+        void * p,
+        std::size_t bytes,
+        std::size_t alignment
+    ) {
+        /*
+         * Again, we just wrap the upstream deallocate method.
+         */
+        m_mem.deallocate(p, bytes, alignment);
+    }
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,4 +9,5 @@ vecmem_add_test( core
    "test_core_allocators.cpp" "test_core_arrays.cpp"
    "test_core_containers.cpp" "test_core_contiguous_memory_resource.cpp"
    "test_core_device_containers.cpp"
+   "test_core_allocator.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main )

--- a/tests/core/test_core_allocator.cpp
+++ b/tests/core/test_core_allocator.cpp
@@ -1,0 +1,107 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/allocator.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
+class test_class {
+    public:
+    test_class() : m_int_2(11), m_bool_2(true) {}
+    test_class(int n) : m_int_2(n), m_bool_2(false) {}
+    test_class(int n, int m) : m_int_2(n), m_bool_2(m > 100) {}
+
+    int m_int_1 = 5;
+    int m_int_2;
+
+    bool m_bool_1 = false;
+    bool m_bool_2;
+};
+
+class core_allocator_test : public testing::Test {
+    protected:
+    vecmem::host_memory_resource m_upstream;
+    vecmem::allocator * m_alloc;
+
+    void SetUp() override {
+        m_alloc = new vecmem::allocator(m_upstream);
+    }
+};
+
+TEST_F(core_allocator_test, basic) {
+    void * p = m_alloc->allocate_bytes(1024);
+
+    EXPECT_TRUE(p != nullptr);
+
+    m_alloc->deallocate_bytes(p, 1024);
+}
+
+TEST_F(core_allocator_test, primitive) {
+    int * p = m_alloc->allocate_object<int>();
+
+    ASSERT_TRUE(p != nullptr);
+
+    *p = 5;
+
+    EXPECT_TRUE(*p == 5);
+
+    m_alloc->deallocate_object<int>(p);
+}
+
+TEST_F(core_allocator_test, array) {
+    int * p = m_alloc->allocate_object<int>(10);
+
+    ASSERT_TRUE(p != nullptr);
+
+    for (int i = 0; i < 10; ++i) {
+        p[i] = i;
+    }
+
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_TRUE(p[i] == i);
+    }
+
+    m_alloc->deallocate_object<int>(p, 10);
+}
+
+TEST_F(core_allocator_test, constructor) {
+    test_class * p1 = m_alloc->new_object<test_class>();
+    test_class * p2 = m_alloc->new_object<test_class>(12);
+    test_class * p3 = m_alloc->new_object<test_class>(21, 611);
+    test_class * p4 = m_alloc->new_object<test_class>(21, 15);
+
+    ASSERT_TRUE(p1 != nullptr);
+    ASSERT_TRUE(p2 != nullptr);
+    ASSERT_TRUE(p3 != nullptr);
+    ASSERT_TRUE(p4 != nullptr);
+
+    EXPECT_TRUE(p1->m_int_1 == 5);
+    EXPECT_TRUE(p1->m_int_2 == 11);
+    EXPECT_TRUE(p1->m_bool_1 == false);
+    EXPECT_TRUE(p1->m_bool_2 == true);
+
+    EXPECT_TRUE(p2->m_int_1 == 5);
+    EXPECT_TRUE(p2->m_int_2 == 12);
+    EXPECT_TRUE(p2->m_bool_1 == false);
+    EXPECT_TRUE(p2->m_bool_2 == false);
+
+    EXPECT_TRUE(p3->m_int_1 == 5);
+    EXPECT_TRUE(p3->m_int_2 == 21);
+    EXPECT_TRUE(p3->m_bool_1 == false);
+    EXPECT_TRUE(p3->m_bool_2 == true);
+
+    EXPECT_TRUE(p4->m_int_1 == 5);
+    EXPECT_TRUE(p4->m_int_2 == 21);
+    EXPECT_TRUE(p4->m_bool_1 == false);
+    EXPECT_TRUE(p4->m_bool_2 == false);
+}


### PR DESCRIPTION
Currently, we support only allocation using memory resources via vectors and other such containers. Sometimes this is too high-level, and we (or users) may want to allocate objects individually using a memory resource. This commit adds a new allocator class which, when initialized with a memory resource, allows allocation of bytes directly, size for object arrays, or constructs new objects.