### PR TITLE
CUDA CMake Requirement Fix, main branch (2021.03.24.)

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# CUDAToolkit requires CMake 3.17.
+cmake_minimum_required( VERSION 3.17 )
+
 # Enable CUDA as a language.
 enable_language( CUDA )
 


### PR DESCRIPTION
The [FindCUDAToolkit.cmake](https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html) module only became available in CMake 3.17. Since I don't want to make the code more complicated than it needs to be (by using [FindCUDA.cmake](https://cmake.org/cmake/help/latest/module/FindCUDA.html) with older CMake versions), it was easiest to just increase the minimum CMake version when building the CUDA library.

Note that if CUDA is not available, an older version of CMake will also be able to handle the rest of the build.