### PR TITLE
Debug Message Print, main branch (2021.03.30.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -9,6 +9,7 @@ include_guard( GLOBAL )
 
 # Include the helper function(s).
 include( vecmem-functions )
+include( vecmem-options )
 
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
@@ -29,3 +30,7 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "-pedantic" )
 endif()
+
+# Add the VECMEM_DEBUG_MSG_LVL flag.
+vecmem_add_flag( CMAKE_CXX_FLAGS
+   "-DVECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}" )

--- a/cmake/vecmem-compiler-options-cuda.cmake
+++ b/cmake/vecmem-compiler-options-cuda.cmake
@@ -9,6 +9,7 @@ include_guard( GLOBAL )
 
 # Include the helper function(s).
 include( vecmem-functions )
+include( vecmem-options )
 
 # Set up the used C++ standard(s).
 set( CMAKE_CUDA_STANDARD 14 CACHE STRING "The (CUDA) C++ standard to use" )
@@ -23,3 +24,7 @@ vecmem_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
 
 # More rigorous tests for the Debug builds.
 vecmem_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+
+# Add the VECMEM_DEBUG_MSG_LVL flag.
+vecmem_add_flag( CMAKE_CUDA_FLAGS
+   "-DVECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}" )

--- a/cmake/vecmem-compiler-options-hip.cmake
+++ b/cmake/vecmem-compiler-options-hip.cmake
@@ -9,6 +9,7 @@ include_guard( GLOBAL )
 
 # Include the helper function(s).
 include( vecmem-functions )
+include( vecmem-options )
 
 # Set up the used C++ standard(s).
 set( CMAKE_HIP_STANDARD 14 CACHE STRING "The (HIP) C++ standard to use" )
@@ -18,6 +19,8 @@ if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wall" )
       vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wextra" )
+      vecmem_add_flag( CMAKE_HIP_FLAGS_${mode}
+         "-DVECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}" )
    endforeach()
 endif()
 

--- a/cmake/vecmem-compiler-options-sycl.cmake
+++ b/cmake/vecmem-compiler-options-sycl.cmake
@@ -9,6 +9,7 @@ include_guard( GLOBAL )
 
 # Include the helper function(s).
 include( vecmem-functions )
+include( vecmem-options )
 
 # Set up the used C++ standard(s).
 set( CMAKE_SYCL_STANDARD 17 CACHE STRING "The (SYCL) C++ standard to use" )
@@ -18,6 +19,8 @@ foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wall" )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wextra" )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wno-unknown-cuda-version" )
+   vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode}
+      "-DVECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}" )
 endforeach()
 
 # More rigorous tests for the Debug builds.

--- a/cmake/vecmem-options.cmake
+++ b/cmake/vecmem-options.cmake
@@ -27,3 +27,7 @@ cmake_dependent_option( VECMEM_BUILD_HIP_LIBRARY
 cmake_dependent_option( VECMEM_BUILD_SYCL_LIBRARY
    "Build the vecmem::sycl library" ON
    "CMAKE_SYCL_COMPILER" OFF )
+
+# Debug message output level in the code.
+set( VECMEM_DEBUG_MSG_LVL 0 CACHE STRING
+   "Debug message output level" )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -53,5 +53,6 @@ vecmem_add_library( vecmem_core core SHARED
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
    # Utilities.
+   "include/vecmem/utils/debug.hpp"
    "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -6,6 +6,9 @@
  */
 #pragma once
 
+// Local include(s).
+#include "vecmem/utils/debug.hpp"
+
 // System include(s).
 #include <cassert>
 
@@ -17,6 +20,9 @@ namespace vecmem {
    device_vector( const data::vector_view< value_type >& data )
    : m_size( data.m_size ), m_ptr( data.m_ptr ) {
 
+      VECMEM_DEBUG_MSG( 5, "Created vecmem::device_vector with size %i from "
+                        "pointer %p", static_cast< int >( m_size ),
+                        static_cast< const void* >( m_ptr ) );
    }
 
    template< typename TYPE >
@@ -29,6 +35,9 @@ namespace vecmem {
    device_vector( const data::vector_view< OTHERTYPE >& data )
    : m_size( data.m_size ), m_ptr( data.m_ptr ) {
 
+      VECMEM_DEBUG_MSG( 5, "Created vecmem::device_vector with size %i from "
+                        "pointer %p", static_cast< int >( m_size ),
+                        static_cast< const void* >( m_ptr ) );
    }
 
    template< typename TYPE >
@@ -36,6 +45,9 @@ namespace vecmem {
    device_vector< TYPE >::device_vector( const device_vector& parent )
    : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {
 
+      VECMEM_DEBUG_MSG( 5, "Created vecmem::device_vector with size %i from "
+                        "pointer %p", static_cast< int >( m_size ),
+                        static_cast< const void* >( m_ptr ) );
    }
 
    template< typename TYPE >

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -1,0 +1,94 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+/// Function name to use for printout operations
+#ifndef VECMEM_PRINTF
+#   if defined(SYCL_LANGUAGE_VERSION) || defined(CL_SYCL_LANGUAGE_VERSION)
+#      define VECMEM_PRINTF cl::sycl::ONEAPI::experimental::printf
+#   else
+#      define VECMEM_PRINTF printf
+#   endif
+#endif // not VECMEM_PRINTF
+
+// Attribute(s) to use on the printed message character string variables
+#ifndef VECMEM_MSG_ATTRIBUTES
+#   ifdef __SYCL_DEVICE_ONLY__
+#      define VECMEM_MSG_ATTRIBUTES __attribute__((opencl_constant))
+#   else
+#      define VECMEM_MSG_ATTRIBUTES
+#   endif
+#endif // not VECMEM_MSG_ATTRIBUTES
+
+/// Set a default maximum level for the printed messages
+#ifndef VECMEM_DEBUG_MSG_LVL
+#   define VECMEM_DEBUG_MSG_LVL 0
+#endif // not VECMEM_DEBUG_MSG_LVL
+
+/// Helper macro for using the underlying @c printf function
+///
+/// This intermediate function is really only necessary for SYCL compatibility.
+/// Since one needs to very carefully declare the character constant that would
+/// be given to the oneAPI printf function.
+///
+#define __VECMEM_PRINT_MSG(MSG, ...)                                           \
+   do {                                                                        \
+      const VECMEM_MSG_ATTRIBUTES char __msg[] = MSG;                          \
+      VECMEM_PRINTF( __msg, __VA_ARGS__ );                                     \
+   } while( false )
+
+/// Print macro for "level 1" debug messages
+#if VECMEM_DEBUG_MSG_LVL >= 1
+#   define __VECMEM_PRINT_1(MSG, ...)                                          \
+           __VECMEM_PRINT_MSG(MSG, __VA_ARGS__ )
+#else
+#   define __VECMEM_PRINT_1(MSG, ...)
+#endif
+
+/// Print macro for "level 2" debug messages
+#if VECMEM_DEBUG_MSG_LVL >= 2
+#   define __VECMEM_PRINT_2(MSG, ...)                                          \
+           __VECMEM_PRINT_MSG(MSG, __VA_ARGS__ )
+#else
+#   define __VECMEM_PRINT_2(MSG, ...)
+#endif
+
+/// Print macro for "level 3" debug messages
+#if VECMEM_DEBUG_MSG_LVL >= 3
+#   define __VECMEM_PRINT_3(MSG, ...)                                          \
+           __VECMEM_PRINT_MSG(MSG, __VA_ARGS__ )
+#else
+#   define __VECMEM_PRINT_3(MSG, ...)
+#endif
+
+/// Print macro for "level 4" debug messages
+#if VECMEM_DEBUG_MSG_LVL >= 4
+#   define __VECMEM_PRINT_4(MSG, ...)                                          \
+           __VECMEM_PRINT_MSG(MSG, __VA_ARGS__ )
+#else
+#   define __VECMEM_PRINT_4(MSG, ...)
+#endif
+
+/// Print macro for "level 5" debug messages
+#if VECMEM_DEBUG_MSG_LVL >= 5
+#   define __VECMEM_PRINT_5(MSG, ...)                                          \
+           __VECMEM_PRINT_MSG(MSG, __VA_ARGS__ )
+#else
+#   define __VECMEM_PRINT_5(MSG, ...)
+#endif
+
+/// Helper macro for printing debug messages from "any" code
+///
+/// Since CUDA, HIP and SYCL all provide "printf style" functions for this, the
+/// macro also provides an interface like @c printf canonically does.
+///
+/// @param LVL The integer message level to use. It must have a value in the
+///            [1-5] range.
+/// @param MSG The text message to use, before the variadic arguments
+///
+#define VECMEM_DEBUG_MSG(LVL, MSG, ...)                                        \
+   __VECMEM_PRINT_##LVL( "%s:%i " MSG "\n", __FILE__, __LINE__, __VA_ARGS__ )

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
 // Local include(s).
 #include "vecmem/containers/array.hpp"
 #include "vecmem/containers/const_device_array.hpp"
@@ -16,9 +19,6 @@
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
-
-// SYCL include(s).
-#include <CL/sycl.hpp>
 
 /// Test fixture for the on-device vecmem container tests
 class sycl_containers_test : public testing::Test {};


### PR DESCRIPTION
This is my proposal following #57.

As discussed in #57, which messages to print are decided at compile time. In a slightly fancy way. :stuck_out_tongue: With the `VECMEM_DEBUG_MSG_LVL` macro value deciding which message levels to print.

To cut right to the chase: I couldn't make it work in HIP device code. :frowning: I struggled with it for a while, but by now I gave up. :frowning:

Everywhere else I could... So in host code and CUDA/SYCL device code the printouts seem to work fine.

On top of the `VECMEM_DEBUG_MSG_LVL` compiler macro, I also introduced the `VECMEM_DEBUG_MSG_LVL` CMake cache variable. It controls the value of `VECMEM_DEBUG_MSG_LVL` for all compiler languages.

P.S. With HIP I observe the following:
  - In "native" `HIP_PLATFORM=hcc` mode (on an AMD card) the test hangs.
  - In `HIP_PLATFORM=nvcc` mode (on an NVidia card) the test runs, but no printout appears.

As a result I really suspect (a) bug(s) in the HIP code. :frowning: