### PR TITLE
VECMEM_DEBUG_MSG Update, main branch (2021.03.31.)

### DIFF
--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -81,6 +81,12 @@
 #   define __VECMEM_PRINT_5(MSG, ...)
 #endif
 
+/// Macro used for handling the case of printing a pure/simple character string
+#define __VECMEM_DEBUG_MSG(LVL, MSG, ...)                                      \
+   __VECMEM_PRINT_##LVL( "[vecmem] %s:%i " MSG "\n%s",                         \
+                         ( static_cast< const char* >( __FILE__ ) +            \
+                           VECMEM_SOURCE_DIR_LENGTH ), __LINE__, __VA_ARGS__ )
+
 /// Helper macro for printing debug messages from "any" code
 ///
 /// Since CUDA, HIP and SYCL all provide "printf style" functions for this, the
@@ -88,9 +94,7 @@
 ///
 /// @param LVL The integer message level to use. It must have a value in the
 ///            [1-5] range.
-/// @param MSG The text message to use, before the variadic arguments
+/// @param ... The "printf style" arguments.
 ///
-#define VECMEM_DEBUG_MSG(LVL, MSG, ...)                                        \
-   __VECMEM_PRINT_##LVL( "[vecmem] %s:%i " MSG "\n",                           \
-                         ( static_cast< const char* >( __FILE__ ) +            \
-                           VECMEM_SOURCE_DIR_LENGTH ), __LINE__, __VA_ARGS__ )
+#define VECMEM_DEBUG_MSG(LVL, ...)                                             \
+   __VECMEM_DEBUG_MSG(LVL, __VA_ARGS__, "")


### PR DESCRIPTION
Made `VECMEM_DEBUG_MSG` work without printing any variable values. Previously the macro would always need to receive at least one argument after the string literal that describes the format of the printout.

I tried to use the `##__VA_ARGS__` GNU extension at first, but that does not work with all compilers under all circumstances. :frowning: Not without making the code super compiler specific. This trick on the other hand should work everywhere by passing a useless empty string as an argument to `__VECMEM_DEBUG_MSG` even when the user didn't provide any arguments to `VECMEM_DEBUG_MSG`.