### PR TITLE
vecmem::jagged_device_vector Update, main branch (2021.03.25.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,8 @@ vecmem_add_library( vecmem_core core SHARED
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
+   "include/vecmem/containers/details/jagged_device_vector_iterator.hpp"
+   "include/vecmem/containers/impl/jagged_device_vector_iterator.ipp"
    "include/vecmem/utils/reverse_iterator.hpp"
    "include/vecmem/utils/reverse_iterator.ipp"
    "include/vecmem/utils/type_traits.hpp"

--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -10,6 +10,7 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -71,9 +72,7 @@ namespace vecmem { namespace data {
          */
         template< typename OTHERTYPE,
                   std::enable_if_t<
-                     ( ! std::is_same< T, OTHERTYPE >::value ) &&
-                     std::is_same< T,
-                                   typename std::add_const< OTHERTYPE >::type >::value,
+                     details::is_same_nc< T, OTHERTYPE >::value,
                      bool > = true >
         VECMEM_HOST_AND_DEVICE
         jagged_vector_view( const jagged_vector_view< OTHERTYPE >& parent );

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -48,9 +49,7 @@ namespace vecmem { namespace data {
       ///
       template< typename OTHERTYPE,
                 std::enable_if_t<
-                   ( ! std::is_same< TYPE, OTHERTYPE >::value ) &&
-                   std::is_same< TYPE,
-                                 typename std::add_const< OTHERTYPE >::type >::value,
+                   details::is_same_nc< TYPE, OTHERTYPE >::value,
                    bool > = true >
       VECMEM_HOST_AND_DEVICE
       vector_view( const vector_view< OTHERTYPE >& parent );

--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -1,0 +1,184 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <cstddef>
+#include <type_traits>
+
+namespace vecmem { namespace details {
+
+   /// Custom iterator for @c vecmem::jagged_device_vector
+   ///
+   /// In order for @c vecmem::jagged_device_vector to be able to offer
+   /// iteration over its elements in an efficient and safe way, it needs to use
+   /// this custom iterator type.
+   ///
+   /// It takes care of converting between the underlying data type and the
+   /// type presented towards the users for access to the data. On top of
+   /// providing all the functionality that an iterator has to.
+   ///
+   template< typename TYPE >
+   class jagged_device_vector_iterator {
+
+   public:
+      /// @name Types describing the underlying data
+      /// @{
+
+      /// Type of the data object that we have an array of
+      typedef data::vector_view< TYPE > data_type;
+      /// Pointer to the data object
+      typedef data_type* data_pointer;
+
+      /// @}
+
+      /// @name Type definitions, mimicking STL iterators
+      /// @{
+
+      /// Value type being (virtually) iterated on
+      typedef device_vector< TYPE > value_type;
+      /// (Pointer) Difference type
+      typedef std::ptrdiff_t difference_type;
+      /// Pointer type to the underlying (virtual) value
+      typedef value_type* pointer;
+      /// Reference type to the underlying (virtual) value
+      typedef value_type& reference;
+
+      /// @}
+
+      /// Default constructor
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator();
+      /// Constructor from an underlying data object
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator( data_pointer data );
+      /// Construct from a non-const underlying data object
+      template< typename OTHERTYPE,
+                std::enable_if_t<
+                   details::is_same_nc< TYPE, OTHERTYPE >::value,
+                   bool > = true >
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator( data::vector_view< OTHERTYPE >* data );
+      /// Copy constructor
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator(
+         const jagged_device_vector_iterator& parent );
+      /// Copy constructor
+      template< typename T >
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator(
+         const jagged_device_vector_iterator< T >& parent );
+
+      /// Copy assignment operator
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator&
+      operator=( const jagged_device_vector_iterator& rhs );
+
+      /// @name Value accessor operators
+      /// @{
+
+      /// De-reference the iterator
+      VECMEM_HOST_AND_DEVICE
+      reference operator*() const;
+      /// Use the iterator as a pointer
+      VECMEM_HOST_AND_DEVICE
+      pointer operator->() const;
+
+      /// @}
+
+      /// @name Iterator updating operators
+      /// @{
+
+      /// Decrement the underlying iterator (with '++' as a prefix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator++();
+      /// Decrement the underlying iterator (wuth '++' as a postfix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator++( int );
+
+      /// Increment the underlying iterator (with '--' as a prefix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator--();
+      /// Increment the underlying iterator (with '--' as a postfix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator--( int );
+
+      /// Decrement the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator+( difference_type n ) const;
+      /// Decrement the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator+=( difference_type n );
+
+      /// Increment the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator-( difference_type n ) const;
+      /// Increment the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator-=( difference_type n );
+
+      /// @}
+
+      /// @name Comparison operators
+      /// @{
+
+      /// Check for the equality of two iterators
+      bool operator==( const jagged_device_vector_iterator& other ) const;
+      /// Check for the inequality of two iterators
+      bool operator!=( const jagged_device_vector_iterator& other ) const;
+
+      /// @}
+
+   private:
+      /// Ensure that the internal value object is valid
+      void ensure_valid() const;
+
+      /// Pointer to the data (in an array)
+      data_pointer m_ptr;
+      /// Flag showing whether the value object is up to date with the pointer
+      mutable bool m_value_is_valid;
+      /// Helper object returned by the iterator
+      mutable value_type m_value;
+
+   }; // class jagged_device_vector_iterator
+
+} } // namespace vecmem::details
+
+namespace std {
+
+   /// Specialisation of @c std::iterator_traits
+   ///
+   /// This is necessary to make @c vecmem::reverse_iterator functional on top
+   /// of @c vecmem::details::jagged_device_vector_iterator.
+   ///
+   template< typename T >
+   struct
+   iterator_traits< vecmem::details::jagged_device_vector_iterator< T > > {
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::value_type
+         value_type;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::difference_type
+         difference_type;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::pointer
+         pointer;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::reference
+         reference;
+   };
+
+} // namespace std
+
+// Include the implementation.
+#include "vecmem/containers/impl/jagged_device_vector_iterator.ipp"

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -10,6 +10,7 @@
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
+#include "vecmem/utils/type_traits.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -58,7 +59,14 @@ namespace vecmem {
 
       /// Constructor, on top of a previously allocated/filled block of memory
       VECMEM_HOST_AND_DEVICE
-      device_array( data::vector_view< value_type > data );
+      device_array( const data::vector_view< value_type >& data );
+      /// Construct a const device array from a non-const data object
+      template< typename OTHERTYPE,
+                std::enable_if_t<
+                   details::is_same_nc< T, OTHERTYPE >::value,
+                   bool > = true >
+      VECMEM_HOST_AND_DEVICE
+      device_array( const data::vector_view< OTHERTYPE >& data );
       /// Copy constructor
       VECMEM_HOST_AND_DEVICE
       device_array( const device_array& parent );

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -9,10 +9,12 @@
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -59,7 +61,14 @@ namespace vecmem {
 
       /// Constructor, on top of a previously allocated/filled block of memory
       VECMEM_HOST_AND_DEVICE
-      device_vector( data::vector_view< value_type > data );
+      device_vector( const data::vector_view< value_type >& data );
+      /// Construct a const device vector from a non-const data object
+      template< typename OTHERTYPE,
+                std::enable_if_t<
+                   details::is_same_nc< TYPE, OTHERTYPE >::value,
+                   bool > = true >
+      VECMEM_HOST_AND_DEVICE
+      device_vector( const data::vector_view< OTHERTYPE >& data );
       /// Copy constructor
       VECMEM_HOST_AND_DEVICE
       device_vector( const device_vector& parent );

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -171,7 +171,7 @@ namespace vecmem {
 
       /// @}
 
-   private:
+   protected:
       /// Size of the array that this object looks at
       size_type m_size;
       /// Pointer to the start of the array

--- a/core/include/vecmem/containers/impl/device_array.ipp
+++ b/core/include/vecmem/containers/impl/device_array.ipp
@@ -13,10 +13,23 @@ namespace vecmem {
 
    template< typename T, std::size_t N >
    VECMEM_HOST_AND_DEVICE
-   device_array< T, N >::device_array( data::vector_view< value_type > data )
+   device_array< T, N >::
+   device_array( const data::vector_view< value_type >& data )
    : m_ptr( data.m_ptr ) {
 
       assert( data.m_size >= N );
+   }
+
+   template< typename T, std::size_t N >
+   template< typename OTHERTYPE,
+             std::enable_if_t<
+                details::is_same_nc< T, OTHERTYPE >::value,
+                bool > >
+   VECMEM_HOST_AND_DEVICE
+   device_array< T, N >::
+   device_array( const data::vector_view< OTHERTYPE >& data )
+   : m_ptr( data.m_ptr ) {
+
    }
 
    template< typename T, std::size_t N >

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -14,7 +14,19 @@ namespace vecmem {
    template< typename TYPE >
    VECMEM_HOST_AND_DEVICE
    device_vector< TYPE >::
-   device_vector( data::vector_view< value_type > data )
+   device_vector( const data::vector_view< value_type >& data )
+   : m_size( data.m_size ), m_ptr( data.m_ptr ) {
+
+   }
+
+   template< typename TYPE >
+   template< typename OTHERTYPE,
+             std::enable_if_t<
+                details::is_same_nc< TYPE, OTHERTYPE >::value,
+                bool > >
+   VECMEM_HOST_AND_DEVICE
+   device_vector< TYPE >::
+   device_vector( const data::vector_view< OTHERTYPE >& data )
    : m_size( data.m_size ), m_ptr( data.m_ptr ) {
 
    }

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -8,77 +8,254 @@
 
 #pragma once
 
+// System include(s).
 #include <cassert>
 
 namespace vecmem {
+
     template<typename T>
     jagged_device_vector<T>::jagged_device_vector(
         const data::jagged_vector_view<T> & data
     ) :
         m_size(data.m_size),
-        m_ptr(data.m_ptr)
+        // This is fairly evil. But we should have tests in place for making
+        // sure that this is valid.
+        m_ptr( reinterpret_cast< pointer >( data.m_ptr ) )
     {
+    }
+
+    template< typename T >
+    jagged_device_vector< T >::
+    jagged_device_vector( const jagged_device_vector& parent )
+    : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {
+
+    }
+
+    template< typename T >
+    jagged_device_vector< T >&
+    jagged_device_vector< T >::operator=( const jagged_device_vector& rhs ) {
+
+        // Check if anything needs to be done.
+        if( this == &rhs ) {
+            return *this;
+        }
+
+        // Make this object point at the same data in memory as the one we're
+        // copying from.
+        m_size = rhs.m_size;
+        m_ptr = rhs.m_ptr;
+
+        // Return this object.
+        return *this;
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::at( size_type pos ) {
+
+        // Check if the index is valid.
+        assert( pos < m_size );
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::at( size_type pos ) const {
+
+        // Check if the index is valid.
+        assert( pos < m_size );
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::operator[]( size_type pos ) {
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::operator[]( size_type pos ) const {
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::front() {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the first element of the vector.
+        return m_ptr[ 0 ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::front() const {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the first element of the vector.
+        return m_ptr[ 0 ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::back() {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the last element of the vector.
+        return m_ptr[ m_size - 1 ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::back() const {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the last element of the vector.
+        return m_ptr[ m_size - 1 ];
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::pointer
+    jagged_device_vector< T >::data() {
+
+        return m_ptr;
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_pointer
+    jagged_device_vector< T >::data() const {
+
+        return m_ptr;
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::iterator
+    jagged_device_vector< T >::begin() {
+
+        return iterator( m_ptr );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::begin() const {
+
+        return const_iterator( m_ptr );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::cbegin() const {
+
+        return begin();
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::iterator
+    jagged_device_vector< T >::end() {
+
+        return iterator( m_ptr + m_size );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::end() const {
+
+        return const_iterator( m_ptr + m_size );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::cend() const {
+
+        return end();
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reverse_iterator
+    jagged_device_vector< T >::rbegin() {
+
+        return reverse_iterator( end() );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::rbegin() const {
+
+        return const_reverse_iterator( end() );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::crbegin() const {
+
+        return rbegin();
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::reverse_iterator
+    jagged_device_vector< T >::rend() {
+
+        return reverse_iterator( begin() );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::rend() const {
+
+        return const_reverse_iterator( begin() );
+    }
+
+    template< typename T >
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::crend() const {
+
+        return rend();
     }
 
     template<typename T>
     bool jagged_device_vector<T>::empty(
         void
     ) const {
-        return size() == 0;
+        return m_size == 0;
     }
 
     template<typename T>
-    std::size_t jagged_device_vector<T>::size(
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::size(
         void
     ) const {
         return m_size;
     }
 
     template<typename T>
-    device_vector<T> jagged_device_vector<T>::at(
-        std::size_t i
-    ) {
-        assert(i < size());
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::max_size() const {
 
-        return device_vector<T>(m_ptr[i]);
+        return m_size;
     }
 
     template<typename T>
-    const device_vector<T> jagged_device_vector<T>::at(
-        std::size_t i
-    ) const {
-        assert(i < size());
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::capacity() const {
 
-        return device_vector<T>(m_ptr[i]);
+        return m_size;
     }
 
-    template<typename T>
-    device_vector<T> jagged_device_vector<T>::operator[](
-        std::size_t i
-    ) {
-        return device_vector<T>(m_ptr[i]);
-    }
-
-    template<typename T>
-    const device_vector<T> jagged_device_vector<T>::operator[](
-        std::size_t i
-    ) const {
-        return device_vector<T>(m_ptr[i]);
-    }
-
-    template<typename T>
-    T & jagged_device_vector<T>::at(
-        std::size_t i,
-        std::size_t j
-    ) {
-        return at(i).at(j);
-    }
-
-    template<typename T>
-    const T & jagged_device_vector<T>::at(
-        std::size_t i,
-        std::size_t j
-    ) const {
-        return at(i).at(j);
-    }
-}
+} // namespace vecmem

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -18,9 +18,7 @@ namespace vecmem {
         const data::jagged_vector_view<T> & data
     ) :
         m_size(data.m_size),
-        // This is fairly evil. But we should have tests in place for making
-        // sure that this is valid.
-        m_ptr( reinterpret_cast< pointer >( data.m_ptr ) )
+        m_ptr(data.m_ptr)
     {
     }
 
@@ -129,20 +127,6 @@ namespace vecmem {
 
         // Return a reference to the last element of the vector.
         return m_ptr[ m_size - 1 ];
-    }
-
-    template< typename T >
-    typename jagged_device_vector< T >::pointer
-    jagged_device_vector< T >::data() {
-
-        return m_ptr;
-    }
-
-    template< typename T >
-    typename jagged_device_vector< T >::const_pointer
-    jagged_device_vector< T >::data() const {
-
-        return m_ptr;
     }
 
     template< typename T >

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -10,33 +10,43 @@
 namespace vecmem { namespace details {
 
    template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >::
+   pointer::pointer( const data_pointer data )
+   : m_vec( *data ) {
+
+   }
+
+   template< typename TYPE >
+   typename jagged_device_vector_iterator< TYPE >::value_type*
+   jagged_device_vector_iterator< TYPE >::pointer::operator->() {
+
+      return &m_vec;
+   }
+
+   template< typename TYPE >
+   const typename jagged_device_vector_iterator< TYPE >::value_type*
+   jagged_device_vector_iterator< TYPE >::pointer::operator->() const {
+
+      return &m_vec;
+   }
+
+   template< typename TYPE >
    jagged_device_vector_iterator< TYPE >::jagged_device_vector_iterator()
-   : m_ptr( nullptr ), m_value_is_valid( false ), m_value( data_type() ) {
+   : m_ptr( nullptr ) {
 
    }
 
    template< typename TYPE >
    jagged_device_vector_iterator< TYPE >::
    jagged_device_vector_iterator( data_pointer data )
-   : m_ptr( data ), m_value_is_valid( false ), m_value( data_type() ) {
-
-   }
-
-   template< typename TYPE >
-   template< typename OTHERTYPE,
-             std::enable_if_t<
-                details::is_same_nc< TYPE, OTHERTYPE >::value,
-                bool > >
-   jagged_device_vector_iterator< TYPE >::
-   jagged_device_vector_iterator( data::vector_view< OTHERTYPE >* data )
-   : m_ptr( data ), m_value_is_valid( false ), m_value( data_type() ) {
+   : m_ptr( data ) {
 
    }
 
    template< typename TYPE >
    jagged_device_vector_iterator< TYPE >::
    jagged_device_vector_iterator( const jagged_device_vector_iterator& parent )
-   : m_ptr( parent.m_ptr ), m_value_is_valid( false ), m_value( data_type() ) {
+   : m_ptr( parent.m_ptr ) {
 
    }
 
@@ -45,7 +55,7 @@ namespace vecmem { namespace details {
    jagged_device_vector_iterator< TYPE >::
    jagged_device_vector_iterator(
       const jagged_device_vector_iterator< T >& parent )
-   : m_ptr( parent.m_ptr ), m_value_is_valid( false ), m_value( data_type() ) {
+   : m_ptr( parent.m_ptr ) {
 
    }
 
@@ -61,7 +71,6 @@ namespace vecmem { namespace details {
 
       // Perform the copy.
       m_ptr = rhs.m_ptr;
-      m_value_is_valid = false;
 
       // Return this object.
       return *this;
@@ -71,16 +80,14 @@ namespace vecmem { namespace details {
    typename jagged_device_vector_iterator< TYPE >::reference
    jagged_device_vector_iterator< TYPE >::operator*() const {
 
-      ensure_valid();
-      return m_value;
+      return *m_ptr;
    }
 
    template< typename TYPE >
    typename jagged_device_vector_iterator< TYPE >::pointer
    jagged_device_vector_iterator< TYPE >::operator->() const {
 
-      ensure_valid();
-      return &m_value;
+      return m_ptr;
    }
 
    template< typename TYPE >
@@ -88,7 +95,6 @@ namespace vecmem { namespace details {
    jagged_device_vector_iterator< TYPE >::operator++() {
 
       ++m_ptr;
-      m_value_is_valid = false;
       return *this;
    }
 
@@ -98,7 +104,6 @@ namespace vecmem { namespace details {
 
       jagged_device_vector_iterator tmp = *this;
       ++m_ptr;
-      m_value_is_valid = false;
       return tmp;
    }
 
@@ -107,7 +112,6 @@ namespace vecmem { namespace details {
    jagged_device_vector_iterator< TYPE >::operator--() {
 
       --m_ptr;
-      m_value_is_valid = false;
       return *this;
    }
 
@@ -117,7 +121,6 @@ namespace vecmem { namespace details {
 
       jagged_device_vector_iterator tmp = *this;
       --m_ptr;
-      m_value_is_valid = false;
       return tmp;
    }
 
@@ -133,7 +136,6 @@ namespace vecmem { namespace details {
    jagged_device_vector_iterator< TYPE >::operator+=( difference_type n ) {
 
       m_ptr += n;
-      m_value_is_valid = false;
       return *this;
    }
 
@@ -149,7 +151,6 @@ namespace vecmem { namespace details {
    jagged_device_vector_iterator< TYPE >::operator-=( difference_type n ) {
 
       m_ptr -= n;
-      m_value_is_valid = false;
       return *this;
    }
 
@@ -165,17 +166,6 @@ namespace vecmem { namespace details {
    operator!=( const jagged_device_vector_iterator& other ) const {
 
       return !( *this == other );
-   }
-
-   template< typename TYPE >
-   void jagged_device_vector_iterator< TYPE >::ensure_valid() const {
-
-      if( m_value_is_valid ) {
-         return;
-      }
-      m_value = value_type( *m_ptr );
-      m_value_is_valid = true;
-      return;
    }
 
 } } // namespace vecmem::details

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -1,0 +1,181 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem { namespace details {
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >::jagged_device_vector_iterator()
+   : m_ptr( nullptr ), m_value_is_valid( false ), m_value( data_type() ) {
+
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator( data_pointer data )
+   : m_ptr( data ), m_value_is_valid( false ), m_value( data_type() ) {
+
+   }
+
+   template< typename TYPE >
+   template< typename OTHERTYPE,
+             std::enable_if_t<
+                details::is_same_nc< TYPE, OTHERTYPE >::value,
+                bool > >
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator( data::vector_view< OTHERTYPE >* data )
+   : m_ptr( data ), m_value_is_valid( false ), m_value( data_type() ) {
+
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator( const jagged_device_vector_iterator& parent )
+   : m_ptr( parent.m_ptr ), m_value_is_valid( false ), m_value( data_type() ) {
+
+   }
+
+   template< typename TYPE >
+   template< typename T >
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator(
+      const jagged_device_vector_iterator< T >& parent )
+   : m_ptr( parent.m_ptr ), m_value_is_valid( false ), m_value( data_type() ) {
+
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::
+   operator=( const jagged_device_vector_iterator& rhs ) {
+
+      // Check if anything needs to be done.
+      if( this == &rhs ) {
+         return *this;
+      }
+
+      // Perform the copy.
+      m_ptr = rhs.m_ptr;
+      m_value_is_valid = false;
+
+      // Return this object.
+      return *this;
+   }
+
+   template< typename TYPE >
+   typename jagged_device_vector_iterator< TYPE >::reference
+   jagged_device_vector_iterator< TYPE >::operator*() const {
+
+      ensure_valid();
+      return m_value;
+   }
+
+   template< typename TYPE >
+   typename jagged_device_vector_iterator< TYPE >::pointer
+   jagged_device_vector_iterator< TYPE >::operator->() const {
+
+      ensure_valid();
+      return &m_value;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator++() {
+
+      ++m_ptr;
+      m_value_is_valid = false;
+      return *this;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator++( int ) {
+
+      jagged_device_vector_iterator tmp = *this;
+      ++m_ptr;
+      m_value_is_valid = false;
+      return tmp;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator--() {
+
+      --m_ptr;
+      m_value_is_valid = false;
+      return *this;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator--( int ) {
+
+      jagged_device_vector_iterator tmp = *this;
+      --m_ptr;
+      m_value_is_valid = false;
+      return tmp;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator+( difference_type n ) const {
+
+      return jagged_device_vector_iterator( m_ptr + n );
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator+=( difference_type n ) {
+
+      m_ptr += n;
+      m_value_is_valid = false;
+      return *this;
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator-( difference_type n ) const {
+
+      return jagged_device_vector_iterator( m_ptr - n );
+   }
+
+   template< typename TYPE >
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator-=( difference_type n ) {
+
+      m_ptr -= n;
+      m_value_is_valid = false;
+      return *this;
+   }
+
+   template< typename TYPE >
+   bool jagged_device_vector_iterator< TYPE >::
+   operator==( const jagged_device_vector_iterator& other ) const {
+
+      return ( m_ptr == other.m_ptr );
+   }
+
+   template< typename TYPE >
+   bool jagged_device_vector_iterator< TYPE >::
+   operator!=( const jagged_device_vector_iterator& other ) const {
+
+      return !( *this == other );
+   }
+
+   template< typename TYPE >
+   void jagged_device_vector_iterator< TYPE >::ensure_valid() const {
+
+      if( m_value_is_valid ) {
+         return;
+      }
+      m_value = value_type( *m_ptr );
+      m_value_is_valid = true;
+      return;
+   }
+
+} } // namespace vecmem::details

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -23,9 +23,7 @@ namespace vecmem { namespace data {
     template< typename T >
     template< typename OTHERTYPE,
               std::enable_if_t<
-                 ( ! std::is_same< T, OTHERTYPE >::value ) &&
-                 std::is_same< T,
-                               typename std::add_const< OTHERTYPE >::type >::value,
+                 details::is_same_nc< T, OTHERTYPE >::value,
                  bool > >
     jagged_vector_view< T >::
     jagged_vector_view( const jagged_vector_view< OTHERTYPE >& parent )

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -18,9 +18,7 @@ namespace vecmem { namespace data {
    template< typename TYPE >
    template< typename OTHERTYPE,
              std::enable_if_t<
-                ( ! std::is_same< TYPE, OTHERTYPE >::value ) &&
-                std::is_same< TYPE,
-                              typename std::add_const< OTHERTYPE >::type >::value,
+                details::is_same_nc< TYPE, OTHERTYPE >::value,
                 bool > >
    VECMEM_HOST_AND_DEVICE
    vector_view< TYPE >::vector_view( const vector_view< OTHERTYPE >& parent )

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -11,6 +11,7 @@
 // Local include(s).
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/details/jagged_device_vector_iterator.hpp"
 #include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
@@ -54,18 +55,15 @@ namespace vecmem {
         typedef std::ptrdiff_t     difference_type;
 
         /// Value reference type
-        typedef value_type&        reference;
+        typedef device_vector< T > reference;
         /// Constant value reference type
-        typedef const value_type&  const_reference;
-        /// Value pointer type
-        typedef value_type*        pointer;
-        /// Constant value pointer type
-        typedef const value_type*  const_pointer;
+        typedef device_vector< const T > const_reference;
 
         /// Forward iterator type
-        typedef pointer            iterator;
+        typedef details::jagged_device_vector_iterator< T > iterator;
         /// Constant forward iterator type
-        typedef const_pointer      const_iterator;
+        typedef details::jagged_device_vector_iterator< const T >
+            const_iterator;
         /// Reverse iterator type
         typedef vecmem::reverse_iterator< iterator > reverse_iterator;
         /// Constant reverse iterator type
@@ -121,13 +119,6 @@ namespace vecmem {
         /// Return the last element of the vector (const)
         VECMEM_HOST_AND_DEVICE
         const_reference back() const;
-
-        /// Access the underlying memory array (non-const)
-        VECMEM_HOST_AND_DEVICE
-        pointer data();
-        /// Access the underlying memory array (const)
-        VECMEM_HOST_AND_DEVICE
-        const_pointer data() const;
 
         /// @}
 
@@ -218,7 +209,7 @@ namespace vecmem {
         /**
          * Objects representing the "inner vectors" towards the user.
          */
-        pointer m_ptr;
+        typename data::jagged_vector_view< T >::pointer m_ptr;
 
     }; // class jagged_device_vector
 

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -8,16 +8,16 @@
 
 #pragma once
 
+// Local include(s).
 #include "vecmem/containers/device_vector.hpp"
-#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/utils/types.hpp"
 
+// System include(s).
 #include <cstddef>
 
 namespace vecmem {
-    namespace data {
-        template<typename T>
-        struct jagged_vector_view;
-    }
 
     /**
      * @brief A view for jagged vectors.
@@ -43,14 +43,141 @@ namespace vecmem {
     template<typename T>
     class jagged_device_vector {
     public:
+        /// @name Type definitions, mimicking @c std::vector
+        /// @{
+
+        /// Type of the "outer" array elements
+        typedef device_vector< T > value_type;
+        /// Size type for the array
+        typedef std::size_t        size_type;
+        /// Pointer difference type
+        typedef std::ptrdiff_t     difference_type;
+
+        /// Value reference type
+        typedef value_type&        reference;
+        /// Constant value reference type
+        typedef const value_type&  const_reference;
+        /// Value pointer type
+        typedef value_type*        pointer;
+        /// Constant value pointer type
+        typedef const value_type*  const_pointer;
+
+        /// Forward iterator type
+        typedef pointer            iterator;
+        /// Constant forward iterator type
+        typedef const_pointer      const_iterator;
+        /// Reverse iterator type
+        typedef vecmem::reverse_iterator< iterator > reverse_iterator;
+        /// Constant reverse iterator type
+        typedef vecmem::reverse_iterator< const_iterator >
+            const_reverse_iterator;
+
+        /// @}
+
         /**
-         * @brief Construct a jagged vector view from a jagged vector data
+         * @brief Construct a jagged device vector from a jagged vector view
          * object.
          */
         VECMEM_HOST_AND_DEVICE
         jagged_device_vector(
             const data::jagged_vector_view<T> & data
         );
+
+        /// Copy constructor
+        VECMEM_HOST_AND_DEVICE
+        jagged_device_vector( const jagged_device_vector& parent );
+
+        /// Copy assignment operator
+        VECMEM_HOST_AND_DEVICE
+        jagged_device_vector& operator=( const jagged_device_vector& rhs );
+
+        /// @name Vector element access functions
+        /// @{
+
+        /// Return a specific element of the vector in a "safe way" (non-const)
+        VECMEM_HOST_AND_DEVICE
+        reference at( size_type pos );
+        /// Return a specific element of the vector in a "safe way" (const)
+        VECMEM_HOST_AND_DEVICE
+        const_reference at( size_type pos ) const;
+
+        /// Return a specific element of the vector (non-const)
+        VECMEM_HOST_AND_DEVICE
+        reference operator[]( size_type pos );
+        /// Return a specific element of the vector (const)
+        VECMEM_HOST_AND_DEVICE
+        const_reference operator[]( size_type pos ) const;
+
+        /// Return the first element of the vector (non-const)
+        VECMEM_HOST_AND_DEVICE
+        reference front();
+        /// Return the first element of the vector (const)
+        VECMEM_HOST_AND_DEVICE
+        const_reference front() const;
+
+        /// Return the last element of the vector (non-const)
+        VECMEM_HOST_AND_DEVICE
+        reference back();
+        /// Return the last element of the vector (const)
+        VECMEM_HOST_AND_DEVICE
+        const_reference back() const;
+
+        /// Access the underlying memory array (non-const)
+        VECMEM_HOST_AND_DEVICE
+        pointer data();
+        /// Access the underlying memory array (const)
+        VECMEM_HOST_AND_DEVICE
+        const_pointer data() const;
+
+        /// @}
+
+        /// @name Iterator providing functions
+        /// @{
+
+        /// Return a forward iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        iterator begin();
+        /// Return a constant forward iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_iterator begin() const;
+        /// Return a constant forward iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_iterator cbegin() const;
+
+        /// Return a forward iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        iterator end();
+        /// Return a constant forward iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_iterator end() const;
+        /// Return a constant forward iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_iterator cend() const;
+
+        /// Return a reverse iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        reverse_iterator rbegin();
+        /// Return a constant reverse iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_reverse_iterator rbegin() const;
+        /// Return a constant reverse iterator pointing at the end of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_reverse_iterator crbegin() const;
+
+        /// Return a reverse iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        reverse_iterator rend();
+        /// Return a constant reverse iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_reverse_iterator rend() const;
+        /// Return a constant reverse iterator pointing at the beginning of the vector
+        VECMEM_HOST_AND_DEVICE
+        const_reverse_iterator crend() const;
+
+        /// @}
+
+        /// @name Capacity checking functions
+        /// @{
 
         /**
          * @brief Checks whether this view has no rows.
@@ -69,104 +196,33 @@ namespace vecmem {
          * @brief Get the number of rows in this view.
          */
         VECMEM_HOST_AND_DEVICE
-        std::size_t size(
+        size_type size(
             void
         ) const;
 
-        /**
-         * @brief Get the row (vector) at a certain index.
-         *
-         * This method will assert that the element is in range if NDEBUG is
-         * unset.
-         *
-         * @param[in] i The row number to fetch.
-         */
+        /// Return the maximum (fixed) number of elements in the vector
         VECMEM_HOST_AND_DEVICE
-        device_vector<T> at(
-            std::size_t i
-        );
+        size_type max_size() const;
+        /// Return the current (fixed) capacity of the vector
+        VECMEM_HOST_AND_DEVICE
+        size_type capacity() const;
 
-        /**
-         * @brief Get the row (vector) at a certain index in a const way.
-         *
-         * This method will assert that the element is in range if NDEBUG is
-         * unset.
-         *
-         * @param[in] i The row number to fetch.
-         */
-        VECMEM_HOST_AND_DEVICE
-        const device_vector<T> at(
-            std::size_t i
-        ) const;
-
-        /**
-         * @brief Get the row (vector) at a certain index.
-         *
-         * This method does no bounds checking at all.
-         *
-         * @param[in] i The row number to fetch.
-         */
-        VECMEM_HOST_AND_DEVICE
-        device_vector<T> operator[](
-            std::size_t i
-        );
-
-        /**
-         * @brief Get the row (vector) at a certain index in a const way.
-         *
-         * This method does no bounds checking at all.
-         *
-         * @param[in] i The row number to fetch.
-         */
-        VECMEM_HOST_AND_DEVICE
-        const device_vector<T> operator[](
-            std::size_t i
-        ) const;
-
-        /**
-         * @brief Retrieve the element at a given two-dimensional coordinate.
-         *
-         * This method can be used to directly retrieve an object from an inner
-         * vector.
-         *
-         * @param[in] i The row index to fetch from.
-         * @param[in] j The index in row i to use.
-         */
-        VECMEM_HOST_AND_DEVICE
-        T & at(
-            std::size_t i,
-            std::size_t j
-        );
-
-        /**
-         * @brief Retrieve the element at a given two-dimensional coordinate in
-         * a const way.
-         *
-         * This method can be used to directly retrieve an object from an inner
-         * vector.
-         *
-         * @param[in] i The row index to fetch from.
-         * @param[in] j The index in row i to use.
-         */
-        VECMEM_HOST_AND_DEVICE
-        const T & at(
-            std::size_t i,
-            std::size_t j
-        ) const;
+        /// @}
 
     private:
         /**
          * The number of rows in this jagged vector.
          */
-        const std::size_t m_size;
+        size_type m_size;
 
         /**
-         * The internal state of this jagged vector, which is heap-allocated by
-         * the given memory manager.
+         * Objects representing the "inner vectors" towards the user.
          */
-        data::vector_view<T> * const m_ptr;
-    };
-}
+        pointer m_ptr;
+
+    }; // class jagged_device_vector
+
+} // namespace vecmem
 
 // Include the implementation.
 #include "vecmem/containers/impl/jagged_device_vector.ipp"

--- a/core/include/vecmem/utils/reverse_iterator.hpp
+++ b/core/include/vecmem/utils/reverse_iterator.hpp
@@ -75,9 +75,6 @@ namespace vecmem {
       /// Use the iterator as a pointer
       VECMEM_HOST_AND_DEVICE
       pointer operator->() const;
-      /// Return the value at a specific offset
-      VECMEM_HOST_AND_DEVICE
-      reference operator[]( difference_type n ) const;
 
       /// @}
 

--- a/core/include/vecmem/utils/reverse_iterator.hpp
+++ b/core/include/vecmem/utils/reverse_iterator.hpp
@@ -128,10 +128,12 @@ namespace vecmem {
 
    /// Comparison operator for reverse iterators
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator==( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 );
    /// Comparison operator for reverse iterators
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator!=( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 );
 

--- a/core/include/vecmem/utils/reverse_iterator.ipp
+++ b/core/include/vecmem/utils/reverse_iterator.ipp
@@ -87,14 +87,6 @@ namespace vecmem {
 
    template< typename Iterator >
    VECMEM_HOST_AND_DEVICE
-   typename reverse_iterator< Iterator >::reference
-   reverse_iterator< Iterator >::operator[]( difference_type n ) const {
-
-      return *( *this + n );
-   }
-
-   template< typename Iterator >
-   VECMEM_HOST_AND_DEVICE
    reverse_iterator< Iterator >& reverse_iterator< Iterator >::operator++() {
 
       --m_current;

--- a/core/include/vecmem/utils/reverse_iterator.ipp
+++ b/core/include/vecmem/utils/reverse_iterator.ipp
@@ -173,6 +173,7 @@ namespace vecmem {
    }
 
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator==( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 ) {
 
@@ -180,6 +181,7 @@ namespace vecmem {
    }
 
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator!=( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 ) {
 

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -43,4 +43,19 @@ namespace vecmem { namespace details {
       typedef T* type;
    };
 
+   /// Helper trait for detecting when a type is a non-const version of another
+   ///
+   /// This comes into play multiple times to enable certain constructors
+   /// conditionally through SFINAE.
+   ///
+   template< typename CTYPE, typename NCTYPE >
+   struct is_same_nc {
+      static constexpr bool value = false;
+   };
+
+   template< typename TYPE >
+   struct is_same_nc< const TYPE, TYPE > {
+      static constexpr bool value = true;
+   };
+
 } } // namespace vecmem::details

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -66,16 +66,17 @@ TEST_F(core_jagged_vector_view_test, two_d_access) {
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access_const) {
-    EXPECT_EQ(m_jag.at(0).at(0), 1);
-    EXPECT_EQ(m_jag.at(0).at(1), 2);
-    EXPECT_EQ(m_jag.at(0).at(2), 3);
-    EXPECT_EQ(m_jag.at(0).at(3), 4);
-    EXPECT_EQ(m_jag.at(1).at(0), 5);
-    EXPECT_EQ(m_jag.at(1).at(1), 6);
-    EXPECT_EQ(m_jag.at(2).at(0), 7);
-    EXPECT_EQ(m_jag.at(2).at(1), 8);
-    EXPECT_EQ(m_jag.at(2).at(2), 9);
-    EXPECT_EQ(m_jag.at(2).at(3), 10);
+    const vecmem::jagged_device_vector<int>& jag = m_jag;
+    EXPECT_EQ(jag.at(0).at(0), 1);
+    EXPECT_EQ(jag.at(0).at(1), 2);
+    EXPECT_EQ(jag.at(0).at(2), 3);
+    EXPECT_EQ(jag.at(0).at(3), 4);
+    EXPECT_EQ(jag.at(1).at(0), 5);
+    EXPECT_EQ(jag.at(1).at(1), 6);
+    EXPECT_EQ(jag.at(2).at(0), 7);
+    EXPECT_EQ(jag.at(2).at(1), 8);
+    EXPECT_EQ(jag.at(2).at(2), 9);
+    EXPECT_EQ(jag.at(2).at(3), 10);
 }
 
 TEST_F(core_jagged_vector_view_test, mutate) {
@@ -100,4 +101,28 @@ TEST_F(core_jagged_vector_view_test, mutate) {
     EXPECT_EQ(m_jag.at(2).at(1), 2 * 8);
     EXPECT_EQ(m_jag.at(2).at(2), 2 * 9);
     EXPECT_EQ(m_jag.at(2).at(3), 2 * 10);
+}
+
+TEST_F(core_jagged_vector_view_test, iterator) {
+    std::size_t i = 0;
+    for( auto itr = m_jag.begin(); itr != m_jag.end(); ++itr ) {
+        i += itr->size();
+    }
+    EXPECT_EQ( i, 16 );
+}
+
+TEST_F(core_jagged_vector_view_test, reverse_iterator) {
+    std::size_t i = 0;
+    for( auto itr = m_jag.rbegin(); itr != m_jag.rend(); ++itr ) {
+        i += itr->size();
+    }
+    EXPECT_EQ( i, 16 );
+}
+
+TEST_F(core_jagged_vector_view_test, value_iteration) {
+    std::size_t i = 0;
+    for( auto& innerv : m_jag ) {
+        i += innerv.size();
+    }
+    EXPECT_EQ( i, 16 );
 }

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -53,51 +53,51 @@ TEST_F(core_jagged_vector_view_test, row_size) {
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access) {
-    EXPECT_EQ(m_jag.at(0, 0), 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2);
-    EXPECT_EQ(m_jag.at(0, 2), 3);
-    EXPECT_EQ(m_jag.at(0, 3), 4);
-    EXPECT_EQ(m_jag.at(1, 0), 5);
-    EXPECT_EQ(m_jag.at(1, 1), 6);
-    EXPECT_EQ(m_jag.at(2, 0), 7);
-    EXPECT_EQ(m_jag.at(2, 1), 8);
-    EXPECT_EQ(m_jag.at(2, 2), 9);
-    EXPECT_EQ(m_jag.at(2, 3), 10);
+    EXPECT_EQ(m_jag.at(0).at(0), 1);
+    EXPECT_EQ(m_jag.at(0).at(1), 2);
+    EXPECT_EQ(m_jag.at(0).at(2), 3);
+    EXPECT_EQ(m_jag.at(0).at(3), 4);
+    EXPECT_EQ(m_jag.at(1).at(0), 5);
+    EXPECT_EQ(m_jag.at(1).at(1), 6);
+    EXPECT_EQ(m_jag.at(2).at(0), 7);
+    EXPECT_EQ(m_jag.at(2).at(1), 8);
+    EXPECT_EQ(m_jag.at(2).at(2), 9);
+    EXPECT_EQ(m_jag.at(2).at(3), 10);
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access_const) {
-    EXPECT_EQ(m_jag.at(0, 0), 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2);
-    EXPECT_EQ(m_jag.at(0, 2), 3);
-    EXPECT_EQ(m_jag.at(0, 3), 4);
-    EXPECT_EQ(m_jag.at(1, 0), 5);
-    EXPECT_EQ(m_jag.at(1, 1), 6);
-    EXPECT_EQ(m_jag.at(2, 0), 7);
-    EXPECT_EQ(m_jag.at(2, 1), 8);
-    EXPECT_EQ(m_jag.at(2, 2), 9);
-    EXPECT_EQ(m_jag.at(2, 3), 10);
+    EXPECT_EQ(m_jag.at(0).at(0), 1);
+    EXPECT_EQ(m_jag.at(0).at(1), 2);
+    EXPECT_EQ(m_jag.at(0).at(2), 3);
+    EXPECT_EQ(m_jag.at(0).at(3), 4);
+    EXPECT_EQ(m_jag.at(1).at(0), 5);
+    EXPECT_EQ(m_jag.at(1).at(1), 6);
+    EXPECT_EQ(m_jag.at(2).at(0), 7);
+    EXPECT_EQ(m_jag.at(2).at(1), 8);
+    EXPECT_EQ(m_jag.at(2).at(2), 9);
+    EXPECT_EQ(m_jag.at(2).at(3), 10);
 }
 
 TEST_F(core_jagged_vector_view_test, mutate) {
-    m_jag.at(0, 0) *= 2;
-    m_jag.at(0, 1) *= 2;
-    m_jag.at(0, 2) *= 2;
-    m_jag.at(0, 3) *= 2;
-    m_jag.at(1, 0) *= 2;
-    m_jag.at(1, 1) *= 2;
-    m_jag.at(2, 0) *= 2;
-    m_jag.at(2, 1) *= 2;
-    m_jag.at(2, 2) *= 2;
-    m_jag.at(2, 3) *= 2;
+    m_jag.at(0).at(0) *= 2;
+    m_jag.at(0).at(1) *= 2;
+    m_jag.at(0).at(2) *= 2;
+    m_jag.at(0).at(3) *= 2;
+    m_jag.at(1).at(0) *= 2;
+    m_jag.at(1).at(1) *= 2;
+    m_jag.at(2).at(0) *= 2;
+    m_jag.at(2).at(1) *= 2;
+    m_jag.at(2).at(2) *= 2;
+    m_jag.at(2).at(3) *= 2;
 
-    EXPECT_EQ(m_jag.at(0, 0), 2 * 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2 * 2);
-    EXPECT_EQ(m_jag.at(0, 2), 2 * 3);
-    EXPECT_EQ(m_jag.at(0, 3), 2 * 4);
-    EXPECT_EQ(m_jag.at(1, 0), 2 * 5);
-    EXPECT_EQ(m_jag.at(1, 1), 2 * 6);
-    EXPECT_EQ(m_jag.at(2, 0), 2 * 7);
-    EXPECT_EQ(m_jag.at(2, 1), 2 * 8);
-    EXPECT_EQ(m_jag.at(2, 2), 2 * 9);
-    EXPECT_EQ(m_jag.at(2, 3), 2 * 10);
+    EXPECT_EQ(m_jag.at(0).at(0), 2 * 1);
+    EXPECT_EQ(m_jag.at(0).at(1), 2 * 2);
+    EXPECT_EQ(m_jag.at(0).at(2), 2 * 3);
+    EXPECT_EQ(m_jag.at(0).at(3), 2 * 4);
+    EXPECT_EQ(m_jag.at(1).at(0), 2 * 5);
+    EXPECT_EQ(m_jag.at(1).at(1), 2 * 6);
+    EXPECT_EQ(m_jag.at(2).at(0), 2 * 7);
+    EXPECT_EQ(m_jag.at(2).at(1), 2 * 8);
+    EXPECT_EQ(m_jag.at(2).at(2), 2 * 9);
+    EXPECT_EQ(m_jag.at(2).at(3), 2 * 10);
 }

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -121,7 +121,7 @@ TEST_F(core_jagged_vector_view_test, reverse_iterator) {
 
 TEST_F(core_jagged_vector_view_test, value_iteration) {
     std::size_t i = 0;
-    for( auto& innerv : m_jag ) {
+    for( const auto& innerv : m_jag ) {
         i += innerv.size();
     }
     EXPECT_EQ( i, 16 );

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -40,18 +40,18 @@ class cuda_jagged_vector_view_test : public testing::Test {
 TEST_F(cuda_jagged_vector_view_test, mutate_in_kernel) {
     doubleJagged(m_data);
 
-    EXPECT_EQ(m_vec.at(0).at(0), 2);
+    EXPECT_EQ(m_vec.at(0).at(0), 4868);
     EXPECT_EQ(m_vec.at(0).at(1), 4);
     EXPECT_EQ(m_vec.at(0).at(2), 6);
     EXPECT_EQ(m_vec.at(0).at(3), 8);
-    EXPECT_EQ(m_vec.at(1).at(0), 10);
+    EXPECT_EQ(m_vec.at(1).at(0), 4876);
     EXPECT_EQ(m_vec.at(1).at(1), 12);
-    EXPECT_EQ(m_vec.at(2).at(0), 14);
+    EXPECT_EQ(m_vec.at(2).at(0), 4880);
     EXPECT_EQ(m_vec.at(2).at(1), 16);
     EXPECT_EQ(m_vec.at(2).at(2), 18);
     EXPECT_EQ(m_vec.at(2).at(3), 20);
-    EXPECT_EQ(m_vec.at(3).at(0), 22);
-    EXPECT_EQ(m_vec.at(5).at(0), 24);
+    EXPECT_EQ(m_vec.at(3).at(0), 4888);
+    EXPECT_EQ(m_vec.at(5).at(0), 4890);
     EXPECT_EQ(m_vec.at(5).at(1), 26);
     EXPECT_EQ(m_vec.at(5).at(2), 28);
     EXPECT_EQ(m_vec.at(5).at(3), 30);

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -26,6 +26,14 @@ void doubleJaggedKernel(
     for (std::size_t i = 0; i < jag.at(t).size(); ++i) {
         jag.at(t).at(i) *= 2;
     }
+    __syncthreads();
+    for( auto itr = jag.rbegin(); itr != jag.rend(); ++itr ) {
+        if( jag[ t ].size() > 0 ) {
+            for( auto itr2 = itr->rbegin(); itr2 != itr->rend(); ++itr2 ) {
+                jag[ t ].front() += *itr2;
+            }
+        }
+    }
 }
 
 void doubleJagged(

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -24,7 +24,7 @@ void doubleJaggedKernel(
     }
 
     for (std::size_t i = 0; i < jag.at(t).size(); ++i) {
-        jag.at(t, i) *= 2;
+        jag.at(t).at(i) *= 2;
     }
 }
 


### PR DESCRIPTION
Okay, with this you really need to hold on to your hat... :stuck_out_tongue:

After some pondering I decided to use a hack for representing jagged vectors in a nice way in device code. Relying on the fact that `vecmem::data::vector_view<T>` and `vecmem::device_vector<T>` have the same data layout in memory. So, as ugly/scary as it seems, the following works:

```c++
vecmem::data::vector_view<T>* ptr1 = ...;
vecmem::device_vector<T>* ptr2 = reinterpret_cast< vecmem::device_vector<T>* >( ptr1 );
```

I was thinking of other solutions for a while about how `vecmem::jagged_device_vector` should present a nice vector-of-vectors interface, but everything else would've been way more expensive. Since remember, allocating memory on the heap in device code should only be done as a last resort.

I added some runtime tests in `test_core_device_containers.cpp` to make sure that this conversion would be valid. Though we may want to turn that into a compile-time check later on as well. :thinking:

I'm really curious about what you think on this one...