### PR TITLE
vecmem::array Memory Handling Update, main branch (2021.03.09.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -36,8 +36,10 @@ vecmem_add_library( vecmem_core core SHARED
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
+   "include/vecmem/utils/deallocator.hpp"
+   "src/utils/deallocator.cpp"
    "include/vecmem/utils/deleter.hpp"
-   "src/utils/deleter.cpp"
+   "include/vecmem/utils/deleter.ipp"
    "include/vecmem/utils/reverse_iterator.hpp"
    "include/vecmem/utils/reverse_iterator.ipp"
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/containers/array.ipp
+++ b/core/include/vecmem/containers/array.ipp
@@ -17,45 +17,44 @@ namespace vecmem {
    namespace details {
 
       /// Helper function used in the @c vecmem::array constructors
-      template< typename T, std::size_t N >
-      std::unique_ptr< typename vecmem::array< T, N >::value_type,
-                       vecmem::details::deleter >
-      allocate_array_memory( vecmem::memory_resource& resource,
-                             typename vecmem::array< T, N >::size_type size ) {
+      template< typename T, std::size_t N, typename A >
+      typename vecmem::array< T, N, A >::memory_type
+      allocate_array_memory(
+         typename vecmem::array< T, N, A >::allocator_type& alloc,
+         typename vecmem::array< T, N, A >::size_type size ) {
 
-         const std::size_t nbytes =
-            size * sizeof( typename vecmem::array< T, N >::value_type );
-         return { size == 0 ? nullptr :
-                  static_cast< typename vecmem::array< T, N >::pointer_type >(
-                     resource.allocate( nbytes ) ),
-                  vecmem::details::deleter( nbytes, resource ) };
+         return { size == 0 ? nullptr : alloc.allocate( size ),
+                  { size, alloc } };
       }
 
    } // namespace details
 
-   template< typename T, std::size_t N >
-   array< T, N >::array( memory_resource& resource )
+   template< typename T, std::size_t N, typename Allocator >
+   array< T, N, Allocator >::array( allocator_type alloc )
    : m_size( N ),
-     m_memory( details::allocate_array_memory< T, N >( resource, m_size ) ) {
+     m_memory( details::allocate_array_memory< T, N, Allocator >( alloc,
+                                                                  m_size ) ) {
 
       static_assert( N != details::array_invalid_size,
                      "Can only use the 'compile time constructor' if a size "
                      "was provided as a template argument" );
    }
 
-   template< typename T, std::size_t N >
-   array< T, N >::array( memory_resource& resource, size_type size )
+   template< typename T, std::size_t N, typename Allocator >
+   array< T, N, Allocator >::array( allocator_type alloc,
+                                    size_type size )
    : m_size( size ),
-     m_memory( details::allocate_array_memory< T, N >( resource, m_size ) ) {
+     m_memory( details::allocate_array_memory< T, N, Allocator >( alloc,
+                                                                  m_size ) ) {
 
       static_assert( N == details::array_invalid_size,
                      "Can only use the 'runtime constructor' if a size was not "
                      "provided as a template argument" );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reference_type
-   array< T, N >::at( size_type pos ) {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reference_type
+   array< T, N, Allocator >::at( size_type pos ) {
 
       if( pos >= m_size ) {
          throw std::out_of_range( "Requested element " + std::to_string( pos ) +
@@ -65,9 +64,9 @@ namespace vecmem {
       return m_memory.get()[ pos ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reference_type
-   array< T, N >::at( size_type pos ) const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reference_type
+   array< T, N, Allocator >::at( size_type pos ) const {
 
       if( pos >= m_size ) {
          throw std::out_of_range( "Requested element " + std::to_string( pos ) +
@@ -77,23 +76,23 @@ namespace vecmem {
       return m_memory.get()[ pos ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reference_type
-   array< T, N >::operator[]( size_type pos ) {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reference_type
+   array< T, N, Allocator >::operator[]( size_type pos ) {
 
       return m_memory.get()[ pos ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reference_type
-   array< T, N >::operator[]( size_type pos ) const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reference_type
+   array< T, N, Allocator >::operator[]( size_type pos ) const {
 
       return m_memory.get()[ pos ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reference_type
-   array< T, N >::front() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reference_type
+   array< T, N, Allocator >::front() {
 
       if( m_size == 0 ) {
          throw std::out_of_range( "Called vecmem::array::front() on an empty "
@@ -102,9 +101,9 @@ namespace vecmem {
       return ( *m_memory );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reference_type
-   array< T, N >::front() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reference_type
+   array< T, N, Allocator >::front() const {
 
       if( m_size == 0 ) {
          throw std::out_of_range( "Called vecmem::array::front() on an empty "
@@ -113,9 +112,9 @@ namespace vecmem {
       return ( *m_memory );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reference_type
-   array< T, N >::back() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reference_type
+   array< T, N, Allocator >::back() {
 
       if( m_size == 0 ) {
          throw std::out_of_range( "Called vecmem::array::back() on an empty "
@@ -124,9 +123,9 @@ namespace vecmem {
       return m_memory.get()[ m_size - 1 ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reference_type
-   array< T, N >::back() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reference_type
+   array< T, N, Allocator >::back() const {
 
       if( m_size == 0 ) {
          throw std::out_of_range( "Called vecmem::array::back() on an empty "
@@ -135,135 +134,135 @@ namespace vecmem {
       return m_memory.get()[ m_size - 1 ];
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::pointer_type
-   array< T, N >::data() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::pointer_type
+   array< T, N, Allocator >::data() {
 
       return m_memory.get();
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_pointer_type
-   array< T, N >::data() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_pointer_type
+   array< T, N, Allocator >::data() const {
 
       return m_memory.get();
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::iterator
-   array< T, N >::begin() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::iterator
+   array< T, N, Allocator >::begin() {
 
       return m_memory.get();
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_iterator
-   array< T, N >::begin() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_iterator
+   array< T, N, Allocator >::begin() const {
 
       return m_memory.get();
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_iterator
-   array< T, N >::cbegin() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_iterator
+   array< T, N, Allocator >::cbegin() const {
 
       return m_memory.get();
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::iterator
-   array< T, N >::end() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::iterator
+   array< T, N, Allocator >::end() {
 
       return ( m_memory.get() + m_size );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_iterator
-   array< T, N >::end() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_iterator
+   array< T, N, Allocator >::end() const {
 
       return ( m_memory.get() + m_size );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_iterator
-   array< T, N >::cend() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_iterator
+   array< T, N, Allocator >::cend() const {
 
       return ( m_memory.get() + m_size );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reverse_iterator
-   array< T, N >::rbegin() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reverse_iterator
+   array< T, N, Allocator >::rbegin() {
 
       return reverse_iterator( end() );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reverse_iterator
-   array< T, N >::rbegin() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reverse_iterator
+   array< T, N, Allocator >::rbegin() const {
 
       return const_reverse_iterator( end() );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reverse_iterator
-   array< T, N >::crbegin() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reverse_iterator
+   array< T, N, Allocator >::crbegin() const {
 
       return const_reverse_iterator( end() );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::reverse_iterator
-   array< T, N >::rend() {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::reverse_iterator
+   array< T, N, Allocator >::rend() {
 
       return reverse_iterator( begin() );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reverse_iterator
-   array< T, N >::rend() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reverse_iterator
+   array< T, N, Allocator >::rend() const {
 
       return const_reverse_iterator( begin() );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::const_reverse_iterator
-   array< T, N >::crend() const {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::const_reverse_iterator
+   array< T, N, Allocator >::crend() const {
 
       return const_reverse_iterator( begin() );
    }
 
-   template< typename T, std::size_t N >
-   bool array< T, N >::empty() const noexcept {
+   template< typename T, std::size_t N, typename Allocator >
+   bool array< T, N, Allocator >::empty() const noexcept {
 
       return ( m_size == 0 );
    }
 
-   template< typename T, std::size_t N >
-   typename array< T, N >::size_type
-   array< T, N >::size() const noexcept {
+   template< typename T, std::size_t N, typename Allocator >
+   typename array< T, N, Allocator >::size_type
+   array< T, N, Allocator >::size() const noexcept {
 
       return m_size;
    }
 
-   template< typename T, std::size_t N >
-   void array< T, N >::fill( const_reference_type value ) {
+   template< typename T, std::size_t N, typename Allocator >
+   void array< T, N, Allocator >::fill( const_reference_type value ) {
 
       std::fill( begin(), end(), value );
    }
 
-   template< typename T, std::size_t N >
+   template< typename T, std::size_t N, typename Allocator >
    VECMEM_HOST
    details::vector_view< T >
-   get_data( array< T, N >& a ) {
+   get_data( array< T, N, Allocator >& a ) {
 
       return { a.size(), a.data() };
    }
 
-   template< typename T, std::size_t N >
+   template< typename T, std::size_t N, typename Allocator >
    VECMEM_HOST
    details::vector_view< const T >
-   get_data( const array< T, N >& a ) {
+   get_data( const array< T, N, Allocator >& a ) {
 
       return { a.size(), a.data() };
    }

--- a/core/include/vecmem/containers/details/vector_buffer.hpp
+++ b/core/include/vecmem/containers/details/vector_buffer.hpp
@@ -9,7 +9,7 @@
 // Local include(s).
 #include "vecmem/containers/details/vector_view.hpp"
 #include "vecmem/memory/resources/memory_resource.hpp"
-#include "vecmem/utils/deleter.hpp"
+#include "vecmem/utils/deallocator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -39,7 +39,7 @@ namespace vecmem::details {
 
    private:
       /// Data object owning the allocated memory
-      std::unique_ptr< TYPE, deleter > m_memory;
+      std::unique_ptr< TYPE, deallocator > m_memory;
 
    }; // class vector_buffer
 

--- a/core/include/vecmem/containers/details/vector_buffer.ipp
+++ b/core/include/vecmem/containers/details/vector_buffer.ipp
@@ -10,16 +10,16 @@ namespace {
 
    /// Function creating the smart pointer for @c vecmem::details::vector_buffer
    template< typename TYPE >
-   std::unique_ptr< TYPE, vecmem::details::deleter >
+   std::unique_ptr< TYPE, vecmem::details::deallocator >
    allocate_buffer_memory(
       typename vecmem::details::vector_buffer< TYPE >::size_type size,
       vecmem::memory_resource& resource ) {
 
       const typename vecmem::details::vector_buffer< TYPE >::size_type
          byteSize = size * sizeof( TYPE );
-      return std::unique_ptr< TYPE, vecmem::details::deleter >(
-                static_cast< TYPE* >( resource.allocate( byteSize ) ),
-                vecmem::details::deleter( byteSize, resource ) );
+      return { size == 0 ? nullptr :
+               static_cast< TYPE* >( resource.allocate( byteSize ) ),
+               { byteSize, resource } };
    }
 
 } // private namespace

--- a/core/include/vecmem/utils/deallocator.hpp
+++ b/core/include/vecmem/utils/deallocator.hpp
@@ -1,0 +1,48 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/resources/memory_resource.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem::details {
+
+   /// Struct used for de-allocating a non-host-accessible memory block
+   ///
+   /// It can be used to make things like @c std::unique_ptr talk to
+   /// @c vecmem::memory_resource.
+   ///
+   class deallocator {
+
+   public:
+      /// Constructor
+      deallocator( std::size_t bytes, memory_resource& resource );
+
+      /// Copy constructor
+      deallocator( const deallocator& ) = default;
+      /// Move constructor
+      deallocator( deallocator&& ) = default;
+      /// Copy assignment operator
+      deallocator& operator=( const deallocator& ) = default;
+      /// Move assignment operator
+      deallocator& operator=( deallocator&& ) = default;
+
+      /// Operator performing the deletion of the object.
+      void operator()( void* ptr );
+
+   private:
+      /// The number of bytes allocated for the memory block
+      std::size_t m_bytes;
+      /// The memory resource used for deleting the memory block
+      memory_resource* m_resource;
+
+   }; // class deallocator
+
+} // namespace vecmem::details

--- a/core/include/vecmem/utils/deleter.hpp
+++ b/core/include/vecmem/utils/deleter.hpp
@@ -14,16 +14,23 @@
 
 namespace vecmem::details {
 
-   /// Struct used for deleting an allocated memory block
+   /// Struct used for deleting an allocated, host-accessible memory block
    ///
    /// It can be used to make things like @c std::unique_ptr talk to
    /// @c vecmem::memory_resource.
    ///
+   template< typename T,
+             typename Allocator = polymorphic_allocator< T > >
    class deleter {
 
    public:
+      /// Size type for the number of elements to delete
+      typedef std::size_t size_type;
+      /// The allocator type to use
+      typedef Allocator   allocator_type;
+
       /// Constructor
-      deleter( std::size_t bytes, memory_resource& resource );
+      deleter( size_type elements, const allocator_type& allocator );
 
       /// Copy constructor
       deleter( const deleter& ) = default;
@@ -38,11 +45,14 @@ namespace vecmem::details {
       void operator()( void* ptr );
 
    private:
-      /// The number of bytes allocated for the memory block
-      std::size_t m_bytes;
-      /// The memory resource used for deleting the memory block
-      memory_resource* m_resource;
+      /// The number of elements allocated for the memory block
+      size_type m_elements;
+      /// The allocator used to delete the elements
+      allocator_type m_allocator;
 
-   }; // struct deleter
+   }; // class deleter
 
 } // namespace vecmem::details
+
+// Include the implementation.
+#include "vecmem/utils/deleter.ipp"

--- a/core/include/vecmem/utils/deleter.ipp
+++ b/core/include/vecmem/utils/deleter.ipp
@@ -1,0 +1,24 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem::details {
+
+   template< typename T, typename Allocator >
+   deleter< T, Allocator >::
+   deleter( size_type elements, const allocator_type& allocator )
+   : m_elements( elements ), m_allocator( allocator ) {
+
+   }
+
+   template< typename T, typename Allocator >
+   void deleter< T, Allocator >::operator()( void* ptr ) {
+
+      m_allocator.deallocate( static_cast< T* >( ptr ), m_elements );
+   }
+
+} // namespace vecmem::details

--- a/core/src/utils/deallocator.cpp
+++ b/core/src/utils/deallocator.cpp
@@ -6,16 +6,16 @@
  */
 
 // Local include(s).
-#include "vecmem/utils/deleter.hpp"
+#include "vecmem/utils/deallocator.hpp"
 
 namespace vecmem::details {
 
-   deleter::deleter( std::size_t bytes, memory_resource& resource )
+   deallocator::deallocator( std::size_t bytes, memory_resource& resource )
    : m_bytes( bytes ), m_resource( &resource ) {
 
    }
 
-   void deleter::operator()( void* ptr ) {
+   void deallocator::operator()( void* ptr ) {
 
       if( ptr != nullptr ) {
          m_resource->deallocate( ptr, m_bytes );

--- a/tests/core/test_core_arrays.cpp
+++ b/tests/core/test_core_arrays.cpp
@@ -26,8 +26,8 @@ class core_array_test : public testing::Test {
 
 protected:
    /// Function testing a particular array object.
-   template< typename T, std::size_t N >
-   void test_array( vecmem::array< T, N >& a ) {
+   template< typename T, std::size_t N, typename A >
+   void test_array( vecmem::array< T, N, A >& a ) {
 
       // Make sure that we use integer types for the test, as it really only
       // works for that...
@@ -84,27 +84,27 @@ protected:
 /// Test with a non-zero sized array whose size is fixed at compile time.
 TEST_F( core_array_test, non_zero_compile_time ) {
 
-   vecmem::array< int, 10 > a( m_resource );
+   vecmem::array< int, 10 > a( &m_resource );
    test_array( a );
 }
 
 /// Test with a non-zero sized array whose size is specified at runtime
 TEST_F( core_array_test, non_zero_runtime ) {
 
-   vecmem::array< int > a( m_resource, 20 );
+   vecmem::array< int > a( &m_resource, 20 );
    test_array( a );
 }
 
 /// Test with a zero sized array whose size is fixed at compile time.
 TEST_F( core_array_test, zero_compile_time ) {
 
-   vecmem::array< unsigned int, 0 > a( m_resource );
+   vecmem::array< unsigned int, 0 > a( &m_resource );
    test_array( a );
 }
 
 /// Test with a zero sized array whose size is specified at runtime
 TEST_F( core_array_test, zero_runtime ) {
 
-   vecmem::array< unsigned int > a( m_resource, 0 );
+   vecmem::array< unsigned int > a( &m_resource, 0 );
    test_array( a );
 }

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -85,7 +85,7 @@ TEST_F( core_container_test, static_vector ) {
 /// Test(s) for @c vecmem::array
 TEST_F( core_container_test, array ) {
 
-   vecmem::array< int, 20 > test_array( m_resource );
+   vecmem::array< int, 20 > test_array( &m_resource );
    std::copy( m_reference_vector.begin(), m_reference_vector.end(),
               test_array.begin() );
    EXPECT_TRUE( std::equal( m_reference_vector.begin(),

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -30,7 +30,7 @@ int main() {
    assert( inputvec1.size() == outputvec1.size() );
 
    // Create the array that is used in the linear transformation.
-   vecmem::array< int, 2 > constants( managed_resource );
+   vecmem::array< int, 2 > constants( &managed_resource );
    constants[ 0 ] = 2;
    constants[ 1 ] = 3;
 

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -38,7 +38,7 @@ int main() {
    assert( inputvec.size() == outputvec.size() );
 
    // Create the array that is used in the linear transformation.
-   vecmem::array< int, 2 > constants( resource );
+   vecmem::array< int, 2 > constants( &resource );
    constants[ 0 ] = 2;
    constants[ 1 ] = 3;
 

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -57,7 +57,7 @@ int main() {
    assert( inputvec.size() == outputvec.size() );
 
    // Create the array that is used in the linear transformation.
-   vecmem::array< int, 2 > constantsarray( resource );
+   vecmem::array< int, 2 > constantsarray( &resource );
    constantsarray[ 0 ] = 2;
    constantsarray[ 1 ] = 3;
 


### PR DESCRIPTION
Following up from @stephenswat's comment in #37, I had to realize that the implementation of `vecmem::array` didn't allow for any complex element types.

To fix this, I updated `vecmem::array` to make use of an allocator instead of `vecmem::memory_resource` directly. Leaving it up to the allocator to properly instantiate/delete complex objects.

To do this, I now introduced 2 helper types:
  - `vecmem::details::deallocator` is a rename of the previous `vecmem::details::deleter` type. Hopefully better conveying with its name that it is only deallocating the memory given to it.
  - `vecmem::details::deleter` is not a template, making use of an allocator itself for deleting the object from memory.

Then I updated all the unit tests for these UI changes. Note that with this change the constructor of `vecmem::vector` and `vecmem::array` became a bit more consistent. :wink: 