### PR TITLE
Forward declare C++17 types for NVCC

### DIFF
--- a/core/include/vecmem/memory/resources/memory_resource.hpp
+++ b/core/include/vecmem/memory/resources/memory_resource.hpp
@@ -14,7 +14,14 @@
  * std::experimental::pmr namespace depending on the GCC version used, so we try
  * to unify them by aliassing depending on the compiler feature flags.
  */
-#if __has_include(<memory_resource>)
+#ifdef __CUDACC__
+namespace vecmem {
+    class memory_resource;
+
+    template<typename T>
+    class polymorphic_allocator;
+}
+#elif __has_include(<memory_resource>)
 #include <memory_resource>
 
 namespace vecmem {


### PR DESCRIPTION
Once again NVCC's dependence on C++14 rears its ugly head. We can't really include the memory_resources.hpp file from any code that might be included from CUDA right now, but we need to do that for some new types. This commit adds a preprocessor clause that forward-declares the memory_resource and polymorphic_allocator types in code compiled by NVCC. That allows NVCC to accept the type for pointers and references without having to include more C++17-only headers.