### PR TITLE
vecmem::data::jagged_vector_buffer Introduction, main branch (2021.03.27.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,8 @@ vecmem_add_library( vecmem_core core SHARED
    "include/vecmem/containers/vector.hpp"
    "include/vecmem/containers/impl/vector.ipp"
    # Data holding/transporting types.
+   "include/vecmem/containers/data/jagged_vector_buffer.hpp"
+   "include/vecmem/containers/impl/jagged_vector_buffer.ipp"
    "include/vecmem/containers/data/jagged_vector_data.hpp"
    "include/vecmem/containers/impl/jagged_vector_data.ipp"
    "include/vecmem/containers/data/jagged_vector_view.hpp"

--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -60,7 +60,9 @@ namespace vecmem::data {
       ///        be host accessible.
       /// @param host_access_resource An optional host accessible memory
       ///        resource. Needed if @c resource is not host accessible.
-      template< typename OTHERTYPE >
+      template< typename OTHERTYPE,
+                std::enable_if_t< std::is_convertible< TYPE, OTHERTYPE >::value,
+                                  bool > = true >
       jagged_vector_buffer( const jagged_vector_view< OTHERTYPE >& other,
                             memory_resource& resource,
                             memory_resource* host_access_resource = nullptr );

--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -1,0 +1,105 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/memory/deallocator.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+
+// System include(s).
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace vecmem::data {
+
+   /// Object owning all the data of a jagged vector
+   ///
+   /// This type is needed for the explicit memory management of jagged vectors.
+   ///
+   template< typename TYPE >
+   class jagged_vector_buffer : public jagged_vector_view< TYPE > {
+
+   public:
+      /// The base type used by this class
+      typedef jagged_vector_view< TYPE > base_type;
+      /// Use the base class's @c size_type
+      typedef typename base_type::size_type size_type;
+      /// Use the base class's @c value_type
+      typedef typename base_type::value_type value_type;
+      /// Pointer type to the jagged array
+      typedef typename base_type::pointer pointer;
+
+      /// @name Checks on the type of the array element
+      /// @{
+
+      /// Make sure that the template type does not have a custom destructor
+      static_assert( std::is_trivially_destructible< TYPE >::value,
+                     "vecmem::data::jagged_vector_buffer can not handle types "
+                     "with custom destructors" );
+      /// Make sure that @c vecmem::data::vector_view does not have a custom
+      /// destructor
+      static_assert( std::is_trivially_destructible< value_type >::value,
+                     "vecmem::data::jagged_vector_buffer can not handle types "
+                     "with custom destructors" );
+
+      /// @}
+
+      /// Constructor from an existing @c vecmem::data::jagged_vector_view
+      ///
+      /// @param other The existing @c vecmem::data::jagged_vector_view object
+      ///        that this buffer should mirror.
+      /// @param resource The device accessible memory resource, which may also
+      ///        be host accessible.
+      /// @param host_access_resource An optional host accessible memory
+      ///        resource. Needed if @c resource is not host accessible.
+      template< typename OTHERTYPE >
+      jagged_vector_buffer( const jagged_vector_view< OTHERTYPE >& other,
+                            memory_resource& resource,
+                            memory_resource* host_access_resource = nullptr );
+
+      /// Constructor from a vector of ("inner vector") sizes
+      ///
+      /// @param sizes Simple vector holding the sizes of the "inner vectors"
+      ///        for the jagged vector buffer.
+      /// @param resource The device accessible memory resource, which may also
+      ///        be host accessible.
+      /// @param host_access_resource An optional host accessible memory
+      ///        resource. Needed if @c resource is not host accessible.
+      jagged_vector_buffer( const std::vector< std::size_t >& sizes,
+                            memory_resource& resource,
+                            memory_resource* host_access_resource = nullptr );
+
+      /// Access the host accessible array describing the inner vectors
+      ///
+      /// This may or may not return the same pointer that
+      /// @c vecmem::data::jagged_vector_view::m_ptr holds. If the buffer is set
+      /// up on top of a "shared" (both host- and device accessible) memory
+      /// resource, then the two will be the same. If not, then
+      /// @c vecmem::data::jagged_vector_view::m_ptr is set up to point at the
+      /// device accessible array, and this function returns a pointer to the
+      /// host accessible one.
+      ///
+      pointer host_ptr() const;
+
+   private:
+      /// Data object for the @c vecmem::data::vector_view array
+      std::unique_ptr< value_type, details::deallocator > m_outer_memory;
+      /// Data object for the @c vecmem::data::vector_view array on the host
+      std::unique_ptr< value_type, details::deallocator > m_outer_host_memory;
+      /// Data object owning the memory of the "inner vectors"
+      std::unique_ptr< TYPE, details::deallocator > m_inner_memory;
+
+   }; // class jagged_vector_buffer
+
+} // namespace vecmem::data
+
+// Include the implementation.
+#include "vecmem/containers/impl/jagged_vector_buffer.ipp"

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -36,7 +36,7 @@ namespace vecmem::data {
 
       /// Make sure that the template type does not have a custom destructor
       static_assert( std::is_trivially_destructible< TYPE >::value,
-                     "vecmem::details::vector_buffer can not handle types with "
+                     "vecmem::data::vector_buffer can not handle types with "
                      "custom destructors" );
 
       /// @}

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -34,9 +34,9 @@ namespace vecmem {
       return result;
    }
 
-   template< typename TYPE, typename ALLOC >
+   template< typename TYPE, typename ALLOC1, typename ALLOC2 >
    data::jagged_vector_data< TYPE >
-   get_data( std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+   get_data( std::vector< std::vector< TYPE, ALLOC1 >, ALLOC2 >& vec,
              memory_resource* resource ) {
 
       // This function needs a non-null memory resource pointer.
@@ -80,9 +80,9 @@ namespace vecmem {
       return result;
    }
 
-   template< typename TYPE, typename ALLOC >
+   template< typename TYPE, typename ALLOC1, typename ALLOC2 >
    data::jagged_vector_data< const TYPE >
-   get_data( const std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+   get_data( const std::vector< std::vector< TYPE, ALLOC1 >, ALLOC2 >& vec,
              memory_resource* resource ) {
 
       // This function needs a non-null memory resource pointer.

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -66,7 +66,9 @@ namespace {
 namespace vecmem::data {
 
    template< typename TYPE >
-   template< typename OTHERTYPE >
+   template< typename OTHERTYPE,
+             std::enable_if_t< std::is_convertible< TYPE, OTHERTYPE >::value,
+                               bool > >
    jagged_vector_buffer< TYPE >::
    jagged_vector_buffer( const jagged_vector_view< OTHERTYPE >& other,
                          memory_resource& resource,
@@ -74,10 +76,6 @@ namespace vecmem::data {
    : jagged_vector_buffer( ::get_sizes( other ), resource,
                            host_access_resource ) {
 
-      // A sanity check.
-      static_assert( sizeof( TYPE ) == sizeof( OTHERTYPE ),
-                     "Can not create vecmem::data::jagged_vector_buffer from "
-                     "incompatible vecmem::data::jagged_vector_view type" );
    }
 
    template< typename TYPE >

--- a/core/include/vecmem/containers/jagged_vector.hpp
+++ b/core/include/vecmem/containers/jagged_vector.hpp
@@ -36,10 +36,10 @@ namespace vecmem {
     get_data( jagged_vector< TYPE >& vec, memory_resource* resource = nullptr );
 
     /// Helper function creating a @c vecmem::data::jagged_vector_data object
-    template< typename TYPE, typename ALLOC >
+    template< typename TYPE, typename ALLOC1, typename ALLOC2 >
     VECMEM_HOST
     data::jagged_vector_data< TYPE >
-    get_data( std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+    get_data( std::vector< std::vector< TYPE, ALLOC1 >, ALLOC2 >& vec,
               memory_resource* resource );
 
     /// Helper function creating a @c vecmem::data::jagged_vector_data object
@@ -50,10 +50,10 @@ namespace vecmem {
               memory_resource* resource = nullptr );
 
     /// Helper function creating a @c vecmem::data::jagged_vector_data object
-    template< typename TYPE, typename ALLOC >
+    template< typename TYPE, typename ALLOC1, typename ALLOC2 >
     VECMEM_HOST
     data::jagged_vector_data< const TYPE >
-    get_data( const std::vector< std::vector< TYPE, ALLOC >, ALLOC >& vec,
+    get_data( const std::vector< std::vector< TYPE, ALLOC1 >, ALLOC2 >& vec,
               memory_resource* resource );
 
 } // namespace vecmem

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -6,10 +6,13 @@
  */
 
 // Local include(s).
+#include "vecmem/containers/data/jagged_vector_buffer.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_buffer.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/contiguous_memory_resource.hpp"
 #include "vecmem/memory/host_memory_resource.hpp"
 
 // GoogleTest include(s).
@@ -21,6 +24,10 @@
 
 /// Test case for the custom device container types
 class core_device_container_test : public testing::Test {
+
+protected:
+   /// Memory resource for the test(s)
+   vecmem::host_memory_resource m_resource;
 
 }; // class core_device_container_test
 
@@ -64,9 +71,8 @@ TEST_F( core_device_container_test, vector_buffer ) {
    auto host_data = vecmem::get_data( host_vector );
 
    // Create an "owning copy" of the host vector's memory.
-   vecmem::host_memory_resource resource;
    vecmem::data::vector_buffer< int >
-      device_data( host_data.m_size, resource );
+      device_data( host_data.m_size, m_resource );
    memcpy( device_data.m_ptr, host_data.m_ptr,
            host_data.m_size * sizeof( int ) );
 
@@ -74,4 +80,43 @@ TEST_F( core_device_container_test, vector_buffer ) {
    EXPECT_EQ( device_data.m_size, host_vector.size() );
    EXPECT_EQ( memcmp( host_data.m_ptr, device_data.m_ptr,
                       host_data.m_size * sizeof( int ) ), 0 );
+}
+
+/// Test(s) for @c vecmem::data::jagged_vector_buffer
+TEST_F( core_device_container_test, jagged_vector_buffer ) {
+
+   // Create a dummy jagged vector in regular host memory.
+   std::vector< std::vector< int > > host_vector {
+      { 1, 2, 3, 4, 5 },
+      { 6, 7 },
+      { 8, 9, 10, 11 },
+      { 12, 13, 14, 15, 16, 17, 18 },
+      {},
+      { 19, 20 } };
+   auto host_data = vecmem::get_data( host_vector, &m_resource );
+
+   // Set up an "alternative" memory resource for the test.
+   vecmem::contiguous_memory_resource cresource( m_resource, 16384 );
+
+   // Create a buffer to hold the same data.
+   vecmem::data::jagged_vector_buffer< int >
+      device_data1( host_data, m_resource );
+   vecmem::data::jagged_vector_buffer< int >
+      device_data2( host_data, m_resource, &cresource );
+
+   // Test the internal state of the buffer.
+   EXPECT_EQ( device_data1.m_ptr, device_data1.host_ptr() );
+   EXPECT_EQ( device_data1.m_size, host_vector.size() );
+   EXPECT_NE( device_data2.m_ptr, device_data2.host_ptr() );
+   EXPECT_EQ( device_data2.m_size, host_vector.size() );
+   for( std::size_t i = 0; i < host_vector.size(); ++i ) {
+      EXPECT_EQ( device_data1.host_ptr()[ i ].m_size, host_vector[ i ].size() );
+      EXPECT_EQ( device_data2.host_ptr()[ i ].m_size, host_vector[ i ].size() );
+   }
+   for( std::size_t i = 0; i < host_vector.size() - 1; ++i ) {
+      EXPECT_EQ( device_data1.host_ptr()[ i ].m_ptr + host_vector[ i ].size(),
+                 device_data1.host_ptr()[ i + 1 ].m_ptr );
+      EXPECT_EQ( device_data2.host_ptr()[ i ].m_ptr + host_vector[ i ].size(),
+                 device_data2.host_ptr()[ i + 1 ].m_ptr );
+   }
 }


### PR DESCRIPTION
In this I tried to figure out how to hold the data of a jagged vector in memory independent of the `vecmem::jagged_vector` that created/filled that memory in the first place.

After quite some deliberation I decided that it would have to be done something like this. That the `vecmem::data::jagged_vector_buffer` object would have to hold 1 or 2 `vecmem::data::vector_view` arrays, depending on what sort of memory resource(s) it gets.

Allocating the memory for holding the "inner vector elements" is easy. `vecmem::data::jagged_vector_buffer` just needs to allocate a 1 dimensional array large enough to hold all of those elements. Since we don't need to be able to read/write that array from host code, that's easy to do.

But the `vecmem::data::vector_view` array we absolutely need host access to. As it needs to be set up to properly point at points inside of the earlier mentioned array. In `vecmem::data::jagged_vector_data` we do this implicitly. Requiring the memory resource passed to `vecmem::data::jagged_vector_data` to **always** provide host-accessible memory. But with `vecmem::data::jagged_vector_buffer`, just like with `vecmem::data::vector_buffer`, I also want to be able to use non-host-accessible memory.

To resolve this I've set up `vecmem::data::jagged_vector_buffer` to allocate either 1 or 2 `vecmem::data::vector_view` arrays, based on how it is constructed. If it is constructed using a single `vecmem::memory_resource`, then it will assume that it is a host-accessible memory resource. If one wants to use a memory resource that's not host-accessible, then both that non-host-accessible, and a host-accessible memory resource needs to be provided to the constructor of `vecmem::data::jagged_vector_buffer`.

In this setup the underlying `vecmem::data::jagged_vector_view` member variables are set up to point to "stuff" that needs to be transferred to the device to use the jagged vector. While `vecmem::data::jagged_vector_buffer::host_ptr()` returns a pointer to the `vecmem::data::vector_view` array that's always (meant to be) host accessible.

The idea here is that the language specific memory copy functions will need to not only arrange for the copy of the array holding the "internal vector elements", but also the copy of the host-accessible `vecmem::data::vector_view` array into the non-host-accessible one.

A couple of things to take note of:
  - `vecmem::data::jagged_vector_buffer` does not inherit from `vecmem::data::jagged_vector_data`, but rather from `vecmem::data::jagged_vector_view`. I'm not too thrilled about this, but I couldn't find a setup where we wouldn't need 3 different classes. I'm ready to be proven wrong though.
  - `vemcem::data::jagged_vector_buffer` does not provide direct access to its "internal vector array". Clients of this object are expected to access that array through the `vecmem::data::vector_view` objects accessible through `vecmem::data::jagged_vector_buffer::host_ptr()`. Deciding at runtime how many separate copy operations they will need to perform the memory transfer. (This is where `vecmem::contiguous_memory_resource` should come into play as well. But I didn't try that in practice just yet.)