### PR TITLE
Static Vector Update, main branch (2021.03.11.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -21,6 +21,8 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wall" )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wextra" )
+      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode}
+         "-Wno-gnu-zero-variadic-macro-arguments" )
    endforeach()
 
    # More rigorous tests for the Debug builds.

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -42,4 +42,5 @@ vecmem_add_library( vecmem_core core SHARED
    # Utilities.
    "include/vecmem/utils/reverse_iterator.hpp"
    "include/vecmem/utils/reverse_iterator.ipp"
+   "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,6 +16,7 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/device_vector.hpp"
    "include/vecmem/containers/device_vector.ipp"
    "include/vecmem/containers/static_vector.hpp"
+   "include/vecmem/containers/static_vector.ipp"
    "include/vecmem/containers/vector.hpp"
    "include/vecmem/containers/vector.ipp"
    # Implementation details for the containers.

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -7,170 +7,271 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
-#include <algorithm>
-#include <cassert>
-#include <vector>
+#include <cstddef>
 
 namespace vecmem {
 
    /// Class mimicking @c std::vector on top of a fixed sized array
+   ///
+   /// This can come in handy when needing vector arithmetics in device code,
+   /// without resorting to heap allocations.
+   ///
+   /// The type does come with a significant limitation over @c std::vector.
+   /// It has a maximal/fixed size that needs to be chosen at compile time.
+   ///
    template< typename TYPE, std::size_t MAX_SIZE >
    class static_vector {
 
    public:
-      /// @name Type definitions mimicking @c std::vector
+      /// @name Type definitions, mimicking @c std::vector
       /// @{
-      typedef std::size_t    size_type;
-      typedef std::ptrdiff_t difference_type;
-      typedef TYPE*          pointer;
-      typedef const TYPE*    const_pointer;
-      typedef TYPE&          reference;
-      typedef const TYPE&    const_reference;
-      typedef TYPE           value_type;
-      static const size_type array_max_size = MAX_SIZE;
-      typedef TYPE           array_type[ array_max_size ];
-      typedef typename std::vector< TYPE >::iterator         iterator;
-      typedef typename std::vector< TYPE >::const_iterator   const_iterator;
-      typedef typename std::vector< TYPE >::reverse_iterator reverse_iterator;
-      typedef typename std::vector< TYPE >::const_reverse_iterator
-         const_reverse_iterator;
+
+      /// Type of the array elements
+      typedef TYPE               value_type;
+      /// Size type for the array
+      typedef std::size_t        size_type;
+      /// Pointer difference type
+      typedef std::ptrdiff_t     difference_type;
+
+      /// The maximal size of the vector
+      static constexpr size_type array_max_size = MAX_SIZE;
+      /// The size of the vector elements
+      static constexpr size_type value_size = sizeof( value_type );
+      /// Type of the array holding the payload of the vector elements
+      typedef char               array_type[ array_max_size * value_size ];
+
+      /// Value reference type
+      typedef value_type&        reference;
+      /// Constant value reference type
+      typedef const value_type&  const_reference;
+      /// Value pointer type
+      typedef value_type*        pointer;
+      /// Constant value pointer type
+      typedef const value_type*  const_pointer;
+
+      /// Forward iterator type
+      typedef pointer            iterator;
+      /// Constant forward iterator type
+      typedef const_pointer      const_iterator;
+      /// Reverse iterator type
+      typedef vecmem::reverse_iterator< iterator >       reverse_iterator;
+      /// Constant reverse iterator type
+      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+
       /// @}
+
+      /// @name Constructors and destructor, mimicking @c std::vector
+      /// @{
 
       /// Default constructor
       VECMEM_HOST_AND_DEVICE
-      static_vector( std::size_t size = 0 ) : m_size( size ) {}
+      static_vector();
+      /// Construct a vector with a specific size
+      VECMEM_HOST_AND_DEVICE
+      static_vector( size_type size, const_reference value = value_type() );
+      /// Construct a vector with values coming from a pair of iterators
+      /*
+      template< typename InputIt >
+      VECMEM_HOST_AND_DEVICE
+      static_vector( InputIt other_begin, InputIt other_end );
+      */
+      /// Copy constructor
+      VECMEM_HOST_AND_DEVICE
+      static_vector( const static_vector& parent );
+
+      /// Destructor
+      VECMEM_HOST_AND_DEVICE
+      ~static_vector();
+
+      /// @}
 
       /// @name Vector element access functions
       /// @{
-      VECMEM_HOST_AND_DEVICE
-      reference at( size_type pos ) {
-         assert( pos < m_size );
-         return m_elements[ pos ];
-      }
 
+      /// Return a specific element of the vector in a "safe way" (non-const)
       VECMEM_HOST_AND_DEVICE
-      const_reference at( size_type pos ) const {
-         assert( pos < m_size );
-         return m_elements[ pos ];
-      }
+      reference at( size_type pos );
+      /// Return a specific element of the vector in a "safe way" (const)
+      VECMEM_HOST_AND_DEVICE
+      const_reference at( size_type pos ) const;
 
+      /// Return a specific element of the vector (non-const)
       VECMEM_HOST_AND_DEVICE
-      reference operator[]( size_type pos ) {
-         return m_elements[ pos ];
-      }
+      reference operator[]( size_type pos );
+      /// Return a specific element of the vector (const)
       VECMEM_HOST_AND_DEVICE
-      const_reference operator[]( size_type pos ) const {
-         return m_elements[ pos ];
-      }
+      const_reference operator[]( size_type pos ) const;
 
+      /// Return the first element of the vector (non-const)
       VECMEM_HOST_AND_DEVICE
-      reference front() {
-         return m_elements[ 0 ];
-      }
+      reference front();
+      /// Return the first element of the vector (const)
       VECMEM_HOST_AND_DEVICE
-      const_reference front() const {
-         return m_elements[ 0 ];
-      }
+      const_reference front() const;
 
+      /// Return the last element of the vector (non-const)
       VECMEM_HOST_AND_DEVICE
-      reference back() {
-         return m_elements[ m_size - 1 ];
-      }
+      reference back();
+      /// Return the last element of the vector (const)
       VECMEM_HOST_AND_DEVICE
-      const_reference back() const {
-         return m_elements[ m_size - 1 ];
-      }
+      const_reference back() const;
+
+      /// Access the underlying memory array (non-const)
+      VECMEM_HOST_AND_DEVICE
+      pointer data();
+      /// Access the underlying memory array (const)
+      VECMEM_HOST_AND_DEVICE
+      const_pointer data() const;
+
       /// @}
 
       /// @name Payload modification functions
       /// @{
+
+      /// Assign new values to the vector
       VECMEM_HOST_AND_DEVICE
-      void push_back( const_reference value ) {
-         assert( m_size + 1 <= array_max_size );
-         m_elements[ m_size ] = value;
-         ++m_size;
-      }
+      void assign( size_type count, const_reference value );
+      /// Assign new values to the vector
+      /*
+      template< typename InputIt >
+      VECMEM_HOST_AND_DEVICE
+      void assign( InputIt other_begin, InputIt other_end );
+      */
+
+      /// Insert a new element into the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator insert( const_iterator pos, const_reference value );
+      /// Insert an element N times into the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator insert( const_iterator pos, size_type count,
+                       const_reference value );
+      /// Insert a list of elements into the vector
+      template< typename InputIt >
+      iterator insert( const_iterator pos, InputIt other_begin,
+                       InputIt other_end );
+
+      /// Insert a new element into the vector
+      template< typename... Args >
+      VECMEM_HOST_AND_DEVICE
+      iterator emplace( const_iterator pos, Args&&... args );
+      /// Add a new element at the end of the vector
+      template< typename... Args >
+      VECMEM_HOST_AND_DEVICE
+      reference emplace_back( Args&&... args );
+
+      /// Add a new element at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      void push_back( const_reference value );
+
+      /// Remove one element from the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator erase( const_iterator pos );
+      /// Remove a list of elements from the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator erase( const_iterator first, const_iterator last );
+      /// Remove the last element of the vector
+      VECMEM_HOST_AND_DEVICE
+      void pop_back();
+
+      /// Clear the vector
+      VECMEM_HOST_AND_DEVICE
+      void clear();
+      /// Resize the vector
+      VECMEM_HOST_AND_DEVICE
+      void resize( std::size_t new_size );
+      /// Resize the vector and fill any new elements with the specified value
+      VECMEM_HOST_AND_DEVICE
+      void resize( std::size_t new_size, const_reference value );
+
       /// @}
 
       /// @name Iterator providing functions
       /// @{
-      VECMEM_HOST
-      iterator begin() {
-         return iterator( m_elements );
-      }
-      VECMEM_HOST
-      const_iterator begin() const {
-         return const_iterator( m_elements );
-      }
-      VECMEM_HOST
-      const_iterator cbegin() const {
-         return begin();
-      }
 
-      VECMEM_HOST
-      iterator end() {
-         return iterator( m_elements + m_size );
-      }
-      VECMEM_HOST
-      const_iterator end() const {
-         return const_iterator( m_elements + m_size );
-      }
-      VECMEM_HOST
-      const_iterator cend() const {
-         return const_iterator( m_elements + m_size );
-      }
+      /// Return a forward iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator begin();
+      /// Return a constant forward iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_iterator begin() const;
+      /// Return a constant forward iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_iterator cbegin() const;
 
-      VECMEM_HOST
-      reverse_iterator rbegin() {
-         return reverse_iterator( end() );
-      }
-      VECMEM_HOST
-      const_reverse_iterator rbegin() const {
-         return const_reverse_iterator( end() );
-      }
-      VECMEM_HOST
-      const_reverse_iterator crbegin() const {
-         return const_reverse_iterator( cend() );
-      }
+      /// Return a forward iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      iterator end();
+      /// Return a constant forward iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_iterator end() const;
+      /// Return a constant forward iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_iterator cend() const;
 
-      VECMEM_HOST
-      reverse_iterator rend() {
-         return reverse_iterator( begin() );
-      }
-      VECMEM_HOST
-      const_reverse_iterator rend() const {
-         return const_reverse_iterator( begin() );
-      }
-      VECMEM_HOST
-      const_reverse_iterator crend() const {
-         return const_reverse_iterator( cbegin() );
-      }
+      /// Return a reverse iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      reverse_iterator rbegin();
+      /// Return a constant reverse iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_reverse_iterator rbegin() const;
+      /// Return a constant reverse iterator pointing at the end of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_reverse_iterator crbegin() const;
+
+      /// Return a reverse iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      reverse_iterator rend();
+      /// Return a constant reverse iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_reverse_iterator rend() const;
+      /// Return a constant reverse iterator pointing at the beginning of the vector
+      VECMEM_HOST_AND_DEVICE
+      const_reverse_iterator crend() const;
+
       /// @}
 
-      /// @name Additional helper functions
+      /// @name Capacity checking/modyfying functions
       /// @{
-      VECMEM_HOST_AND_DEVICE
-      bool empty() const {
-         return m_size == 0;
-      }
 
+      /// Check whether the vector is empty
       VECMEM_HOST_AND_DEVICE
-      size_type size() const {
-         return m_size;
-      }
+      bool empty() const;
+      /// Return the number of elements in the vector
+      VECMEM_HOST_AND_DEVICE
+      size_type size() const;
+      /// Return the maximum (fixed) number of elements in the vector
+      VECMEM_HOST_AND_DEVICE
+      size_type max_size() const;
+      /// Return the current (fixed) capacity of the vector
+      VECMEM_HOST_AND_DEVICE
+      size_type capacity() const;
+      /// Reserve additional storage for the vector
+      VECMEM_HOST_AND_DEVICE
+      void reserve( size_type new_cap );
 
-      VECMEM_HOST_AND_DEVICE
-      void resize( std::size_t value ) {
-         assert( value <= array_max_size );
-         m_size = value;
-         return;
-      }
       /// @}
 
    private:
+      /// Construct a new vector element
+      VECMEM_HOST_AND_DEVICE
+      void construct( size_type pos, const_reference value );
+      /// Destruct a vector element
+      VECMEM_HOST_AND_DEVICE
+      void destruct( size_type pos );
+
+      /// Helper type for identifying an element in the
+      struct ElementId {
+         size_type m_index;
+         pointer m_ptr;
+      }; // struct ElementId
+      /// Get the relevant identifiers of an element using an iterator
+      VECMEM_HOST_AND_DEVICE
+      ElementId element_id( const_iterator pos );
+
       /// Size of the vector
       size_type m_size;
       /// Array that holds the PoD elements of the vector
@@ -179,3 +280,6 @@ namespace vecmem {
    }; // class static_vector
 
 } // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/containers/static_vector.ipp"

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -8,10 +8,12 @@
 
 // Local include(s).
 #include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -74,11 +76,12 @@ namespace vecmem {
       VECMEM_HOST_AND_DEVICE
       static_vector( size_type size, const_reference value = value_type() );
       /// Construct a vector with values coming from a pair of iterators
-      /*
-      template< typename InputIt >
+      template< typename InputIt,
+                std::enable_if_t<
+                   details::is_iterator_of< InputIt, value_type >::value,
+                   bool > = true >
       VECMEM_HOST_AND_DEVICE
       static_vector( InputIt other_begin, InputIt other_end );
-      */
       /// Copy constructor
       VECMEM_HOST_AND_DEVICE
       static_vector( const static_vector& parent );
@@ -136,11 +139,12 @@ namespace vecmem {
       VECMEM_HOST_AND_DEVICE
       void assign( size_type count, const_reference value );
       /// Assign new values to the vector
-      /*
-      template< typename InputIt >
+      template< typename InputIt,
+                std::enable_if_t<
+                   details::is_iterator_of< InputIt, value_type >::value,
+                   bool > = true >
       VECMEM_HOST_AND_DEVICE
       void assign( InputIt other_begin, InputIt other_end );
-      */
 
       /// Insert a new element into the vector
       VECMEM_HOST_AND_DEVICE
@@ -150,7 +154,10 @@ namespace vecmem {
       iterator insert( const_iterator pos, size_type count,
                        const_reference value );
       /// Insert a list of elements into the vector
-      template< typename InputIt >
+      template< typename InputIt,
+                std::enable_if_t<
+                   details::is_iterator_of< InputIt, value_type >::value,
+                   bool > = true >
       iterator insert( const_iterator pos, InputIt other_begin,
                        InputIt other_end );
 

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -44,7 +44,9 @@ namespace vecmem {
       /// The size of the vector elements
       static constexpr size_type value_size = sizeof( value_type );
       /// Type of the array holding the payload of the vector elements
-      typedef char               array_type[ array_max_size * value_size ];
+      typedef typename
+      details::array_type< char, array_max_size * value_size >::type
+         array_type;
 
       /// Value reference type
       typedef value_type&        reference;

--- a/core/include/vecmem/containers/static_vector.ipp
+++ b/core/include/vecmem/containers/static_vector.ipp
@@ -1,0 +1,601 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <cassert>
+#include <cstring>
+
+namespace vecmem {
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   static_vector< TYPE, MAX_SIZE >::static_vector()
+   : m_size( 0 ), m_elements() {
+
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   static_vector< TYPE, MAX_SIZE >::
+   static_vector( size_type size, const_reference value )
+   : m_size( size ), m_elements() {
+
+      assign( size, value );
+   }
+
+   /*
+   template< typename TYPE, std::size_t MAX_SIZE >
+   template< typename InputIt >
+   VECMEM_HOST_AND_DEVICE
+   static_vector< TYPE, MAX_SIZE >::
+   static_vector( InputIt other_begin, InputIt other_end )
+   : m_size( 0 ), m_elements() {
+
+      assign( other_begin, other_end );
+   }
+   */
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   static_vector< TYPE, MAX_SIZE >::
+   static_vector( const static_vector& parent )
+   : m_size( parent.m_size ), m_elements() {
+
+      // Make copies of all of the elements.
+      for( size_type i = 0; i < m_size; ++i ) {
+         construct( i, parent[ i ] );
+      }
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   static_vector< TYPE, MAX_SIZE >::~static_vector() {
+
+      clear();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reference
+   static_vector< TYPE, MAX_SIZE >::at( size_type pos ) {
+
+      // Make sure that the element exists.
+      assert( pos < m_size );
+
+      // Return the element.
+      return *( reinterpret_cast< pointer >( m_elements ) + pos );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reference
+   static_vector< TYPE, MAX_SIZE >::at( size_type pos ) const {
+
+      // Make sure that the element exists.
+      assert( pos < m_size );
+
+      // Return the element.
+      return *( reinterpret_cast< const_pointer >( m_elements ) + pos );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reference
+   static_vector< TYPE, MAX_SIZE >::operator[]( size_type pos ) {
+
+      // Return the element.
+      return *( reinterpret_cast< pointer >( m_elements ) + pos );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reference
+   static_vector< TYPE, MAX_SIZE >::operator[]( size_type pos ) const {
+
+      // Return the element.
+      return *( reinterpret_cast< const_pointer >( m_elements ) + pos );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reference
+   static_vector< TYPE, MAX_SIZE >::front() {
+
+      // Make sure that the element exists.
+      assert( m_size > 0 );
+
+      // Return the element.
+      return *( reinterpret_cast< pointer >( m_elements ) );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reference
+   static_vector< TYPE, MAX_SIZE >::front() const {
+
+      // Make sure that the element exists.
+      assert( m_size > 0 );
+
+      // Return the element.
+      return *( reinterpret_cast< const_pointer >( m_elements ) );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reference
+   static_vector< TYPE, MAX_SIZE >::back() {
+
+      // Make sure that the element exists.
+      assert( m_size > 0 );
+
+      // Return the element.
+      return *( reinterpret_cast< pointer >( m_elements ) + m_size - 1 );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reference
+   static_vector< TYPE, MAX_SIZE >::back() const {
+
+      // Make sure that the element exists.
+      assert( m_size > 0 );
+
+      // Return the element.
+      return *( reinterpret_cast< const_pointer >( m_elements ) + m_size - 1 );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::pointer
+   static_vector< TYPE, MAX_SIZE >::data() {
+
+      return reinterpret_cast< pointer >( m_elements );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_pointer
+   static_vector< TYPE, MAX_SIZE >::data() const {
+
+      return reinterpret_cast< const_pointer >( m_elements );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::
+   assign( size_type count, const_reference value ) {
+
+      // Make sure that the sizes are compatible.
+      assert( array_max_size >= count );
+
+      // Remove all previous elements.
+      clear();
+
+      // Create the required number of identical elements.
+      for( size_type i = 0; i < count; ++i ) {
+         construct( i, value );
+      }
+
+      // Set the assigned size of the vector.
+      m_size = count;
+   }
+
+   /*
+   template< typename TYPE, std::size_t MAX_SIZE >
+   template< typename InputIt >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::
+   assign( InputIt other_begin, InputIt other_end ) {
+
+      // Remove all previous elements.
+      clear();
+
+      // Create copies of all of the elements one-by-one. It's very inefficient,
+      // but we can't make any assumptions about the type of the input iterator
+      // received by this function.
+      for( InputIt itr = other_begin; itr != other_end; ++itr ) {
+         construct( m_size++, *itr );
+      }
+   }
+   */
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos,
+                                            const_reference value ) {
+
+      // Make sure that one more position is available.
+      assert( m_size < array_max_size );
+
+      // Find the index of this iterator inside of the vector.
+      auto id = element_id( pos );
+
+      // Move the payload of the existing elements after "pos".
+      memmove( static_cast< void* >( id.m_ptr + 1 ),
+               static_cast< const void* >( id.m_ptr ),
+               ( m_size - id.m_index ) * value_size );
+
+      // Instantiate the new value.
+      construct( id.m_index, value );
+
+      // Increment the size.
+      ++m_size;
+
+      // Return an iterator to the inserted element.
+      return id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos, size_type count,
+                                            const_reference value ) {
+
+      // Make sure that the requested number of positions are still available.
+      assert( m_size + count <= array_max_size );
+
+      // Find the index of this iterator inside of the vector.
+      auto id = element_id( pos );
+
+      // Move the payload of the existing elements after "pos".
+      memmove( static_cast< void* >( id.m_ptr + count ),
+               static_cast< const void* >( id.m_ptr ),
+               ( m_size - id.m_index ) * value_size );
+
+      // Instantiate all the new values.
+      for( size_type i = 0; i < count; ++i ) {
+         construct( id.m_index + i, value );
+      }
+
+      // Increment the size.
+      m_size += count;
+
+      // Return an iterator to the first inserted element.
+      return id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   template< typename InputIt >
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos,
+                                            InputIt other_begin,
+                                            InputIt other_end ) {
+
+      // Find the index of this iterator inside of the vector.
+      auto id = element_id( pos );
+
+      // Insert the elements one by one. It's very inefficient, but we can't
+      // make any assumptions about the type of the input iterator received by
+      // this function.
+      const_iterator self_itr = pos;
+      for( InputIt other_itr = other_begin; other_itr != other_end;
+           ++other_itr, ++self_itr ) {
+         insert( self_itr, *other_itr );
+      }
+
+      // Return an iterator to the first inserted element.
+      return id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   template< typename... Args >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::emplace( const_iterator pos,
+                                             Args&&... args ) {
+
+      // Make sure that one more position is available.
+      assert( m_size < array_max_size );
+
+      // Find the index of this iterator inside of the vector.
+      auto id = element_id( pos );
+
+      // Move the payload of the existing elements after "pos".
+      memmove( static_cast< void* >( id.m_ptr + 1 ),
+               static_cast< const void* >( id.m_ptr ),
+               ( m_size - id.m_index ) * value_size );
+
+      // Instantiate the new value.
+      new( id.m_ptr ) value_type( std::forward( args )... );
+
+      // Increment the size.
+      ++m_size;
+
+      // Return an iterator to the inserted element.
+      return id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   template< typename... Args >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reference
+   static_vector< TYPE, MAX_SIZE >::emplace_back( Args&&... args ) {
+
+      return *( emplace( end(), std::forward( args )... ) );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::push_back( const_reference value ) {
+
+      insert( end(), value );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::erase( const_iterator pos ) {
+
+      // Find the index of this iterator inside of the vector.
+      auto id = element_id( pos );
+
+      // Destroy the object.
+      destruct( id.m_index );
+
+      // Move up the payload of the elements from after the removed one.
+      memmove( static_cast< void* >( id.m_ptr ),
+               static_cast< const void* >( id.m_ptr + 1 ),
+               ( m_size - id.m_index - 1 ) * value_size );
+
+      // Decrement the size.
+      --m_size;
+
+      // Return an iterator to after the removed element.
+      return id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::erase( const_iterator first,
+                                           const_iterator last ) {
+
+      // Find the indices and pointers of the iterators.
+      auto first_id = element_id( first );
+      auto last_id  = element_id( last );
+      assert( first_id.m_index <= last_id.m_index );
+
+      // Destroy the objects.
+      for( size_type i = first_id.m_index; i < last_id.m_index; ++i ) {
+         destruct( i );
+      }
+
+      // Move up the payload of the elements from after the removed range.
+      memmove( static_cast< void* >( first_id.m_ptr ),
+               static_cast< const void* >( last_id.m_ptr ),
+               ( m_size - last_id.m_index ) * value_size );
+
+      // Decrease the size.
+      m_size -= ( last_id.m_index - first_id.m_index );
+
+      // Return an iterator to after the removed elements.
+      return first_id.m_ptr;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::pop_back() {
+
+      erase( end() - 1 );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::clear() {
+
+      for( size_type i = 0; i < m_size; ++i ) {
+         destruct( i );
+      }
+      m_size = 0;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::resize( std::size_t new_size ) {
+
+      resize( new_size, value_type() );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::resize( std::size_t new_size,
+                                                 const_reference value ) {
+
+      // Make sure that the request can be done.
+      assert( new_size <= array_max_size );
+
+      // Check if anything even needs to be done.
+      if( new_size == m_size ) {
+         return;
+      }
+
+      // If the new size is smaller than the current size, remove the unwanted
+      // elements.
+      if( new_size < m_size ) {
+         erase( begin() + new_size, end() );
+      }
+      // If the new size is larger than the current size, insert extra elements.
+      else {
+         insert( end(), new_size - m_size, value );
+      }
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::begin() {
+
+      return reinterpret_cast< iterator >( m_elements );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_iterator
+   static_vector< TYPE, MAX_SIZE >::begin() const {
+
+      return reinterpret_cast< const_iterator >( m_elements );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_iterator
+   static_vector< TYPE, MAX_SIZE >::cbegin() const {
+
+      return begin();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::iterator
+   static_vector< TYPE, MAX_SIZE >::end() {
+
+      return ( reinterpret_cast< iterator >( m_elements ) + m_size );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_iterator
+   static_vector< TYPE, MAX_SIZE >::end() const {
+
+      return ( reinterpret_cast< const_iterator >( m_elements ) + m_size );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_iterator
+   static_vector< TYPE, MAX_SIZE >::cend() const {
+
+      return end();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::rbegin() {
+
+      return reverse_iterator( end() );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::rbegin() const {
+
+      return const_reverse_iterator( end() );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::crbegin() const {
+
+      return rbegin();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::rend() {
+
+      return reverse_iterator( begin() );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::rend() const {
+
+      return const_reverse_iterator( begin() );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::const_reverse_iterator
+   static_vector< TYPE, MAX_SIZE >::crend() const {
+
+      return rend();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   bool static_vector< TYPE, MAX_SIZE >::empty() const {
+
+      return m_size == 0;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::size_type
+   static_vector< TYPE, MAX_SIZE >::size() const {
+
+      return m_size;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::size_type
+   static_vector< TYPE, MAX_SIZE >::max_size() const {
+
+      return array_max_size;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::size_type
+   static_vector< TYPE, MAX_SIZE >::capacity() const {
+
+      return array_max_size;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::reserve( size_type new_cap ) {
+
+      // Make sure that the user didn't ask for too much.
+      assert( new_cap <= array_max_size );
+      ( void ) new_cap;
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::
+   construct( size_type pos, const_reference value ) {
+
+      // Make sure that the position is available.
+      assert( pos < array_max_size );
+
+      // Use the constructor of the type.
+      pointer ptr = reinterpret_cast< pointer >( m_elements ) + pos;
+      new( ptr ) value_type( value );
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   void static_vector< TYPE, MAX_SIZE >::destruct( size_type pos ) {
+
+      // Make sure that the element has been allocated.
+      assert( pos < m_size );
+
+      // Use the destructor of the type.
+      pointer ptr = reinterpret_cast< pointer >( m_elements ) + pos;
+      ptr->~value_type();
+   }
+
+   template< typename TYPE, std::size_t MAX_SIZE >
+   VECMEM_HOST_AND_DEVICE
+   typename static_vector< TYPE, MAX_SIZE >::ElementId
+   static_vector< TYPE, MAX_SIZE >::element_id( const_iterator pos ) {
+
+      size_type const index = pos - begin();
+      assert( index <= m_size );
+      pointer const ptr = reinterpret_cast< pointer >( m_elements ) + index;
+      return { index, ptr };
+   }
+
+} // namespace vecmem

--- a/core/include/vecmem/containers/static_vector.ipp
+++ b/core/include/vecmem/containers/static_vector.ipp
@@ -30,21 +30,6 @@ namespace vecmem {
    }
 
    template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt,
-             std::enable_if_t<
-                details::is_iterator_of<
-                   InputIt,
-                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
-                bool > >
-   VECMEM_HOST_AND_DEVICE
-   static_vector< TYPE, MAX_SIZE >::
-   static_vector( InputIt other_begin, InputIt other_end )
-   : m_size( 0 ), m_elements() {
-
-      assign( other_begin, other_end );
-   }
-
-   template< typename TYPE, std::size_t MAX_SIZE >
    VECMEM_HOST_AND_DEVICE
    static_vector< TYPE, MAX_SIZE >::
    static_vector( const static_vector& parent )
@@ -190,28 +175,6 @@ namespace vecmem {
    }
 
    template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt,
-             std::enable_if_t<
-                details::is_iterator_of<
-                   InputIt,
-                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
-                bool > >
-   VECMEM_HOST_AND_DEVICE
-   void static_vector< TYPE, MAX_SIZE >::
-   assign( InputIt other_begin, InputIt other_end ) {
-
-      // Remove all previous elements.
-      clear();
-
-      // Create copies of all of the elements one-by-one. It's very inefficient,
-      // but we can't make any assumptions about the type of the input iterator
-      // received by this function.
-      for( InputIt itr = other_begin; itr != other_end; ++itr ) {
-         construct( m_size++, *itr );
-      }
-   }
-
-   template< typename TYPE, std::size_t MAX_SIZE >
    VECMEM_HOST_AND_DEVICE
    typename static_vector< TYPE, MAX_SIZE >::iterator
    static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos,
@@ -262,34 +225,6 @@ namespace vecmem {
 
       // Increment the size.
       m_size += count;
-
-      // Return an iterator to the first inserted element.
-      return id.m_ptr;
-   }
-
-   template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt,
-             std::enable_if_t<
-                details::is_iterator_of<
-                   InputIt,
-                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
-                bool > >
-   typename static_vector< TYPE, MAX_SIZE >::iterator
-   static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos,
-                                            InputIt other_begin,
-                                            InputIt other_end ) {
-
-      // Find the index of this iterator inside of the vector.
-      auto id = element_id( pos );
-
-      // Insert the elements one by one. It's very inefficient, but we can't
-      // make any assumptions about the type of the input iterator received by
-      // this function.
-      const_iterator self_itr = pos;
-      for( InputIt other_itr = other_begin; other_itr != other_end;
-           ++other_itr, ++self_itr ) {
-         insert( self_itr, *other_itr );
-      }
 
       // Return an iterator to the first inserted element.
       return id.m_ptr;

--- a/core/include/vecmem/containers/static_vector.ipp
+++ b/core/include/vecmem/containers/static_vector.ipp
@@ -9,6 +9,7 @@
 // System include(s).
 #include <cassert>
 #include <cstring>
+#include <utility>
 
 namespace vecmem {
 
@@ -28,9 +29,13 @@ namespace vecmem {
       assign( size, value );
    }
 
-   /*
    template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt >
+   template< typename InputIt,
+             std::enable_if_t<
+                details::is_iterator_of<
+                   InputIt,
+                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
+                bool > >
    VECMEM_HOST_AND_DEVICE
    static_vector< TYPE, MAX_SIZE >::
    static_vector( InputIt other_begin, InputIt other_end )
@@ -38,7 +43,6 @@ namespace vecmem {
 
       assign( other_begin, other_end );
    }
-   */
 
    template< typename TYPE, std::size_t MAX_SIZE >
    VECMEM_HOST_AND_DEVICE
@@ -185,9 +189,13 @@ namespace vecmem {
       m_size = count;
    }
 
-   /*
    template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt >
+   template< typename InputIt,
+             std::enable_if_t<
+                details::is_iterator_of<
+                   InputIt,
+                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
+                bool > >
    VECMEM_HOST_AND_DEVICE
    void static_vector< TYPE, MAX_SIZE >::
    assign( InputIt other_begin, InputIt other_end ) {
@@ -202,7 +210,6 @@ namespace vecmem {
          construct( m_size++, *itr );
       }
    }
-   */
 
    template< typename TYPE, std::size_t MAX_SIZE >
    VECMEM_HOST_AND_DEVICE
@@ -261,7 +268,12 @@ namespace vecmem {
    }
 
    template< typename TYPE, std::size_t MAX_SIZE >
-   template< typename InputIt >
+   template< typename InputIt,
+             std::enable_if_t<
+                details::is_iterator_of<
+                   InputIt,
+                   typename static_vector< TYPE, MAX_SIZE >::value_type >::value,
+                bool > >
    typename static_vector< TYPE, MAX_SIZE >::iterator
    static_vector< TYPE, MAX_SIZE >::insert( const_iterator pos,
                                             InputIt other_begin,
@@ -302,7 +314,7 @@ namespace vecmem {
                ( m_size - id.m_index ) * value_size );
 
       // Instantiate the new value.
-      new( id.m_ptr ) value_type( std::forward( args )... );
+      new( id.m_ptr ) value_type( std::forward< Args >( args )... );
 
       // Increment the size.
       ++m_size;
@@ -317,7 +329,7 @@ namespace vecmem {
    typename static_vector< TYPE, MAX_SIZE >::reference
    static_vector< TYPE, MAX_SIZE >::emplace_back( Args&&... args ) {
 
-      return *( emplace( end(), std::forward( args )... ) );
+      return *( emplace( end(), std::forward< Args >( args )... ) );
    }
 
    template< typename TYPE, std::size_t MAX_SIZE >

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -1,0 +1,31 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <iterator>
+#include <type_traits>
+
+namespace vecmem { namespace details {
+
+   /// Helper trait for identifying input iterators
+   ///
+   /// It comes in handy in some of the functions of the custom (device)
+   /// container types that use templated iterator values. Which could hide
+   /// overloads of the same function with the same number of (non-templated)
+   /// arguments.
+   ///
+   /// The implementation is *very* simplistic at the moment. It could/should
+   /// be made more elaborate when the need arises.
+   ///
+   template< typename iterator_type, typename value_type >
+   using is_iterator_of =
+      std::is_convertible<
+         typename std::iterator_traits< iterator_type >::value_type,
+         value_type >;
+
+} } // namespace vecmem::details

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -28,4 +28,19 @@ namespace vecmem { namespace details {
          typename std::iterator_traits< iterator_type >::value_type,
          value_type >;
 
+   /// Helper type for an array with a given type and size
+   ///
+   /// This is needed to handle zero-sized arrays correctly. As those are not
+   /// part of the C++ standard.
+   ///
+   template< typename T, std::size_t size >
+   struct array_type {
+      typedef T type[ size ];
+   };
+
+   template< typename T >
+   struct array_type< T, 0 > {
+      typedef T* type;
+   };
+
 } } // namespace vecmem::details

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,5 +9,5 @@ vecmem_add_test( core
    "test_core_allocators.cpp" "test_core_arrays.cpp"
    "test_core_containers.cpp" "test_core_contiguous_memory_resource.cpp"
    "test_core_device_containers.cpp" "test_core_allocator.cpp"
-   "test_core_vectors.cpp"
+   "test_core_static_vector.cpp" "test_core_vectors.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main )

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -72,11 +72,10 @@ TEST_F( core_container_test, device_vector ) {
 /// Test(s) for @c vecmem::static_vector
 TEST_F( core_container_test, static_vector ) {
 
-   vecmem::static_vector< int, 20 > test_vector;
-   test_vector.resize( m_reference_vector.size() );
+   vecmem::static_vector< int, 20 > test_vector( m_reference_vector.size() );
    std::copy( m_reference_vector.begin(), m_reference_vector.end(),
               test_vector.begin() );
-   EXPECT_TRUE( test_vector.size() == m_reference_vector.size() );
+   EXPECT_EQ( test_vector.size(), m_reference_vector.size() );
    EXPECT_TRUE( std::equal( m_reference_vector.begin(),
                             m_reference_vector.end(),
                             test_vector.begin() ) );

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -1,0 +1,70 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/containers/static_vector.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+/// Test case for @c vecmem::static_vector
+template< typename T >
+class core_static_vector_test : public testing::Test {};
+
+/// Test suite for primitive types.
+typedef testing::Types< int, long, float, double > primitive_types;
+TYPED_TEST_SUITE( core_static_vector_test, primitive_types );
+
+/// Test the constructor with a size
+TYPED_TEST( core_static_vector_test, sized_constructor ) {
+
+   // Create a vector.
+   vecmem::static_vector< TypeParam, 100 > v( 10 );
+   EXPECT_EQ( v.size(), 10 );
+
+   // Make sure that it's elements were created as expected.
+   for( const TypeParam& value : v ) {
+      EXPECT_EQ( value, TypeParam() );
+   }
+}
+
+/// Test the constructor with a size and a custom value
+TYPED_TEST( core_static_vector_test, sized_constructor_with_value ) {
+
+   // Create a vector.
+   static const TypeParam DEFAULT_VALUE = 10;
+   vecmem::static_vector< TypeParam, 100 > v( 10, DEFAULT_VALUE );
+   EXPECT_EQ( v.size(), 10 );
+
+   // Make sure that it's elements were created as expected.
+   for( const TypeParam& value : v ) {
+      EXPECT_EQ( value, DEFAULT_VALUE );
+   }
+}
+
+/// Test the copy constructor
+TYPED_TEST( core_static_vector_test, copy_constructor ) {
+
+   /// Create a reference vector.
+   static const TypeParam DEFAULT_VALUE = 123;
+   vecmem::static_vector< TypeParam, 100 > ref( 10, DEFAULT_VALUE );
+
+   // Create a copy.
+   vecmem::static_vector< TypeParam, 100 > copy( ref );
+
+   // Check the copy.
+   EXPECT_EQ( ref.size(), copy.size() );
+   EXPECT_TRUE( std::equal( ref.begin(), ref.end(), copy.begin(),
+                            []( const TypeParam& v1, const TypeParam& v2 ) {
+                               return ( std::abs( v1 - v2 ) < 0.001 );
+                            } ) );
+}

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <vector>
 
 /// Test case for @c vecmem::static_vector
 template< typename T >
@@ -24,8 +25,22 @@ class core_static_vector_test : public testing::Test {};
 typedef testing::Types< int, long, float, double > primitive_types;
 TYPED_TEST_SUITE( core_static_vector_test, primitive_types );
 
+namespace {
+   /// Helper function for comparing the value of primitive types
+   template< typename T >
+   bool almost_equal( const T& v1, const T& v2 ) {
+      return ( std::abs( v1 - v2 ) < 0.001 );
+   }
+} // private namespace
+
+/// Helper macro for comparing two vectors.
+#define EXPECT_EQ_VEC( v1, v2 )                                                \
+   EXPECT_EQ( v1.size(), v2.size() );                                          \
+   EXPECT_TRUE( std::equal( std::begin( v1 ), std::end( v1 ), std::begin( v2 ),\
+                            ::almost_equal< TypeParam > ) )
+
 /// Test the constructor with a size
-TYPED_TEST( core_static_vector_test, sized_constructor ) {
+TYPED_TEST( core_static_vector_test, constructor_with_size ) {
 
    // Create a vector.
    vecmem::static_vector< TypeParam, 100 > v( 10 );
@@ -38,7 +53,7 @@ TYPED_TEST( core_static_vector_test, sized_constructor ) {
 }
 
 /// Test the constructor with a size and a custom value
-TYPED_TEST( core_static_vector_test, sized_constructor_with_value ) {
+TYPED_TEST( core_static_vector_test, constructor_with_size_and_value ) {
 
    // Create a vector.
    static const TypeParam DEFAULT_VALUE = 10;
@@ -51,10 +66,36 @@ TYPED_TEST( core_static_vector_test, sized_constructor_with_value ) {
    }
 }
 
+/// Test the constructor with a range of values
+TYPED_TEST( core_static_vector_test, constructor_with_iterators ) {
+
+   // Create a reference vector.
+   const std::vector< TypeParam > ref = { 1, 23, 64, 66, 23, 64, 99 };
+
+   // Create the test vector based on it.
+   const vecmem::static_vector< TypeParam, 100 > test( ref.begin(), ref.end() );
+   EXPECT_EQ_VEC( ref, test );
+}
+
+/// Test the default constructor
+TYPED_TEST( core_static_vector_test, default_constructor ) {
+
+   // Create a default vector.
+   const vecmem::static_vector< TypeParam, 100 > test1;
+   EXPECT_EQ( test1.size(), 0 );
+
+   // Create a default vector with zero capacity.
+   // This is not allowed at the moment!
+   /*
+   const vecmem::static_vector< TypeParam, 0 > test2;
+   EXPECT_EQ( test2.size(), 0 );
+   */
+}
+
 /// Test the copy constructor
 TYPED_TEST( core_static_vector_test, copy_constructor ) {
 
-   /// Create a reference vector.
+   // Create a reference vector.
    static const TypeParam DEFAULT_VALUE = 123;
    vecmem::static_vector< TypeParam, 100 > ref( 10, DEFAULT_VALUE );
 
@@ -62,9 +103,126 @@ TYPED_TEST( core_static_vector_test, copy_constructor ) {
    vecmem::static_vector< TypeParam, 100 > copy( ref );
 
    // Check the copy.
-   EXPECT_EQ( ref.size(), copy.size() );
-   EXPECT_TRUE( std::equal( ref.begin(), ref.end(), copy.begin(),
-                            []( const TypeParam& v1, const TypeParam& v2 ) {
-                               return ( std::abs( v1 - v2 ) < 0.001 );
-                            } ) );
+   EXPECT_EQ_VEC( ref, copy );
+}
+
+/// Test the element access functions and operators
+TYPED_TEST( core_static_vector_test, element_access ) {
+
+   // Create a vector.
+   vecmem::static_vector< TypeParam, 100 > v( 10 );
+
+   // Modify its elements.
+   for( std::size_t i = 0; i < v.size(); ++i ) {
+      v.at( i ) = TypeParam( i );
+   }
+
+   // Check that the settings "took".
+   for( std::size_t i = 0; i < v.size(); ++i ) {
+      EXPECT_EQ( v[ i ], TypeParam( i ) );
+   }
+
+   // Test the front() and back() functions.
+   EXPECT_EQ( v.front(), TypeParam( 0 ) );
+   EXPECT_EQ( v.back(), TypeParam( 9 ) );
+
+   // Make sure that the vector points to a meaningful place.
+   EXPECT_EQ( &( v.front() ), v.data() );
+}
+
+/// Test modifying an existing vector
+TYPED_TEST( core_static_vector_test, modifications ) {
+
+   // Here we perform the same operations on a reference and on a test vector.
+   // Assuming that std::vector would always behave correctly, so we just need
+   // to test vecmem::static_vector against it.
+
+   // Fill the vectors with some simple content.
+   std::vector< TypeParam > ref( 50 );
+   vecmem::static_vector< TypeParam, 100 > test( 50 );
+   EXPECT_EQ_VEC( ref, test );
+   for( std::size_t i = 0; i < ref.size(); ++i ) {
+      ref[ i ] = TypeParam( i );
+      test[ i ] = TypeParam( i );
+   }
+   EXPECT_EQ_VEC( ref, test );
+
+   // Add a single element to the end of them.
+   ref.push_back( TypeParam( 60 ) );
+   test.push_back( TypeParam( 60 ) );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Do the same, just in a slightly different colour.
+   ref.emplace_back( 70 );
+   test.emplace_back( 70 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Insert a single element in the middle of them.
+   ref.insert( ref.begin() + 20, TypeParam( 15 ) );
+   test.insert( test.begin() + 20, TypeParam( 15 ) );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Emplace a single element in the middle of them.
+   ref.emplace( ref.begin() + 15, 55 );
+   test.emplace( test.begin() + 15, 55 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Remove one element from them.
+   ref.erase( ref.begin() + 30 );
+   test.erase( test.begin() + 30 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Remove a range of elements from them.
+   ref.erase( ref.begin() + 10, ref.begin() + 25 );
+   test.erase( test.begin() + 10, test.begin() + 25 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Insert N copies of the same value in them.
+   ref.insert( ref.begin() + 13, 10, TypeParam( 34 ) );
+   test.insert( test.begin() + 13, 10, TypeParam( 34 ) );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Insert a range of new values.
+   static const std::vector< TypeParam > ins = { 33, 44, 55 };
+   ref.insert( ref.begin() + 24, ins.begin(), ins.end() );
+   test.insert( test.begin() + 24, ins.begin(), ins.end() );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Reduce the size of them.
+   ref.resize( 5 );
+   test.resize( 5 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Expand them.
+   ref.resize( 20 );
+   test.resize( 20 );
+   EXPECT_EQ_VEC( ref, test );
+
+   // Expand them using a specific fill value.
+   ref.resize( 30, TypeParam( 93 ) );
+   test.resize( 30, TypeParam( 93 ) );
+   EXPECT_EQ_VEC( ref, test );
+}
+
+/// Test the capacity functions of @c vecmem::static_vector
+TYPED_TEST( core_static_vector_test, capacity ) {
+
+   // Create a simple vector.
+   vecmem::static_vector< TypeParam, 100 > v;
+
+   // Simple checks on the empty vector.
+   EXPECT_EQ( v.empty(), true );
+   EXPECT_EQ( v.size(), 0 );
+   EXPECT_EQ( v.max_size(), 100 );
+   EXPECT_EQ( v.capacity(), 100 );
+
+   // Resize it, and test it again.
+   v.resize( 50 );
+   EXPECT_EQ( v.empty(), false );
+   EXPECT_EQ( v.size(), 50 );
+   EXPECT_EQ( v.max_size(), 100 );
+   EXPECT_EQ( v.capacity(), 100 );
+
+   // Make sure that the (no-op) reserve function can be called.
+   v.reserve( 70 );
 }

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -85,11 +85,8 @@ TYPED_TEST( core_static_vector_test, default_constructor ) {
    EXPECT_EQ( test1.size(), 0 );
 
    // Create a default vector with zero capacity.
-   // This is not allowed at the moment!
-   /*
    const vecmem::static_vector< TypeParam, 0 > test2;
    EXPECT_EQ( test2.size(), 0 );
-   */
 }
 
 /// Test the copy constructor


### PR DESCRIPTION
I decided that while you work on the jagged vector concept @stephenswat, I would do some house cleaning in `vecmem::static_vector`. With 2 goals in mind:
  - Make it handle custom (non-trivial) constructors and destructors on the types that it wraps;
  - Implement the rest of `std::vector` in it. At least the parts that make sense.

The main feature of the update is that the vector now uses a `char` array for storing the payload of its elements. This is to avoid the requirement of having a default constructor on the template type.

The code is for sure not bug-free at this point. It just has too many memory operations for me not to have made any mistakes in them. But I wanted to open a PR at this point already, to let you comment on the overall ideas.

Note that I added a new test that allows me to test different features of `vecmem::static_vector` for different template types through GoogleTest. Unfortunately the way it is implemented in GoogleTest required me to disable a GNU specific warning in the build. (Otherwise the Debug build would fail.) Still, this automated testing for different template types should come in handy in some of our other tests as well. :wink: