### PR TITLE
Implement jagged vector views

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,14 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/static_vector.ipp"
    "include/vecmem/containers/vector.hpp"
    "include/vecmem/containers/vector.ipp"
+   # Jagged vectors.
+   "include/vecmem/containers/jagged_vector.hpp"
+   "include/vecmem/containers/jagged_vector_data.hpp"
+   "include/vecmem/containers/jagged_vector_data.ipp"
+   "include/vecmem/containers/jagged_device_vector.hpp"
+   "include/vecmem/containers/jagged_device_vector.ipp"
+   "include/vecmem/containers/details/jagged_vector_view.hpp"
+   "include/vecmem/containers/details/jagged_vector_view.ipp"
    # Implementation details for the containers.
    "include/vecmem/containers/details/vector_buffer.hpp"
    "include/vecmem/containers/details/vector_buffer.ipp"

--- a/core/include/vecmem/containers/details/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/details/jagged_vector_view.hpp
@@ -1,0 +1,57 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/containers/details/vector_view.hpp"
+
+#include <cstddef>
+
+namespace vecmem { namespace details {
+    /**
+     * @brief A view for jagged vectors.
+     *
+     * A jagged vector is a two-dimensional vector in which the inner vectors do
+     * not necessarily have the same size. For example, a jagged vector might
+     * look like this:
+     *
+     * [[0, 1, 2],
+     *  [3, 4],
+     *  [],
+     *  [5, 6, 7]]
+     *
+     * This class is a view of existing two-dimensional vectors created using a
+     * vector-of-vectors formalism. Elements cannot be added or removed through
+     * this view, but individual elements can be accessed and modified.
+     *
+     * @warning This view class shares memory with the vectors from which it was
+     * constructed. Operating on the underlying vectors while an instance of
+     * this class exists deriving from it is undefined and may leave the view in
+     * an undefined state.
+     */
+    template<typename T>
+    struct jagged_vector_view {
+        jagged_vector_view(
+            std::size_t size,
+            vector_view<T> * ptr
+        );
+
+        /**
+         * The number of rows in this jagged vector.
+         */
+        std::size_t m_size;
+
+        /**
+         * The internal state of this jagged vector, which is heap-allocated by
+         * the given memory manager.
+         */
+        vector_view<T> * m_ptr;
+    };
+}}
+
+#include "jagged_vector_view.ipp"

--- a/core/include/vecmem/containers/details/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/details/jagged_vector_view.ipp
@@ -1,0 +1,25 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/containers/details/vector_view.hpp"
+
+#include <cstddef>
+
+namespace vecmem { namespace details {
+    template<typename T>
+    jagged_vector_view<T>::jagged_vector_view(
+        std::size_t size,
+        vector_view<T> * ptr
+    ) :
+        m_size(size),
+        m_ptr(ptr)
+    {
+    }
+}}

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -1,0 +1,171 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/details/vector_view.hpp"
+
+#include <cstddef>
+
+namespace vecmem {
+    namespace details {
+        template<typename T>
+        struct jagged_vector_view;
+    }
+
+    /**
+     * @brief A view for jagged vectors.
+     *
+     * A jagged vector is a two-dimensional vector in which the inner vectors do
+     * not necessarily have the same size. For example, a jagged vector might
+     * look like this:
+     *
+     * [[0, 1, 2],
+     *  [3, 4],
+     *  [],
+     *  [5, 6, 7]]
+     *
+     * This class is a view of existing two-dimensional vectors created using a
+     * vector-of-vectors formalism. Elements cannot be added or removed through
+     * this view, but individual elements can be accessed and modified.
+     *
+     * @warning This view class shares memory with the vectors from which it was
+     * constructed. Operating on the underlying vectors while an instance of
+     * this class exists deriving from it is undefined and may leave the view in
+     * an undefined state.
+     */
+    template<typename T>
+    class jagged_device_vector {
+    public:
+        /**
+         * @brief Construct a jagged vector view from a jagged vector data
+         * object.
+         */
+        VECMEM_HOST_AND_DEVICE
+        jagged_device_vector(
+            const details::jagged_vector_view<T> & data
+        );
+
+        /**
+         * @brief Checks whether this view has no rows.
+         *
+         * Returns true if the jagged vector is empty, and false otherwise.
+         *
+         * @note A jagged vector of shape [[]] (that is to say, an empty row) is
+         * not considered empty, but a jagged vector of shape [] is.
+         */
+        VECMEM_HOST_AND_DEVICE
+        bool empty(
+            void
+        ) const;
+
+        /**
+         * @brief Get the number of rows in this view.
+         */
+        VECMEM_HOST_AND_DEVICE
+        std::size_t size(
+            void
+        ) const;
+
+        /**
+         * @brief Get the row (vector) at a certain index.
+         *
+         * This method will assert that the element is in range if NDEBUG is
+         * unset.
+         *
+         * @param[in] i The row number to fetch.
+         */
+        VECMEM_HOST_AND_DEVICE
+        device_vector<T> at(
+            std::size_t i
+        );
+
+        /**
+         * @brief Get the row (vector) at a certain index in a const way.
+         *
+         * This method will assert that the element is in range if NDEBUG is
+         * unset.
+         *
+         * @param[in] i The row number to fetch.
+         */
+        VECMEM_HOST_AND_DEVICE
+        const device_vector<T> at(
+            std::size_t i
+        ) const;
+
+        /**
+         * @brief Get the row (vector) at a certain index.
+         *
+         * This method does no bounds checking at all.
+         *
+         * @param[in] i The row number to fetch.
+         */
+        VECMEM_HOST_AND_DEVICE
+        device_vector<T> operator[](
+            std::size_t i
+        );
+
+        /**
+         * @brief Get the row (vector) at a certain index in a const way.
+         *
+         * This method does no bounds checking at all.
+         *
+         * @param[in] i The row number to fetch.
+         */
+        VECMEM_HOST_AND_DEVICE
+        const device_vector<T> operator[](
+            std::size_t i
+        ) const;
+
+        /**
+         * @brief Retrieve the element at a given two-dimensional coordinate.
+         *
+         * This method can be used to directly retrieve an object from an inner
+         * vector.
+         *
+         * @param[in] i The row index to fetch from.
+         * @param[in] j The index in row i to use.
+         */
+        VECMEM_HOST_AND_DEVICE
+        T & at(
+            std::size_t i,
+            std::size_t j
+        );
+
+        /**
+         * @brief Retrieve the element at a given two-dimensional coordinate in
+         * a const way.
+         *
+         * This method can be used to directly retrieve an object from an inner
+         * vector.
+         *
+         * @param[in] i The row index to fetch from.
+         * @param[in] j The index in row i to use.
+         */
+        VECMEM_HOST_AND_DEVICE
+        const T & at(
+            std::size_t i,
+            std::size_t j
+        ) const;
+
+    private:
+        /**
+         * The number of rows in this jagged vector.
+         */
+        const std::size_t m_size;
+
+        /**
+         * The internal state of this jagged vector, which is heap-allocated by
+         * the given memory manager.
+         */
+        details::vector_view<T> * const m_ptr;
+    };
+}
+
+#include "jagged_device_vector.ipp"

--- a/core/include/vecmem/containers/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/jagged_device_vector.ipp
@@ -1,0 +1,84 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cassert>
+
+namespace vecmem {
+    template<typename T>
+    jagged_device_vector<T>::jagged_device_vector(
+        const details::jagged_vector_view<T> & data
+    ) :
+        m_size(data.m_size),
+        m_ptr(data.m_ptr)
+    {
+    }
+
+    template<typename T>
+    bool jagged_device_vector<T>::empty(
+        void
+    ) const {
+        return size() == 0;
+    }
+
+    template<typename T>
+    std::size_t jagged_device_vector<T>::size(
+        void
+    ) const {
+        return m_size;
+    }
+
+    template<typename T>
+    device_vector<T> jagged_device_vector<T>::at(
+        std::size_t i
+    ) {
+        assert(i < size());
+
+        return device_vector<T>(m_ptr[i]);
+    }
+
+    template<typename T>
+    const device_vector<T> jagged_device_vector<T>::at(
+        std::size_t i
+    ) const {
+        assert(i < size());
+
+        return device_vector<T>(m_ptr[i]);
+    }
+
+    template<typename T>
+    device_vector<T> jagged_device_vector<T>::operator[](
+        std::size_t i
+    ) {
+        return device_vector<T>(m_ptr[i]);
+    }
+
+    template<typename T>
+    const device_vector<T> jagged_device_vector<T>::operator[](
+        std::size_t i
+    ) const {
+        return device_vector<T>(m_ptr[i]);
+    }
+
+    template<typename T>
+    T & jagged_device_vector<T>::at(
+        std::size_t i,
+        std::size_t j
+    ) {
+        return at(i).at(j);
+    }
+
+    template<typename T>
+    const T & jagged_device_vector<T>::at(
+        std::size_t i,
+        std::size_t j
+    ) const {
+        return at(i).at(j);
+    }
+}

--- a/core/include/vecmem/containers/jagged_vector.hpp
+++ b/core/include/vecmem/containers/jagged_vector.hpp
@@ -1,0 +1,16 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/containers/vector.hpp"
+
+namespace vecmem {
+    template<typename T>
+    using jagged_vector = vector<vector<T>>;
+}

--- a/core/include/vecmem/containers/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/jagged_vector_data.hpp
@@ -1,0 +1,68 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/containers/details/jagged_vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/vector.hpp"
+
+#include <cstddef>
+
+namespace vecmem {
+    template<typename T>
+    class jagged_vector_view;
+
+    /**
+     * @brief A data wrapper for jagged vectors.
+     *
+     * This class constructs the relevant administrative data from a vector of
+     * vectors, and is designed to be later turned into a @c jagged_vector_view
+     * object.
+     */
+    template<typename T>
+    class jagged_vector_data : public details::jagged_vector_view<T> {
+    public:
+        using base_type = details::jagged_vector_view<T>;
+
+        /**
+         * @brief Construct jagged vector data from a jagged vector.
+         *
+         * This class converts from std vectors (or rather, vecmem::vectors) to
+         * a jagged vector data.
+         *
+         * @param[in] vec The jagged vector to make a data view for.
+         * @param[in] mem The memory resource to manage the internal state. If
+         * set to nullptr, uses the same memory resource as the jagged vector.
+         */
+        jagged_vector_data(
+            jagged_vector<T> & vec,
+            memory_resource * mem = nullptr
+        );
+
+        /**
+         * @brief Destruct the jagged vector data.
+         *
+         * This destructor does not affect the viewed data in any way. The
+         * internal state is destroyed if and only if this object is not a copy.
+         */
+        ~jagged_vector_data(
+            void
+        );
+
+    private:
+        /**
+         * The memory manager used to manage the internal state (row data) of
+         * the jagged data.
+         */
+        memory_resource * m_mem;
+    };
+}
+
+#include "jagged_vector_data.ipp"

--- a/core/include/vecmem/containers/jagged_vector_data.ipp
+++ b/core/include/vecmem/containers/jagged_vector_data.ipp
@@ -1,0 +1,63 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/containers/details/vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/vector.hpp"
+
+#include <cstddef>
+
+namespace vecmem {
+    template<typename T>
+    jagged_vector_data<T>::jagged_vector_data(
+        jagged_vector<T> & vec,
+        memory_resource * mem
+    ) :
+        base_type(
+            vec.size(),
+            static_cast<details::vector_view<T> *>(
+                (mem == nullptr ? vec.get_allocator().resource() : mem)->allocate(
+                    vec.size() * sizeof(details::vector_view<T>)
+                )
+            )
+        ),
+        m_mem(mem == nullptr ? vec.get_allocator().resource() : mem)
+    {
+        /*
+         * To construct a jagged view, we copy the important information (the
+         * size and starting pointer) of the standard vectors to our reduced
+         * complexity format.
+         */
+        for (std::size_t i = 0; i < base_type::m_size; ++i) {
+            /*
+             * We use the memory allocated earlier and construct device vector
+             * objects there.
+             */
+            new (base_type::m_ptr + i) details::vector_view<T>(
+                vec.at(i).size(),
+                vec.at(i).data()
+            );
+        }
+    }
+
+    template<typename T>
+    jagged_vector_data<T>::~jagged_vector_data(
+        void
+    ) {
+        /*
+         * Use the memory manager to deallocate the memory owned by this object.
+         */
+        m_mem->deallocate(
+            base_type::m_ptr,
+            base_type::m_size * sizeof(details::vector_view<T>)
+        );
+    }
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -10,4 +10,5 @@ vecmem_add_test( core
    "test_core_contiguous_memory_resource.cpp" "test_core_device_containers.cpp"
    "test_core_memory_resources.cpp" "test_core_static_vector.cpp"
    "test_core_vector.cpp"
+   "test_core_jagged_vector_view.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -1,0 +1,103 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/containers/jagged_vector.hpp"
+#include "vecmem/containers/jagged_vector_data.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/details/jagged_vector_view.hpp"
+
+#include <gtest/gtest.h>
+
+class core_jagged_vector_view_test : public testing::Test {
+    protected:
+    vecmem::host_memory_resource m_mem;
+    vecmem::jagged_vector<int> m_vec;
+    vecmem::jagged_vector_data<int> m_data;
+    vecmem::jagged_device_vector<int> m_jag;
+
+    core_jagged_vector_view_test(
+        void
+    ) :
+        m_vec({
+            vecmem::vector<int>({1, 2, 3, 4}, &m_mem),
+            vecmem::vector<int>({5, 6}, &m_mem),
+            vecmem::vector<int>({7, 8, 9, 10}, &m_mem),
+            vecmem::vector<int>({11}, &m_mem),
+            vecmem::vector<int>(&m_mem),
+            vecmem::vector<int>({12, 13, 14, 15, 16}, &m_mem)
+        }, &m_mem),
+        m_data(m_vec, &m_mem),
+        m_jag(m_data)
+    {
+    }
+};
+
+TEST_F(core_jagged_vector_view_test, top_level_size) {
+    EXPECT_EQ(m_jag.size(), 6);
+}
+
+TEST_F(core_jagged_vector_view_test, row_size) {
+    EXPECT_EQ(m_jag.at(0).size(), 4);
+    EXPECT_EQ(m_jag.at(1).size(), 2);
+    EXPECT_EQ(m_jag.at(2).size(), 4);
+    EXPECT_EQ(m_jag.at(3).size(), 1);
+    EXPECT_EQ(m_jag.at(4).size(), 0);
+    EXPECT_EQ(m_jag.at(5).size(), 5);
+}
+
+TEST_F(core_jagged_vector_view_test, two_d_access) {
+    EXPECT_EQ(m_jag.at(0, 0), 1);
+    EXPECT_EQ(m_jag.at(0, 1), 2);
+    EXPECT_EQ(m_jag.at(0, 2), 3);
+    EXPECT_EQ(m_jag.at(0, 3), 4);
+    EXPECT_EQ(m_jag.at(1, 0), 5);
+    EXPECT_EQ(m_jag.at(1, 1), 6);
+    EXPECT_EQ(m_jag.at(2, 0), 7);
+    EXPECT_EQ(m_jag.at(2, 1), 8);
+    EXPECT_EQ(m_jag.at(2, 2), 9);
+    EXPECT_EQ(m_jag.at(2, 3), 10);
+}
+
+TEST_F(core_jagged_vector_view_test, two_d_access_const) {
+    EXPECT_EQ(m_jag.at(0, 0), 1);
+    EXPECT_EQ(m_jag.at(0, 1), 2);
+    EXPECT_EQ(m_jag.at(0, 2), 3);
+    EXPECT_EQ(m_jag.at(0, 3), 4);
+    EXPECT_EQ(m_jag.at(1, 0), 5);
+    EXPECT_EQ(m_jag.at(1, 1), 6);
+    EXPECT_EQ(m_jag.at(2, 0), 7);
+    EXPECT_EQ(m_jag.at(2, 1), 8);
+    EXPECT_EQ(m_jag.at(2, 2), 9);
+    EXPECT_EQ(m_jag.at(2, 3), 10);
+}
+
+TEST_F(core_jagged_vector_view_test, mutate) {
+    m_jag.at(0, 0) *= 2;
+    m_jag.at(0, 1) *= 2;
+    m_jag.at(0, 2) *= 2;
+    m_jag.at(0, 3) *= 2;
+    m_jag.at(1, 0) *= 2;
+    m_jag.at(1, 1) *= 2;
+    m_jag.at(2, 0) *= 2;
+    m_jag.at(2, 1) *= 2;
+    m_jag.at(2, 2) *= 2;
+    m_jag.at(2, 3) *= 2;
+
+    EXPECT_EQ(m_jag.at(0, 0), 2 * 1);
+    EXPECT_EQ(m_jag.at(0, 1), 2 * 2);
+    EXPECT_EQ(m_jag.at(0, 2), 2 * 3);
+    EXPECT_EQ(m_jag.at(0, 3), 2 * 4);
+    EXPECT_EQ(m_jag.at(1, 0), 2 * 5);
+    EXPECT_EQ(m_jag.at(1, 1), 2 * 6);
+    EXPECT_EQ(m_jag.at(2, 0), 2 * 7);
+    EXPECT_EQ(m_jag.at(2, 1), 2 * 8);
+    EXPECT_EQ(m_jag.at(2, 2), 2 * 9);
+    EXPECT_EQ(m_jag.at(2, 3), 2 * 10);
+}

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -15,5 +15,8 @@ vecmem_add_test( cuda
    "test_cuda_memory_resources.cpp"
    "test_cuda_containers.cpp" "test_cuda_containers_kernels.cuh"
    "test_cuda_containers_kernels.cu"
+   "test_cuda_jagged_vector_view.cpp"
+   "test_cuda_jagged_vector_view_kernels.cu"
+   "test_cuda_jagged_vector_view_kernels.cuh"
    LINK_LIBRARIES vecmem::core vecmem::cuda GTest::gtest_main
                   vecmem_testing_common )

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -1,0 +1,62 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "test_cuda_jagged_vector_view_kernels.cuh"
+
+#include "vecmem/memory/cuda/managed_memory_resource.hpp"
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/containers/jagged_vector.hpp"
+#include "vecmem/containers/jagged_vector_data.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+
+#include <gtest/gtest.h>
+
+class cuda_jagged_vector_view_test : public testing::Test {
+    protected:
+    vecmem::cuda::managed_memory_resource m_mem;
+    vecmem::jagged_vector<int> m_vec;
+    vecmem::jagged_vector_data<int> m_data;
+
+    cuda_jagged_vector_view_test(
+        void
+    ) :
+        m_vec({
+            vecmem::vector<int>({1, 2, 3, 4}, &m_mem),
+            vecmem::vector<int>({5, 6}, &m_mem),
+            vecmem::vector<int>({7, 8, 9, 10}, &m_mem),
+            vecmem::vector<int>({11}, &m_mem),
+            vecmem::vector<int>(&m_mem),
+            vecmem::vector<int>({12, 13, 14, 15, 16}, &m_mem)
+        }, &m_mem),
+        m_data(m_vec, &m_mem)
+    {
+    }
+};
+
+TEST_F(cuda_jagged_vector_view_test, mutate_in_kernel) {
+    doubleJagged(m_data);
+
+    vecmem::jagged_device_vector<int> m_jag(m_data);
+
+    EXPECT_EQ(m_jag.at(0, 0), 2);
+    EXPECT_EQ(m_jag.at(0, 1), 4);
+    EXPECT_EQ(m_jag.at(0, 2), 6);
+    EXPECT_EQ(m_jag.at(0, 3), 8);
+    EXPECT_EQ(m_jag.at(1, 0), 10);
+    EXPECT_EQ(m_jag.at(1, 1), 12);
+    EXPECT_EQ(m_jag.at(2, 0), 14);
+    EXPECT_EQ(m_jag.at(2, 1), 16);
+    EXPECT_EQ(m_jag.at(2, 2), 18);
+    EXPECT_EQ(m_jag.at(2, 3), 20);
+    EXPECT_EQ(m_jag.at(3, 0), 22);
+    EXPECT_EQ(m_jag.at(5, 0), 24);
+    EXPECT_EQ(m_jag.at(5, 1), 26);
+    EXPECT_EQ(m_jag.at(5, 2), 28);
+    EXPECT_EQ(m_jag.at(5, 3), 30);
+    EXPECT_EQ(m_jag.at(5, 4), 32);
+}

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -1,0 +1,38 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "test_cuda_jagged_vector_view_kernels.cuh"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/details/jagged_vector_view.hpp"
+#include "../../cuda/src/utils/cuda_error_handling.hpp"
+
+__global__
+void doubleJaggedKernel(
+    vecmem::details::jagged_vector_view<int> _jag
+) {
+    const std::size_t t = blockIdx.x * blockDim.x + threadIdx.x;
+
+    vecmem::jagged_device_vector<int> jag(_jag);
+
+    if (t >= jag.size()) {
+        return;
+    }
+
+    for (std::size_t i = 0; i < jag.at(t).size(); ++i) {
+        jag.at(t, i) *= 2;
+    }
+}
+
+void doubleJagged(
+    vecmem::details::jagged_vector_view<int> & jag
+) {
+    doubleJaggedKernel<<<1, jag.m_size>>>(jag);
+
+    VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
+    VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cuh
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cuh
@@ -1,0 +1,15 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/containers/details/jagged_vector_view.hpp"
+
+void doubleJagged(
+    vecmem::details::jagged_vector_view<int> & jag
+);


### PR DESCRIPTION
There we go, finally. This change adds two new classes, the `jagged_vector_data` and the `jagged_vector_view`. The first is designed to be a host-constructible wrapper around the `vecmem::vector<vecmem::vector<T>>` type, while the second one is a device-accessible wrapper around the jagged vector data type. We add some tests for this new type for both core code as well as CUDA code to make sure the CUDA compiler will accept our type.