### PR TITLE
Memory Handling Update, main branch (2021.03.10.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,6 +27,8 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/memory/allocator.hpp"
    "include/vecmem/memory/allocator.ipp"
    "src/memory/allocator.cpp"
+   "include/vecmem/memory/deallocator.hpp"
+   "src/memory/deallocator.cpp"
    # Memory management.
    "include/vecmem/memory/resources/memory_resource.hpp"
    "src/memory/host_memory_resource.cpp"
@@ -36,8 +38,6 @@ vecmem_add_library( vecmem_core core SHARED
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
-   "include/vecmem/utils/deleter.hpp"
-   "src/utils/deleter.cpp"
    "include/vecmem/utils/reverse_iterator.hpp"
    "include/vecmem/utils/reverse_iterator.ipp"
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -9,7 +9,6 @@
 // Local include(s).
 #include "vecmem/containers/details/vector_view.hpp"
 #include "vecmem/memory/resources/memory_resource.hpp"
-#include "vecmem/utils/deleter.hpp"
 #include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
@@ -83,6 +82,33 @@ namespace vecmem {
                      "types" );
 
       /// @}
+
+      /// Struct used for deleting the allocated memory block
+      class deleter {
+
+      public:
+         /// Constructor
+         deleter( size_type size, memory_resource& resource );
+
+         /// Copy constructor
+         deleter( const deleter& ) = default;
+         /// Move constructor
+         deleter( deleter&& ) = default;
+         /// Copy assignment operator
+         deleter& operator=( const deleter& ) = default;
+         /// Move assignment operator
+         deleter& operator=( deleter&& ) = default;
+
+         /// Operator performing the deletion of the object.
+         void operator()( void* ptr );
+
+      private:
+         /// The number of elements in the array
+         size_type m_size;
+         /// The memory resource used for deleting the memory block
+         memory_resource* m_resource;
+
+      }; // struct deleter
 
       /// Constructor with a memory resource to use
       ///
@@ -192,7 +218,7 @@ namespace vecmem {
       /// The size of the allocated array
       size_type m_size;
       /// The allocated array
-      std::unique_ptr< value_type, details::deleter > m_memory;
+      std::unique_ptr< value_type, deleter > m_memory;
 
    }; // class array
 

--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -10,12 +10,13 @@
 #include "vecmem/containers/details/vector_view.hpp"
 #include "vecmem/memory/resources/memory_resource.hpp"
 #include "vecmem/utils/deleter.hpp"
+#include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
-#include <iterator>
 #include <memory>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -52,24 +53,34 @@ namespace vecmem {
       typedef std::ptrdiff_t     difference_type;
 
       /// Value reference type
-      typedef value_type&        reference_type;
+      typedef value_type&        reference;
       /// Constant value reference type
-      typedef const value_type&  const_reference_type;
+      typedef const value_type&  const_reference;
 
       /// Value pointer type
-      typedef value_type*        pointer_type;
+      typedef value_type*        pointer;
       /// Constant value pointer type
-      typedef const value_type*  const_pointer_type;
+      typedef const value_type*  const_pointer;
 
       /// Forward iterator type
-      typedef pointer_type       iterator;
+      typedef pointer            iterator;
       /// Constant forward iterator type
-      typedef const_pointer_type const_iterator;
+      typedef const_pointer      const_iterator;
 
       /// Reverse iterator type
-      typedef std::reverse_iterator< iterator > reverse_iterator;
+      typedef vecmem::reverse_iterator< iterator > reverse_iterator;
       /// Constant reverse iterator type
-      typedef std::reverse_iterator< const_iterator > const_reverse_iterator;
+      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+
+      /// @}
+
+      /// @name Check(s) on the type of the array element
+      /// @{
+
+      /// Make sure that the template type is default constructible
+      static_assert( std::is_default_constructible< value_type >::value,
+                     "vecmem::array can only handle default-constructible "
+                     "types" );
 
       /// @}
 
@@ -94,29 +105,29 @@ namespace vecmem {
       /// @{
 
       /// Access one element of the array (non-const)
-      reference_type at( size_type pos );
+      reference at( size_type pos );
       /// Access one element of the array (const)
-      const_reference_type at( size_type pos ) const;
+      const_reference at( size_type pos ) const;
 
       /// Access one element in the array (non-const)
-      reference_type operator[]( size_type pos );
+      reference operator[]( size_type pos );
       /// Access one element in the array (const)
-      const_reference_type operator[]( size_type pos ) const;
+      const_reference operator[]( size_type pos ) const;
 
       /// Access the first element in the array (non-const)
-      reference_type front();
+      reference front();
       /// Access the first element in the array (const)
-      const_reference_type front() const;
+      const_reference front() const;
 
       /// Access the last element of the array (non-const)
-      reference_type back();
+      reference back();
       /// Access the last element of the array (const)
-      const_reference_type back() const;
+      const_reference back() const;
 
       /// Access a pointer to the underlying memory block (non-const)
-      pointer_type data();
+      pointer data();
       /// Access a pointer to the underlying memory block (const)
-      const_pointer_type data() const;
+      const_pointer data() const;
 
       /// @}
 
@@ -173,7 +184,7 @@ namespace vecmem {
       /// @{
 
       /// Assign the specified value to all elements of the array
-      void fill( const_reference_type value );
+      void fill( const_reference value );
 
       /// @}
 

--- a/core/include/vecmem/containers/details/vector_buffer.hpp
+++ b/core/include/vecmem/containers/details/vector_buffer.hpp
@@ -9,12 +9,13 @@
 // Local include(s).
 #include "vecmem/containers/details/vector_view.hpp"
 #include "vecmem/memory/resources/memory_resource.hpp"
-#include "vecmem/utils/deleter.hpp"
+#include "vecmem/memory/deallocator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
 #include <memory>
+#include <type_traits>
 
 namespace vecmem::details {
 
@@ -30,6 +31,16 @@ namespace vecmem::details {
       /// The base type used by this class
       typedef vector_view< TYPE > base_type;
 
+      /// @name Checks on the type of the array element
+      /// @{
+
+      /// Make sure that the template type does not have a custom destructor
+      static_assert( std::is_trivially_destructible< TYPE >::value,
+                     "vecmem::details::vector_buffer can not handle types with "
+                     "custom destructors" );
+
+      /// @}
+
       /// Constructor with a size
       ///
       /// It is left up to external code to copy data into the allocated memory.
@@ -39,7 +50,7 @@ namespace vecmem::details {
 
    private:
       /// Data object owning the allocated memory
-      std::unique_ptr< TYPE, deleter > m_memory;
+      std::unique_ptr< TYPE, deallocator > m_memory;
 
    }; // class vector_buffer
 

--- a/core/include/vecmem/containers/details/vector_buffer.ipp
+++ b/core/include/vecmem/containers/details/vector_buffer.ipp
@@ -10,16 +10,16 @@ namespace {
 
    /// Function creating the smart pointer for @c vecmem::details::vector_buffer
    template< typename TYPE >
-   std::unique_ptr< TYPE, vecmem::details::deleter >
+   std::unique_ptr< TYPE, vecmem::details::deallocator >
    allocate_buffer_memory(
       typename vecmem::details::vector_buffer< TYPE >::size_type size,
       vecmem::memory_resource& resource ) {
 
       const typename vecmem::details::vector_buffer< TYPE >::size_type
          byteSize = size * sizeof( TYPE );
-      return std::unique_ptr< TYPE, vecmem::details::deleter >(
-                static_cast< TYPE* >( resource.allocate( byteSize ) ),
-                vecmem::details::deleter( byteSize, resource ) );
+      return { size == 0 ? nullptr :
+               static_cast< TYPE* >( resource.allocate( byteSize ) ),
+               { byteSize, resource } };
    }
 
 } // private namespace

--- a/core/include/vecmem/memory/deallocator.hpp
+++ b/core/include/vecmem/memory/deallocator.hpp
@@ -14,25 +14,27 @@
 
 namespace vecmem::details {
 
-   /// Struct used for deleting an allocated memory block
+   /// Struct used for deallocating an allocated memory block
    ///
    /// It can be used to make things like @c std::unique_ptr talk to
-   /// @c vecmem::memory_resource.
+   /// @c vecmem::memory_resource. Note however that this is *not* a "deleter"
+   /// type. It *does not* call any custom destructors. It merely de-allocates
+   /// a memory block.
    ///
-   class deleter {
+   class deallocator {
 
    public:
       /// Constructor
-      deleter( std::size_t bytes, memory_resource& resource );
+      deallocator( std::size_t bytes, memory_resource& resource );
 
       /// Copy constructor
-      deleter( const deleter& ) = default;
+      deallocator( const deallocator& ) = default;
       /// Move constructor
-      deleter( deleter&& ) = default;
+      deallocator( deallocator&& ) = default;
       /// Copy assignment operator
-      deleter& operator=( const deleter& ) = default;
+      deallocator& operator=( const deallocator& ) = default;
       /// Move assignment operator
-      deleter& operator=( deleter&& ) = default;
+      deallocator& operator=( deallocator&& ) = default;
 
       /// Operator performing the deletion of the object.
       void operator()( void* ptr );
@@ -43,6 +45,6 @@ namespace vecmem::details {
       /// The memory resource used for deleting the memory block
       memory_resource* m_resource;
 
-   }; // struct deleter
+   }; // struct deallocator
 
 } // namespace vecmem::details

--- a/core/src/memory/deallocator.cpp
+++ b/core/src/memory/deallocator.cpp
@@ -6,16 +6,16 @@
  */
 
 // Local include(s).
-#include "vecmem/utils/deleter.hpp"
+#include "vecmem/memory/deallocator.hpp"
 
 namespace vecmem::details {
 
-   deleter::deleter( std::size_t bytes, memory_resource& resource )
+   deallocator::deallocator( std::size_t bytes, memory_resource& resource )
    : m_bytes( bytes ), m_resource( &resource ) {
 
    }
 
-   void deleter::operator()( void* ptr ) {
+   void deallocator::operator()( void* ptr ) {
 
       if( ptr != nullptr ) {
          m_resource->deallocate( ptr, m_bytes );

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -8,6 +8,6 @@
 vecmem_add_test( core
    "test_core_allocators.cpp" "test_core_arrays.cpp"
    "test_core_containers.cpp" "test_core_contiguous_memory_resource.cpp"
-   "test_core_device_containers.cpp"
-   "test_core_allocator.cpp"
+   "test_core_device_containers.cpp" "test_core_allocator.cpp"
+   "test_core_vectors.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main )

--- a/tests/core/test_core_arrays.cpp
+++ b/tests/core/test_core_arrays.cpp
@@ -108,3 +108,35 @@ TEST_F( core_array_test, zero_runtime ) {
    vecmem::array< unsigned int > a( m_resource, 0 );
    test_array( a );
 }
+
+namespace {
+
+   /// Simple test type
+   struct TestType1 {
+      /// Constructor
+      TestType1( int a = 10 ) : m_value( a + 1 ), m_pointer( nullptr ) {}
+      /// Destructor
+      ~TestType1() {
+         if( m_pointer != nullptr ) {
+            *m_pointer -= 1;
+         }
+      }
+      /// Simple member variable
+      int m_value;
+      /// Pointer member variable
+      int* m_pointer;
+   }; // struct TestType1
+
+} // private namespace
+
+/// Make sure that a non-trivial constructor and destructor is executed properly
+TEST_F( core_array_test, constructor_destructor ) {
+
+   int dummy = 5;
+   {
+      vecmem::array< TestType1, 10 > a( m_resource );
+      EXPECT_EQ( a.front().m_value, 11 );
+      a.back().m_pointer = &dummy;
+   }
+   EXPECT_EQ( dummy, 4 );
+}

--- a/tests/core/test_core_vectors.cpp
+++ b/tests/core/test_core_vectors.cpp
@@ -1,0 +1,52 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+/// Test case for @c vecmem::vector
+class core_vector_test : public testing::Test {
+
+protected:
+   /// Memory resource to use in the tests
+   vecmem::host_memory_resource m_resource;
+
+}; // class core_vector_test
+
+namespace {
+
+   /// Simple test type
+   struct TestType1 {
+      /// Constructor
+      TestType1( int a, int& b ) : m_value( a + 1 ), m_pointer( &b ) {}
+      /// Destructor
+      ~TestType1() {
+         *m_pointer -= 1;
+      }
+      /// Simple member variable
+      int m_value;
+      /// Pointer member variable
+      int* m_pointer;
+   }; // struct TestType1
+
+} // private namespace
+
+/// Make sure that a non-trivial constructor and destructor is executed properly
+TEST_F( core_vector_test, constructor_destructor ) {
+
+   int dummy = 5;
+   {
+      vecmem::vector< ::TestType1 > test_vector( &m_resource );
+      test_vector.emplace_back( 10, dummy );
+      EXPECT_EQ( test_vector.back().m_value, 11 );
+   }
+   EXPECT_EQ( dummy, 4 );
+}


### PR DESCRIPTION
This is meant as a replacement for #39.

Instead of bothering with allocators, `vecmem::array` is taught directly to call the constructors of non-trivial types, and is updated to use its own custom deleter type once again to make sure that custom destructors would be called correctly.

At the same time renamed `vecmem::details::deleter` to `vecmem::details::deallocator`, as the latter better reflects what this type does. It just deallocates memory, it is not able to call any custom destructors. (Since it is used for non-host-accessible memory resources as well.)

Updated both `vecmem::array` and `vecmem::details::vector_buffer` to explicitly require certain properties from their value types.

Finally, added some tests to make sure that both `vecmem::vector` and `vecmem::array` would call the constructor and destructor of its elements correctly. (For `vecmem::vector` it's a bit unnecessary, but it could come in handy if we do some bigger changes to how `vecmem::vector` is defined.)