### PR TITLE
vecmem::jagged_device_vector Update, main branch (2021.03.26.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,8 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/data/vector_view.hpp"
    "include/vecmem/containers/impl/vector_view.ipp"
    # Iterator types.
+   "include/vecmem/containers/details/jagged_device_vector_iterator.hpp"
+   "include/vecmem/containers/impl/jagged_device_vector_iterator.ipp"
    "include/vecmem/containers/details/reverse_iterator.hpp"
    "include/vecmem/containers/impl/reverse_iterator.ipp"
    # Allocator

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -32,6 +32,9 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/impl/vector_buffer.ipp"
    "include/vecmem/containers/data/vector_view.hpp"
    "include/vecmem/containers/impl/vector_view.ipp"
+   # Iterator types.
+   "include/vecmem/containers/details/reverse_iterator.hpp"
+   "include/vecmem/containers/impl/reverse_iterator.ipp"
    # Allocator
    "include/vecmem/memory/allocator.hpp"
    "include/vecmem/memory/allocator.ipp"
@@ -48,7 +51,5 @@ vecmem_add_library( vecmem_core core SHARED
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
-   "include/vecmem/utils/reverse_iterator.hpp"
-   "include/vecmem/utils/reverse_iterator.ipp"
    "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -8,8 +8,8 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/details/reverse_iterator.hpp"
 #include "vecmem/memory/memory_resource.hpp"
-#include "vecmem/utils/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -67,9 +67,10 @@ namespace vecmem {
       typedef const_pointer      const_iterator;
 
       /// Reverse iterator type
-      typedef vecmem::reverse_iterator< iterator > reverse_iterator;
+      typedef vecmem::details::reverse_iterator< iterator > reverse_iterator;
       /// Constant reverse iterator type
-      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+      typedef vecmem::details::reverse_iterator< const_iterator >
+         const_reverse_iterator;
 
       /// @}
 

--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -10,6 +10,7 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -71,9 +72,7 @@ namespace vecmem { namespace data {
          */
         template< typename OTHERTYPE,
                   std::enable_if_t<
-                     ( ! std::is_same< T, OTHERTYPE >::value ) &&
-                     std::is_same< T,
-                                   typename std::add_const< OTHERTYPE >::type >::value,
+                     details::is_same_nc< T, OTHERTYPE >::value,
                      bool > = true >
         VECMEM_HOST_AND_DEVICE
         jagged_vector_view( const jagged_vector_view< OTHERTYPE >& parent );

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -48,9 +49,7 @@ namespace vecmem { namespace data {
       ///
       template< typename OTHERTYPE,
                 std::enable_if_t<
-                   ( ! std::is_same< TYPE, OTHERTYPE >::value ) &&
-                   std::is_same< TYPE,
-                                 typename std::add_const< OTHERTYPE >::type >::value,
+                   details::is_same_nc< TYPE, OTHERTYPE >::value,
                    bool > = true >
       VECMEM_HOST_AND_DEVICE
       vector_view( const vector_view< OTHERTYPE >& parent );

--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -1,0 +1,205 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <cstddef>
+#include <iterator>
+
+namespace vecmem { namespace details {
+
+   /// Custom iterator for @c vecmem::jagged_device_vector
+   ///
+   /// In order for @c vecmem::jagged_device_vector to be able to offer
+   /// iteration over its elements in an efficient and safe way, it needs to use
+   /// this custom iterator type.
+   ///
+   /// It takes care of converting between the underlying data type and the
+   /// type presented towards the users for access to the data. On top of
+   /// providing all the functionality that an iterator has to.
+   ///
+   template< typename TYPE >
+   class jagged_device_vector_iterator {
+
+   public:
+      /// @name Types describing the underlying data
+      /// @{
+
+      /// Type of the data object that we have an array of
+      typedef data::vector_view< TYPE > data_type;
+      /// Pointer to the data object
+      typedef data_type* data_pointer;
+
+      /// @}
+
+      /// @name Type definitions, mimicking STL iterators
+      /// @{
+
+      /// Value type being (virtually) iterated on
+      typedef device_vector< TYPE > value_type;
+      /// (Pointer) Difference type
+      typedef std::ptrdiff_t difference_type;
+      /// "Reference" type to the underlying (virtual) value
+      typedef value_type reference;
+
+      /// Helper class for returning "pointer-like" objects from the iterator
+      ///
+      /// Since the iterator returned everything by value as temporary objects,
+      /// in order to provide a proper return type for its @c operator->, this
+      /// custom type needs to be used.
+      ///
+      class pointer {
+
+      public:
+         /// Constructor from a data pointer
+         ///
+         /// Used a pointer instead of a reference to make the rest of the code
+         /// in @c vecmem::details::jagged_device_vector_iterator as unaware of
+         /// the existence of this type as possible.
+         ///
+         VECMEM_HOST_AND_DEVICE
+         pointer( const data_pointer data );
+
+         /// Return a pointer to a device vector (non-const)
+         VECMEM_HOST_AND_DEVICE
+         value_type* operator->();
+         /// Return a pointer to a device vector (const)
+         VECMEM_HOST_AND_DEVICE
+         const value_type* operator->() const;
+
+      private:
+         /// Temporary device vector created on the stack
+         value_type m_vec;
+
+      }; // class pointer
+
+      /// @}
+
+      /// Default constructor
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator();
+      /// Constructor from an underlying data object
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator( data_pointer data );
+      /// Copy constructor
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator(
+         const jagged_device_vector_iterator& parent );
+      /// Copy constructor
+      template< typename T >
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator(
+         const jagged_device_vector_iterator< T >& parent );
+
+      /// Copy assignment operator
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator&
+      operator=( const jagged_device_vector_iterator& rhs );
+
+      /// @name Value accessor operators
+      /// @{
+
+      /// De-reference the iterator
+      VECMEM_HOST_AND_DEVICE
+      reference operator*() const;
+      /// Use the iterator as a pointer
+      VECMEM_HOST_AND_DEVICE
+      pointer operator->() const;
+      /// Return the value at a specific offset
+      VECMEM_HOST_AND_DEVICE
+      reference operator[]( difference_type n ) const;
+
+      /// @}
+
+      /// @name Iterator updating operators
+      /// @{
+
+      /// Decrement the underlying iterator (with '++' as a prefix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator++();
+      /// Decrement the underlying iterator (wuth '++' as a postfix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator++( int );
+
+      /// Increment the underlying iterator (with '--' as a prefix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator--();
+      /// Increment the underlying iterator (with '--' as a postfix)
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator--( int );
+
+      /// Decrement the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator+( difference_type n ) const;
+      /// Decrement the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator+=( difference_type n );
+
+      /// Increment the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator operator-( difference_type n ) const;
+      /// Increment the underlying iterator by a specific value
+      VECMEM_HOST_AND_DEVICE
+      jagged_device_vector_iterator& operator-=( difference_type n );
+
+      /// @}
+
+      /// @name Comparison operators
+      /// @{
+
+      /// Check for the equality of two iterators
+      VECMEM_HOST_AND_DEVICE
+      bool operator==( const jagged_device_vector_iterator& other ) const;
+      /// Check for the inequality of two iterators
+      VECMEM_HOST_AND_DEVICE
+      bool operator!=( const jagged_device_vector_iterator& other ) const;
+
+      /// @}
+
+   private:
+      /// Pointer to the data (in an array)
+      data_pointer m_ptr;
+
+   }; // class jagged_device_vector_iterator
+
+} } // namespace vecmem::details
+
+namespace std {
+
+   /// Specialisation of @c std::iterator_traits
+   ///
+   /// This is necessary to make @c vecmem::reverse_iterator functional on top
+   /// of @c vecmem::details::jagged_device_vector_iterator.
+   ///
+   template< typename T >
+   struct
+   iterator_traits< vecmem::details::jagged_device_vector_iterator< T > > {
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::value_type
+         value_type;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::difference_type
+         difference_type;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::pointer
+         pointer;
+      typedef typename
+         vecmem::details::jagged_device_vector_iterator< T >::reference
+         reference;
+      typedef std::random_access_iterator_tag iterator_category;
+   };
+
+} // namespace std
+
+// Include the implementation.
+#include "vecmem/containers/impl/jagged_device_vector_iterator.ipp"

--- a/core/include/vecmem/containers/details/reverse_iterator.hpp
+++ b/core/include/vecmem/containers/details/reverse_iterator.hpp
@@ -12,7 +12,7 @@
 // System include(s).
 #include <iterator>
 
-namespace vecmem {
+namespace vecmem { namespace details {
 
    /// Type mimicking @c std::reverse_iterator
    ///
@@ -131,14 +131,16 @@ namespace vecmem {
 
    /// Comparison operator for reverse iterators
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator==( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 );
    /// Comparison operator for reverse iterators
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator!=( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 );
 
-} // namespace vecmem
+} } // namespace vecmem::details
 
 // Include the implementation.
-#include "vecmem/utils/reverse_iterator.ipp"
+#include "vecmem/containers/impl/reverse_iterator.ipp"

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -9,10 +9,12 @@
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/containers/details/reverse_iterator.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -59,7 +61,14 @@ namespace vecmem {
 
       /// Constructor, on top of a previously allocated/filled block of memory
       VECMEM_HOST_AND_DEVICE
-      device_array( data::vector_view< value_type > data );
+      device_array( const data::vector_view< value_type >& data );
+      /// Construct a const device array from a non-const data object
+      template< typename OTHERTYPE,
+                std::enable_if_t<
+                   details::is_same_nc< T, OTHERTYPE >::value,
+                   bool > = true >
+      VECMEM_HOST_AND_DEVICE
+      device_array( const data::vector_view< OTHERTYPE >& data );
       /// Copy constructor
       VECMEM_HOST_AND_DEVICE
       device_array( const device_array& parent );

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -8,7 +8,7 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
-#include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/containers/details/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -50,9 +50,10 @@ namespace vecmem {
       /// Constant forward iterator type
       typedef const_pointer     const_iterator;
       /// Reverse iterator type
-      typedef vecmem::reverse_iterator< iterator >       reverse_iterator;
+      typedef vecmem::details::reverse_iterator< iterator > reverse_iterator;
       /// Constant reverse iterator type
-      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+      typedef vecmem::details::reverse_iterator< const_iterator >
+         const_reverse_iterator;
 
       /// @}
 

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -8,7 +8,7 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
-#include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/containers/details/reverse_iterator.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -51,9 +51,10 @@ namespace vecmem {
       /// Constant forward iterator type
       typedef const_pointer     const_iterator;
       /// Reverse iterator type
-      typedef vecmem::reverse_iterator< iterator >       reverse_iterator;
+      typedef vecmem::details::reverse_iterator< iterator > reverse_iterator;
       /// Constant reverse iterator type
-      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+      typedef vecmem::details::reverse_iterator< const_iterator >
+         const_reverse_iterator;
 
       /// @}
 

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -9,10 +9,12 @@
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/containers/details/reverse_iterator.hpp"
+#include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -60,7 +62,14 @@ namespace vecmem {
 
       /// Constructor, on top of a previously allocated/filled block of memory
       VECMEM_HOST_AND_DEVICE
-      device_vector( data::vector_view< value_type > data );
+      device_vector( const data::vector_view< value_type >& data );
+      /// Construct a const device vector from a non-const data object
+      template< typename OTHERTYPE,
+                std::enable_if_t<
+                   details::is_same_nc< TYPE, OTHERTYPE >::value,
+                   bool > = true >
+      VECMEM_HOST_AND_DEVICE
+      device_vector( const data::vector_view< OTHERTYPE >& data );
       /// Copy constructor
       VECMEM_HOST_AND_DEVICE
       device_vector( const device_vector& parent );

--- a/core/include/vecmem/containers/impl/device_array.ipp
+++ b/core/include/vecmem/containers/impl/device_array.ipp
@@ -13,10 +13,23 @@ namespace vecmem {
 
    template< typename T, std::size_t N >
    VECMEM_HOST_AND_DEVICE
-   device_array< T, N >::device_array( data::vector_view< value_type > data )
+   device_array< T, N >::
+   device_array( const data::vector_view< value_type >& data )
    : m_ptr( data.m_ptr ) {
 
       assert( data.m_size >= N );
+   }
+
+   template< typename T, std::size_t N >
+   template< typename OTHERTYPE,
+             std::enable_if_t<
+                details::is_same_nc< T, OTHERTYPE >::value,
+                bool > >
+   VECMEM_HOST_AND_DEVICE
+   device_array< T, N >::
+   device_array( const data::vector_view< OTHERTYPE >& data )
+   : m_ptr( data.m_ptr ) {
+
    }
 
    template< typename T, std::size_t N >

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -14,7 +14,19 @@ namespace vecmem {
    template< typename TYPE >
    VECMEM_HOST_AND_DEVICE
    device_vector< TYPE >::
-   device_vector( data::vector_view< value_type > data )
+   device_vector( const data::vector_view< value_type >& data )
+   : m_size( data.m_size ), m_ptr( data.m_ptr ) {
+
+   }
+
+   template< typename TYPE >
+   template< typename OTHERTYPE,
+             std::enable_if_t<
+                details::is_same_nc< TYPE, OTHERTYPE >::value,
+                bool > >
+   VECMEM_HOST_AND_DEVICE
+   device_vector< TYPE >::
+   device_vector( const data::vector_view< OTHERTYPE >& data )
    : m_size( data.m_size ), m_ptr( data.m_ptr ) {
 
    }

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -8,10 +8,13 @@
 
 #pragma once
 
+// System include(s).
 #include <cassert>
 
 namespace vecmem {
+
     template<typename T>
+    VECMEM_HOST_AND_DEVICE
     jagged_device_vector<T>::jagged_device_vector(
         const data::jagged_vector_view<T> & data
     ) :
@@ -20,65 +23,267 @@ namespace vecmem {
     {
     }
 
-    template<typename T>
-    bool jagged_device_vector<T>::empty(
-        void
-    ) const {
-        return size() == 0;
+    template< typename T >
+    template< typename OTHERTYPE,
+              std::enable_if_t<
+                  details::is_same_nc< T, OTHERTYPE >::value,
+                  bool > >
+    VECMEM_HOST_AND_DEVICE
+    jagged_device_vector< T >::
+    jagged_device_vector( const data::jagged_vector_view< OTHERTYPE >& data )
+    : m_size( data.m_size ),
+      // This looks scarier than it really is. We "just" reinterpret a
+      // vecmem::data::vector_view<T> pointer to be seen as
+      // vecmem::data::vector_view<const T> instead.
+      m_ptr( reinterpret_cast<
+          typename data::jagged_vector_view< T >::pointer >( data.m_ptr ) ) {
+
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    jagged_device_vector< T >::
+    jagged_device_vector( const jagged_device_vector& parent )
+    : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {
+
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    jagged_device_vector< T >&
+    jagged_device_vector< T >::operator=( const jagged_device_vector& rhs ) {
+
+        // Check if anything needs to be done.
+        if( this == &rhs ) {
+            return *this;
+        }
+
+        // Make this object point at the same data in memory as the one we're
+        // copying from.
+        m_size = rhs.m_size;
+        m_ptr = rhs.m_ptr;
+
+        // Return this object.
+        return *this;
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::at( size_type pos ) {
+
+        // Check if the index is valid.
+        assert( pos < m_size );
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::at( size_type pos ) const {
+
+        // Check if the index is valid.
+        assert( pos < m_size );
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::operator[]( size_type pos ) {
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::operator[]( size_type pos ) const {
+
+        // Return a reference to the vector element.
+        return m_ptr[ pos ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::front() {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the first element of the vector.
+        return m_ptr[ 0 ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::front() const {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the first element of the vector.
+        return m_ptr[ 0 ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reference
+    jagged_device_vector< T >::back() {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the last element of the vector.
+        return m_ptr[ m_size - 1 ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reference
+    jagged_device_vector< T >::back() const {
+
+        // Make sure that there is at least one element in the outer vector.
+        assert( m_size > 0 );
+
+        // Return a reference to the last element of the vector.
+        return m_ptr[ m_size - 1 ];
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::iterator
+    jagged_device_vector< T >::begin() {
+
+        return iterator( m_ptr );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::begin() const {
+
+        return const_iterator( m_ptr );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::cbegin() const {
+
+        return begin();
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::iterator
+    jagged_device_vector< T >::end() {
+
+        return iterator( m_ptr + m_size );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::end() const {
+
+        return const_iterator( m_ptr + m_size );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_iterator
+    jagged_device_vector< T >::cend() const {
+
+        return end();
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reverse_iterator
+    jagged_device_vector< T >::rbegin() {
+
+        return reverse_iterator( end() );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::rbegin() const {
+
+        return const_reverse_iterator( end() );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::crbegin() const {
+
+        return rbegin();
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::reverse_iterator
+    jagged_device_vector< T >::rend() {
+
+        return reverse_iterator( begin() );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::rend() const {
+
+        return const_reverse_iterator( begin() );
+    }
+
+    template< typename T >
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector< T >::const_reverse_iterator
+    jagged_device_vector< T >::crend() const {
+
+        return rend();
     }
 
     template<typename T>
-    std::size_t jagged_device_vector<T>::size(
+    VECMEM_HOST_AND_DEVICE
+    bool jagged_device_vector<T>::empty(
+        void
+    ) const {
+        return m_size == 0;
+    }
+
+    template<typename T>
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::size(
         void
     ) const {
         return m_size;
     }
 
     template<typename T>
-    device_vector<T> jagged_device_vector<T>::at(
-        std::size_t i
-    ) {
-        assert(i < size());
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::max_size() const {
 
-        return device_vector<T>(m_ptr[i]);
+        return m_size;
     }
 
     template<typename T>
-    const device_vector<T> jagged_device_vector<T>::at(
-        std::size_t i
-    ) const {
-        assert(i < size());
+    VECMEM_HOST_AND_DEVICE
+    typename jagged_device_vector<T>::size_type
+    jagged_device_vector<T>::capacity() const {
 
-        return device_vector<T>(m_ptr[i]);
+        return m_size;
     }
 
-    template<typename T>
-    device_vector<T> jagged_device_vector<T>::operator[](
-        std::size_t i
-    ) {
-        return device_vector<T>(m_ptr[i]);
-    }
-
-    template<typename T>
-    const device_vector<T> jagged_device_vector<T>::operator[](
-        std::size_t i
-    ) const {
-        return device_vector<T>(m_ptr[i]);
-    }
-
-    template<typename T>
-    T & jagged_device_vector<T>::at(
-        std::size_t i,
-        std::size_t j
-    ) {
-        return at(i).at(j);
-    }
-
-    template<typename T>
-    const T & jagged_device_vector<T>::at(
-        std::size_t i,
-        std::size_t j
-    ) const {
-        return at(i).at(j);
-    }
-}
+} // namespace vecmem

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -1,0 +1,200 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem { namespace details {
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >::
+   pointer::pointer( const data_pointer data )
+   : m_vec( *data ) {
+
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename jagged_device_vector_iterator< TYPE >::value_type*
+   jagged_device_vector_iterator< TYPE >::pointer::operator->() {
+
+      return &m_vec;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   const typename jagged_device_vector_iterator< TYPE >::value_type*
+   jagged_device_vector_iterator< TYPE >::pointer::operator->() const {
+
+      return &m_vec;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >::jagged_device_vector_iterator()
+   : m_ptr( nullptr ) {
+
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator( data_pointer data )
+   : m_ptr( data ) {
+
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator( const jagged_device_vector_iterator& parent )
+   : m_ptr( parent.m_ptr ) {
+
+   }
+
+   template< typename TYPE >
+   template< typename T >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >::
+   jagged_device_vector_iterator(
+      const jagged_device_vector_iterator< T >& parent )
+   : m_ptr( parent.m_ptr ) {
+
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::
+   operator=( const jagged_device_vector_iterator& rhs ) {
+
+      // Check if anything needs to be done.
+      if( this == &rhs ) {
+         return *this;
+      }
+
+      // Perform the copy.
+      m_ptr = rhs.m_ptr;
+
+      // Return this object.
+      return *this;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename jagged_device_vector_iterator< TYPE >::reference
+   jagged_device_vector_iterator< TYPE >::operator*() const {
+
+      return *m_ptr;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename jagged_device_vector_iterator< TYPE >::pointer
+   jagged_device_vector_iterator< TYPE >::operator->() const {
+
+      return m_ptr;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename jagged_device_vector_iterator< TYPE >::reference
+   jagged_device_vector_iterator< TYPE >::
+   operator[]( difference_type n ) const {
+
+      return *( *this + n );
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator++() {
+
+      ++m_ptr;
+      return *this;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator++( int ) {
+
+      jagged_device_vector_iterator tmp = *this;
+      ++m_ptr;
+      return tmp;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator--() {
+
+      --m_ptr;
+      return *this;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator--( int ) {
+
+      jagged_device_vector_iterator tmp = *this;
+      --m_ptr;
+      return tmp;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator+( difference_type n ) const {
+
+      return jagged_device_vector_iterator( m_ptr + n );
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator+=( difference_type n ) {
+
+      m_ptr += n;
+      return *this;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >
+   jagged_device_vector_iterator< TYPE >::operator-( difference_type n ) const {
+
+      return jagged_device_vector_iterator( m_ptr - n );
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   jagged_device_vector_iterator< TYPE >&
+   jagged_device_vector_iterator< TYPE >::operator-=( difference_type n ) {
+
+      m_ptr -= n;
+      return *this;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   bool jagged_device_vector_iterator< TYPE >::
+   operator==( const jagged_device_vector_iterator& other ) const {
+
+      return ( m_ptr == other.m_ptr );
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   bool jagged_device_vector_iterator< TYPE >::
+   operator!=( const jagged_device_vector_iterator& other ) const {
+
+      return !( *this == other );
+   }
+
+} } // namespace vecmem::details

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -11,6 +11,7 @@
 namespace vecmem { namespace data {
 
     template<typename T>
+    VECMEM_HOST_AND_DEVICE
     jagged_vector_view<T>::jagged_vector_view(
         size_type size,
         pointer ptr
@@ -23,10 +24,9 @@ namespace vecmem { namespace data {
     template< typename T >
     template< typename OTHERTYPE,
               std::enable_if_t<
-                 ( ! std::is_same< T, OTHERTYPE >::value ) &&
-                 std::is_same< T,
-                               typename std::add_const< OTHERTYPE >::type >::value,
+                 details::is_same_nc< T, OTHERTYPE >::value,
                  bool > >
+    VECMEM_HOST_AND_DEVICE
     jagged_vector_view< T >::
     jagged_vector_view( const jagged_vector_view< OTHERTYPE >& parent )
     : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {

--- a/core/include/vecmem/containers/impl/reverse_iterator.ipp
+++ b/core/include/vecmem/containers/impl/reverse_iterator.ipp
@@ -9,7 +9,7 @@
 // Local include(s).
 #include "vecmem/utils/types.hpp"
 
-namespace vecmem {
+namespace vecmem { namespace details {
 
    template< typename Iterator >
    VECMEM_HOST_AND_DEVICE
@@ -181,6 +181,7 @@ namespace vecmem {
    }
 
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator==( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 ) {
 
@@ -188,10 +189,11 @@ namespace vecmem {
    }
 
    template< typename T >
+   VECMEM_HOST_AND_DEVICE
    bool operator!=( const reverse_iterator< T >& itr1,
                     const reverse_iterator< T >& itr2 ) {
 
       return !( itr1 == itr2 );
    }
 
-} // namespace vecmem
+} } // namespace vecmem::details

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -18,9 +18,7 @@ namespace vecmem { namespace data {
    template< typename TYPE >
    template< typename OTHERTYPE,
              std::enable_if_t<
-                ( ! std::is_same< TYPE, OTHERTYPE >::value ) &&
-                std::is_same< TYPE,
-                              typename std::add_const< OTHERTYPE >::type >::value,
+                details::is_same_nc< TYPE, OTHERTYPE >::value,
                 bool > >
    VECMEM_HOST_AND_DEVICE
    vector_view< TYPE >::vector_view( const vector_view< OTHERTYPE >& parent )

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/utils/reverse_iterator.hpp"
+#include "vecmem/containers/details/reverse_iterator.hpp"
 #include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
@@ -62,9 +62,10 @@ namespace vecmem {
       /// Constant forward iterator type
       typedef const_pointer      const_iterator;
       /// Reverse iterator type
-      typedef vecmem::reverse_iterator< iterator >       reverse_iterator;
+      typedef vecmem::details::reverse_iterator< iterator > reverse_iterator;
       /// Constant reverse iterator type
-      typedef vecmem::reverse_iterator< const_iterator > const_reverse_iterator;
+      typedef vecmem::details::reverse_iterator< const_iterator >
+         const_reverse_iterator;
 
       /// @}
 
@@ -303,7 +304,7 @@ namespace vecmem {
       VECMEM_HOST_AND_DEVICE
       void destruct( size_type pos );
 
-      /// Helper type for identifying an element in the
+      /// Helper type for identifying an element in the array
       struct ElementId {
          size_type m_index;
          pointer m_ptr;

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -43,4 +43,19 @@ namespace vecmem { namespace details {
       typedef T* type;
    };
 
+   /// Helper trait for detecting when a type is a non-const version of another
+   ///
+   /// This comes into play multiple times to enable certain constructors
+   /// conditionally through SFINAE.
+   ///
+   template< typename CTYPE, typename NCTYPE >
+   struct is_same_nc {
+      static constexpr bool value = false;
+   };
+
+   template< typename TYPE >
+   struct is_same_nc< const TYPE, TYPE > {
+      static constexpr bool value = true;
+   };
+
 } } // namespace vecmem::details

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -53,51 +53,76 @@ TEST_F(core_jagged_vector_view_test, row_size) {
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access) {
-    EXPECT_EQ(m_jag.at(0, 0), 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2);
-    EXPECT_EQ(m_jag.at(0, 2), 3);
-    EXPECT_EQ(m_jag.at(0, 3), 4);
-    EXPECT_EQ(m_jag.at(1, 0), 5);
-    EXPECT_EQ(m_jag.at(1, 1), 6);
-    EXPECT_EQ(m_jag.at(2, 0), 7);
-    EXPECT_EQ(m_jag.at(2, 1), 8);
-    EXPECT_EQ(m_jag.at(2, 2), 9);
-    EXPECT_EQ(m_jag.at(2, 3), 10);
+    EXPECT_EQ(m_jag.at(0).at(0), 1);
+    EXPECT_EQ(m_jag.at(0).at(1), 2);
+    EXPECT_EQ(m_jag.at(0).at(2), 3);
+    EXPECT_EQ(m_jag.at(0).at(3), 4);
+    EXPECT_EQ(m_jag.at(1).at(0), 5);
+    EXPECT_EQ(m_jag.at(1).at(1), 6);
+    EXPECT_EQ(m_jag.at(2).at(0), 7);
+    EXPECT_EQ(m_jag.at(2).at(1), 8);
+    EXPECT_EQ(m_jag.at(2).at(2), 9);
+    EXPECT_EQ(m_jag.at(2).at(3), 10);
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access_const) {
-    EXPECT_EQ(m_jag.at(0, 0), 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2);
-    EXPECT_EQ(m_jag.at(0, 2), 3);
-    EXPECT_EQ(m_jag.at(0, 3), 4);
-    EXPECT_EQ(m_jag.at(1, 0), 5);
-    EXPECT_EQ(m_jag.at(1, 1), 6);
-    EXPECT_EQ(m_jag.at(2, 0), 7);
-    EXPECT_EQ(m_jag.at(2, 1), 8);
-    EXPECT_EQ(m_jag.at(2, 2), 9);
-    EXPECT_EQ(m_jag.at(2, 3), 10);
+    const vecmem::jagged_device_vector<int>& jag = m_jag;
+    EXPECT_EQ(jag.at(0).at(0), 1);
+    EXPECT_EQ(jag.at(0).at(1), 2);
+    EXPECT_EQ(jag.at(0).at(2), 3);
+    EXPECT_EQ(jag.at(0).at(3), 4);
+    EXPECT_EQ(jag.at(1).at(0), 5);
+    EXPECT_EQ(jag.at(1).at(1), 6);
+    EXPECT_EQ(jag.at(2).at(0), 7);
+    EXPECT_EQ(jag.at(2).at(1), 8);
+    EXPECT_EQ(jag.at(2).at(2), 9);
+    EXPECT_EQ(jag.at(2).at(3), 10);
 }
 
 TEST_F(core_jagged_vector_view_test, mutate) {
-    m_jag.at(0, 0) *= 2;
-    m_jag.at(0, 1) *= 2;
-    m_jag.at(0, 2) *= 2;
-    m_jag.at(0, 3) *= 2;
-    m_jag.at(1, 0) *= 2;
-    m_jag.at(1, 1) *= 2;
-    m_jag.at(2, 0) *= 2;
-    m_jag.at(2, 1) *= 2;
-    m_jag.at(2, 2) *= 2;
-    m_jag.at(2, 3) *= 2;
+    m_jag.at(0).at(0) *= 2;
+    m_jag.at(0).at(1) *= 2;
+    m_jag.at(0).at(2) *= 2;
+    m_jag.at(0).at(3) *= 2;
+    m_jag.at(1).at(0) *= 2;
+    m_jag.at(1).at(1) *= 2;
+    m_jag.at(2).at(0) *= 2;
+    m_jag.at(2).at(1) *= 2;
+    m_jag.at(2).at(2) *= 2;
+    m_jag.at(2).at(3) *= 2;
 
-    EXPECT_EQ(m_jag.at(0, 0), 2 * 1);
-    EXPECT_EQ(m_jag.at(0, 1), 2 * 2);
-    EXPECT_EQ(m_jag.at(0, 2), 2 * 3);
-    EXPECT_EQ(m_jag.at(0, 3), 2 * 4);
-    EXPECT_EQ(m_jag.at(1, 0), 2 * 5);
-    EXPECT_EQ(m_jag.at(1, 1), 2 * 6);
-    EXPECT_EQ(m_jag.at(2, 0), 2 * 7);
-    EXPECT_EQ(m_jag.at(2, 1), 2 * 8);
-    EXPECT_EQ(m_jag.at(2, 2), 2 * 9);
-    EXPECT_EQ(m_jag.at(2, 3), 2 * 10);
+    EXPECT_EQ(m_jag.at(0).at(0), 2 * 1);
+    EXPECT_EQ(m_jag.at(0).at(1), 2 * 2);
+    EXPECT_EQ(m_jag.at(0).at(2), 2 * 3);
+    EXPECT_EQ(m_jag.at(0).at(3), 2 * 4);
+    EXPECT_EQ(m_jag.at(1).at(0), 2 * 5);
+    EXPECT_EQ(m_jag.at(1).at(1), 2 * 6);
+    EXPECT_EQ(m_jag.at(2).at(0), 2 * 7);
+    EXPECT_EQ(m_jag.at(2).at(1), 2 * 8);
+    EXPECT_EQ(m_jag.at(2).at(2), 2 * 9);
+    EXPECT_EQ(m_jag.at(2).at(3), 2 * 10);
+}
+
+TEST_F(core_jagged_vector_view_test, iterator) {
+    std::size_t i = 0;
+    for( auto itr = m_jag.begin(); itr != m_jag.end(); ++itr ) {
+        i += itr->size();
+    }
+    EXPECT_EQ( i, 16 );
+}
+
+TEST_F(core_jagged_vector_view_test, reverse_iterator) {
+    std::size_t i = 0;
+    for( auto itr = m_jag.rbegin(); itr != m_jag.rend(); ++itr ) {
+        i += itr->size();
+    }
+    EXPECT_EQ( i, 16 );
+}
+
+TEST_F(core_jagged_vector_view_test, value_iteration) {
+    std::size_t i = 0;
+    for( const auto& innerv : m_jag ) {
+        i += innerv.size();
+    }
+    EXPECT_EQ( i, 16 );
 }

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -40,18 +40,18 @@ class cuda_jagged_vector_view_test : public testing::Test {
 TEST_F(cuda_jagged_vector_view_test, mutate_in_kernel) {
     doubleJagged(m_data);
 
-    EXPECT_EQ(m_vec.at(0).at(0), 2);
+    EXPECT_EQ(m_vec.at(0).at(0), 202);
     EXPECT_EQ(m_vec.at(0).at(1), 4);
     EXPECT_EQ(m_vec.at(0).at(2), 6);
     EXPECT_EQ(m_vec.at(0).at(3), 8);
-    EXPECT_EQ(m_vec.at(1).at(0), 10);
+    EXPECT_EQ(m_vec.at(1).at(0), 210);
     EXPECT_EQ(m_vec.at(1).at(1), 12);
-    EXPECT_EQ(m_vec.at(2).at(0), 14);
+    EXPECT_EQ(m_vec.at(2).at(0), 214);
     EXPECT_EQ(m_vec.at(2).at(1), 16);
     EXPECT_EQ(m_vec.at(2).at(2), 18);
     EXPECT_EQ(m_vec.at(2).at(3), 20);
-    EXPECT_EQ(m_vec.at(3).at(0), 22);
-    EXPECT_EQ(m_vec.at(5).at(0), 24);
+    EXPECT_EQ(m_vec.at(3).at(0), 222);
+    EXPECT_EQ(m_vec.at(5).at(0), 224);
     EXPECT_EQ(m_vec.at(5).at(1), 26);
     EXPECT_EQ(m_vec.at(5).at(2), 28);
     EXPECT_EQ(m_vec.at(5).at(3), 30);

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -24,7 +24,19 @@ void doubleJaggedKernel(
     }
 
     for (std::size_t i = 0; i < jag.at(t).size(); ++i) {
-        jag.at(t, i) *= 2;
+        jag.at(t).at(i) *= 2;
+    }
+    __syncthreads();
+    // Iterate over all outer vectors.
+    for( auto itr1 = jag.rbegin(); itr1 != jag.rend(); ++itr1 ) {
+        if( ( jag[ t ].size() > 0 ) && ( itr1->size() > 1 ) ) {
+            // Iterate over all inner vectors, skipping the first elements.
+            // Since those are being updated at the same time, by other threads.
+            for( auto itr2 = itr1->rbegin(); itr2 != ( itr1->rend() - 1 );
+                 ++itr2 ) {
+                jag[ t ].front() += *itr2;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This is meant to replace #54.

After a long discussion in that PR, (for now) `vecmem::jagged_device_vector` is implemented with no unsafe type conversions. Returning `vecmem::device_vector` objects by value from many of its functions instead.

This was implemented through a number of technical changes:
  - Renamed `vecmem::reverse_iterator` to `vecmem::details::reverse_iterator`, and moved it under `vecmem/containers/details/`. This is so the 2 iterators of the project would end up side-by-side.
  - Introduced the `vecmem::details::is_same_nc` trait, and taught `vecmem::device_array` and `vecmem::device_vector` using it how to create "constant objects" on top of non-const data. Which was absolutely necessary in `vecmem::device_vector` for `vecmem::jagged_device_vector`. (And as long as I was doing it there, I also updated `vecmem::device_array` in the same way.)
  - Introduced a custom `vecmem::details::jagged_device_vector_iterator` type that provides a random access forward iterator for `vecmem::jagged_device_vector`.
 
With all these in place I largely re-wrote `vecmem::jagged_device_vector` to provide an interface similar to that of `vecmem::device_vector`.

Finally, I updated the relevant tests to use/test the new interface of `vecmem::jagged_device_vector`.