### PR TITLE
Jagged Vector Data Updates, main branch (2021.03.24.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -20,6 +20,7 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/jagged_device_vector.hpp"
    "include/vecmem/containers/impl/jagged_device_vector.ipp"
    "include/vecmem/containers/jagged_vector.hpp"
+   "include/vecmem/containers/impl/jagged_vector.ipp"
    "include/vecmem/containers/vector.hpp"
    "include/vecmem/containers/impl/vector.ipp"
    # Data holding/transporting types.

--- a/core/include/vecmem/containers/data/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_data.hpp
@@ -8,14 +8,16 @@
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/memory/deallocator.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
-#include "vecmem/containers/device_vector.hpp"
-#include "vecmem/containers/vector.hpp"
 
-#include <cstddef>
+// System include(s).
+#include <memory>
 
 namespace vecmem::data {
+
     /**
      * @brief A data wrapper for jagged vectors.
      *
@@ -25,41 +27,35 @@ namespace vecmem::data {
      */
     template<typename T>
     class jagged_vector_data : public jagged_vector_view<T> {
+
     public:
+        /// Type of the base class
         using base_type = jagged_vector_view<T>;
+        /// Use the base class's @c size_type
+        typedef typename base_type::size_type size_type;
+        /// Use the base class's @c value_type
+        typedef typename base_type::value_type value_type;
 
         /**
-         * @brief Construct jagged vector data from a jagged vector.
+         * @brief Construct jagged vector data from raw information
          *
          * This class converts from std vectors (or rather, vecmem::vectors) to
          * a jagged vector data.
          *
-         * @param[in] vec The jagged vector to make a data view for.
-         * @param[in] mem The memory resource to manage the internal state. If
-         * set to nullptr, uses the same memory resource as the jagged vector.
+         * @param[in] size Size of the "outer vector"
+         * @param[in] mem The memory resource to manage the internal state
          */
         jagged_vector_data(
-            jagged_vector<T> & vec,
-            memory_resource * mem = nullptr
-        );
-
-        /**
-         * @brief Destruct the jagged vector data.
-         *
-         * This destructor does not affect the viewed data in any way. The
-         * internal state is destroyed if and only if this object is not a copy.
-         */
-        ~jagged_vector_data(
-            void
+            size_type size,
+            memory_resource& mem
         );
 
     private:
-        /**
-         * The memory manager used to manage the internal state (row data) of
-         * the jagged data.
-         */
-        memory_resource * m_mem;
-    };
+        /// Data object owning the allocated memory
+        std::unique_ptr< value_type, details::deallocator > m_memory;
+
+    }; // class jagged_vector_data
+
 } // namespace vecmem::data
 
 // Include the implementation.

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -1,0 +1,107 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <cassert>
+
+namespace vecmem {
+
+   template< typename TYPE >
+   data::jagged_vector_data< TYPE >
+   get_data( jagged_vector< TYPE >& vec, memory_resource* resource ) {
+
+      // Get the size of the "outer vector".
+      const std::size_t size = vec.size();
+
+      // Construct the object to be returned.
+      data::jagged_vector_data< TYPE >
+         result( size, ( resource != nullptr ? *resource :
+                         *( vec.get_allocator().resource() ) ) );
+
+      // Fill the result object with information.
+      for( std::size_t i = 0; i < size; ++i ) {
+         result.m_ptr[ i ].m_size = vec[ i ].size();
+         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+      }
+
+      // Return the created object.
+      return result;
+   }
+
+   template< typename TYPE, typename ALLOC >
+   data::jagged_vector_data< TYPE >
+   get_data( std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+             memory_resource* resource ) {
+
+      // This function needs a non-null memory resource pointer.
+      assert( resource != nullptr );
+
+      // Get the size of the "outer vector".
+      const std::size_t size = vec.size();
+
+      // Construct the object to be returned.
+      data::jagged_vector_data< TYPE > result( size, *resource );
+
+      // Fill the result object with information.
+      for( std::size_t i = 0; i < size; ++i ) {
+         result.m_ptr[ i ].m_size = vec[ i ].size();
+         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+      }
+
+      // Return the created object.
+      return result;
+   }
+
+   template< typename TYPE >
+   data::jagged_vector_data< const TYPE >
+   get_data( const jagged_vector< TYPE >& vec, memory_resource* resource ) {
+
+      // Get the size of the "outer vector".
+      const std::size_t size = vec.size();
+
+      // Construct the object to be returned.
+      data::jagged_vector_data< const TYPE >
+         result( size, ( resource != nullptr ? *resource :
+                         *( vec.get_allocator().resource() ) ) );
+
+      // Fill the result object with information.
+      for( std::size_t i = 0; i < size; ++i ) {
+         result.m_ptr[ i ].m_size = vec[ i ].size();
+         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+      }
+
+      // Return the created object.
+      return result;
+   }
+
+   template< typename TYPE, typename ALLOC >
+   data::jagged_vector_data< const TYPE >
+   get_data( const std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+             memory_resource* resource ) {
+
+      // This function needs a non-null memory resource pointer.
+      assert( resource != nullptr );
+
+      // Get the size of the "outer vector".
+      const std::size_t size = vec.size();
+
+      // Construct the object to be returned.
+      data::jagged_vector_data< const TYPE > result( size, *resource );
+
+      // Fill the result object with information.
+      for( std::size_t i = 0; i < size; ++i ) {
+         result.m_ptr[ i ].m_size = vec[ i ].size();
+         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+      }
+
+      // Return the created object.
+      return result;
+   }
+
+} // namespace vecmem

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -9,13 +9,28 @@
 #pragma once
 
 namespace vecmem { namespace data {
+
     template<typename T>
     jagged_vector_view<T>::jagged_vector_view(
-        std::size_t size,
-        vector_view<T> * ptr
+        size_type size,
+        pointer ptr
     ) :
         m_size(size),
         m_ptr(ptr)
     {
     }
+
+    template< typename T >
+    template< typename OTHERTYPE,
+              std::enable_if_t<
+                 ( ! std::is_same< T, OTHERTYPE >::value ) &&
+                 std::is_same< T,
+                               typename std::add_const< OTHERTYPE >::type >::value,
+                 bool > >
+    jagged_vector_view< T >::
+    jagged_vector_view( const jagged_vector_view< OTHERTYPE >& parent )
+    : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {
+
+    }
+
 }} // namespace vemcem::data

--- a/core/include/vecmem/containers/jagged_vector.hpp
+++ b/core/include/vecmem/containers/jagged_vector.hpp
@@ -8,9 +8,55 @@
 
 #pragma once
 
+// Local include(s).
 #include "vecmem/containers/vector.hpp"
+#include "vecmem/containers/data/jagged_vector_data.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/utils/types.hpp"
 
 namespace vecmem {
+
+    /**
+    * @brief Alias type for jagged vectors with our polymorphic allocator
+    *
+    * This type serves as an alias for a common type pattern, namely a
+    * host-accessible vector of vectors with a memory resource which is not
+    * known at compile time, which could be host memory or shared memory.
+    *
+    * @warning This type should only be used with host-accessible memory
+    * resources.
+    */
     template<typename T>
     using jagged_vector = vector<vector<T>>;
-}
+
+    /// Helper function creating a @c vecmem::data::jagged_vector_data object
+    template< typename TYPE >
+    VECMEM_HOST
+    data::jagged_vector_data< TYPE >
+    get_data( jagged_vector< TYPE >& vec, memory_resource* resource = nullptr );
+
+    /// Helper function creating a @c vecmem::data::jagged_vector_data object
+    template< typename TYPE, typename ALLOC >
+    VECMEM_HOST
+    data::jagged_vector_data< TYPE >
+    get_data( std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+              memory_resource* resource );
+
+    /// Helper function creating a @c vecmem::data::jagged_vector_data object
+    template< typename TYPE >
+    VECMEM_HOST
+    data::jagged_vector_data< const TYPE >
+    get_data( const jagged_vector< TYPE >& vec,
+              memory_resource* resource = nullptr );
+
+    /// Helper function creating a @c vecmem::data::jagged_vector_data object
+    template< typename TYPE, typename ALLOC >
+    VECMEM_HOST
+    data::jagged_vector_data< const TYPE >
+    get_data( const std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+              memory_resource* resource );
+
+} // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/containers/impl/jagged_vector.ipp"

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -6,6 +6,7 @@
  */
 
 // Local include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_buffer.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/containers/vector.hpp"
@@ -25,6 +26,20 @@ class core_device_container_test : public testing::Test {
 
 /// Test that the "simple" data types are trivially constructible.
 TEST_F( core_device_container_test, trivial_construct ) {
+
+   EXPECT_TRUE( std::is_trivially_default_constructible<
+                   vecmem::data::jagged_vector_view< const int > >() );
+   EXPECT_TRUE( std::is_trivially_constructible<
+                   vecmem::data::jagged_vector_view< const int > >() );
+   EXPECT_TRUE( std::is_trivially_copy_constructible<
+                   vecmem::data::jagged_vector_view< const int > >() );
+
+   EXPECT_TRUE( std::is_trivially_default_constructible<
+                   vecmem::data::jagged_vector_view< int > >() );
+   EXPECT_TRUE( std::is_trivially_constructible<
+                   vecmem::data::jagged_vector_view< int > >() );
+   EXPECT_TRUE( std::is_trivially_copy_constructible<
+                   vecmem::data::jagged_vector_view< int > >() );
 
    EXPECT_TRUE( std::is_trivially_default_constructible<
                    vecmem::data::vector_view< const int > >() );

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -33,7 +33,7 @@ class core_jagged_vector_view_test : public testing::Test {
             vecmem::vector<int>(&m_mem),
             vecmem::vector<int>({12, 13, 14, 15, 16}, &m_mem)
         }, &m_mem),
-        m_data(m_vec, &m_mem),
+        m_data(vecmem::get_data(m_vec)),
         m_jag(m_data)
     {
     }

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -12,7 +12,6 @@
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/containers/data/jagged_vector_data.hpp"
-#include "vecmem/containers/jagged_device_vector.hpp"
 
 #include <gtest/gtest.h>
 
@@ -33,7 +32,7 @@ class cuda_jagged_vector_view_test : public testing::Test {
             vecmem::vector<int>(&m_mem),
             vecmem::vector<int>({12, 13, 14, 15, 16}, &m_mem)
         }, &m_mem),
-        m_data(m_vec, &m_mem)
+        m_data(vecmem::get_data(m_vec, &m_mem))
     {
     }
 };
@@ -41,22 +40,20 @@ class cuda_jagged_vector_view_test : public testing::Test {
 TEST_F(cuda_jagged_vector_view_test, mutate_in_kernel) {
     doubleJagged(m_data);
 
-    vecmem::jagged_device_vector<int> m_jag(m_data);
-
-    EXPECT_EQ(m_jag.at(0, 0), 2);
-    EXPECT_EQ(m_jag.at(0, 1), 4);
-    EXPECT_EQ(m_jag.at(0, 2), 6);
-    EXPECT_EQ(m_jag.at(0, 3), 8);
-    EXPECT_EQ(m_jag.at(1, 0), 10);
-    EXPECT_EQ(m_jag.at(1, 1), 12);
-    EXPECT_EQ(m_jag.at(2, 0), 14);
-    EXPECT_EQ(m_jag.at(2, 1), 16);
-    EXPECT_EQ(m_jag.at(2, 2), 18);
-    EXPECT_EQ(m_jag.at(2, 3), 20);
-    EXPECT_EQ(m_jag.at(3, 0), 22);
-    EXPECT_EQ(m_jag.at(5, 0), 24);
-    EXPECT_EQ(m_jag.at(5, 1), 26);
-    EXPECT_EQ(m_jag.at(5, 2), 28);
-    EXPECT_EQ(m_jag.at(5, 3), 30);
-    EXPECT_EQ(m_jag.at(5, 4), 32);
+    EXPECT_EQ(m_vec.at(0).at(0), 2);
+    EXPECT_EQ(m_vec.at(0).at(1), 4);
+    EXPECT_EQ(m_vec.at(0).at(2), 6);
+    EXPECT_EQ(m_vec.at(0).at(3), 8);
+    EXPECT_EQ(m_vec.at(1).at(0), 10);
+    EXPECT_EQ(m_vec.at(1).at(1), 12);
+    EXPECT_EQ(m_vec.at(2).at(0), 14);
+    EXPECT_EQ(m_vec.at(2).at(1), 16);
+    EXPECT_EQ(m_vec.at(2).at(2), 18);
+    EXPECT_EQ(m_vec.at(2).at(3), 20);
+    EXPECT_EQ(m_vec.at(3).at(0), 22);
+    EXPECT_EQ(m_vec.at(5).at(0), 24);
+    EXPECT_EQ(m_vec.at(5).at(1), 26);
+    EXPECT_EQ(m_vec.at(5).at(2), 28);
+    EXPECT_EQ(m_vec.at(5).at(3), 30);
+    EXPECT_EQ(m_vec.at(5).at(4), 32);
 }


### PR DESCRIPTION
In this PR I re-designed `vecmem::data::jagged_vector_view` and `vecmem::data::jagged_vector_data` a bit.

In the base class I only made some stylistic changes, but left the design the same as it was. (Since there's little that one can change in that class. :stuck_out_tongue:)

However I re-wrote `vecmem::data::jagged_vector_data` not to depend on `vecmem::jagged_vector` directly anymore. Instead it is created using primitive variables, leaving it up to the newly introduced `vecmem::get_data(...)` overloads to construct proper(ly filled) objects.

At the same time I also modified `vecmem::data::jagged_vector_data`'s memory management to use [std::unique_ptr](https://en.cppreference.com/w/cpp/memory/unique_ptr). Memory ownership in this type, and the `vecmem::data::jagged_vector_buffer` that I plan to introduce next, is just a bit iffy. I hope that by using [std::unique_ptr](https://en.cppreference.com/w/cpp/memory/unique_ptr), we'll get notified more clearly about trying to use unsafe copy/move operations.

The tests in the end only had to be adjusted slightly to account for these changes.