### PR TITLE
HIP 4.1 Compatibility, main branch (2021.04.01.)

### DIFF
--- a/cmake/FindHIPToolkit.cmake
+++ b/cmake/FindHIPToolkit.cmake
@@ -12,7 +12,7 @@ endif()
 set( CMAKE_HIP_PLATFORM "${CMAKE_HIP_PLATFORM_DEFAULT}" CACHE STRING
    "Platform to build the HIP code for" )
 set_property( CACHE CMAKE_HIP_PLATFORM
-   PROPERTY STRINGS "hcc" "nvcc" )
+   PROPERTY STRINGS "hcc" "nvcc" "amd" "nvidia" )
 
 # Set a helper variable.
 set( _quietFlag )
@@ -22,7 +22,8 @@ endif()
 
 # Look for the CUDA toolkit if we are building NVidia code.
 set( _requiredVars )
-if( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" )
+if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
+    ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    find_package( CUDAToolkit ${_quietFlag} )
    list( APPEND _requiredVars CUDAToolkit_FOUND )
 endif()
@@ -66,7 +67,8 @@ endif()
 
 # Look for the HIP runtime library.
 set( HIP_LIBRARIES )
-if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
+if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" ) OR
+    ( "${CMAKE_HIP_PLATFORM}" STREQUAL "amd" ) )
    find_library( HIP_amdhip64_LIBRARY
       NAMES "amdhip64"
       PATHS "${HIP_ROOT_DIR}"
@@ -80,7 +82,8 @@ if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
    set( HIP_RUNTIME_LIBRARY "${HIP_amdhip64_LIBRARY}" )
    list( APPEND HIP_LIBRARIES "${HIP_amdhip64_LIBRARY}" )
    list( APPEND _requiredVars HIP_RUNTIME_LIBRARY )
-elseif( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" )
+elseif( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
+        ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    set( HIP_RUNTIME_LIBRARY "${CUDA_cudart_LIBRARY}" )
    list( APPEND HIP_LIBRARIES CUDA::cudart )
 else()
@@ -88,15 +91,17 @@ else()
 endif()
 
 # Set up the compiler definitions needed to use the HIP headers.
-if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
+if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" ) OR
+    ( "${CMAKE_HIP_PLATFORM}" STREQUAL "amd" ) )
    set( HIP_DEFINITIONS "__HIP_PLATFORM_HCC__" )
-elseif( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" )
+elseif( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
+        ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    set( HIP_DEFINITIONS "__HIP_PLATFORM_NVCC__" )
 else()
    message( SEND_ERROR "Invalid (CMAKE_)HIP_PLATFORM setting received" )
 endif()
 
-# Handle the standard find_package arguments:
+# Handle the standard find_package arguments.
 include( FindPackageHandleStandardArgs )
 find_package_handle_standard_args( HIPToolkit
    FOUND_VAR HIPToolkit_FOUND

--- a/cmake/hip/CMakeDetermineHIPCompiler.cmake
+++ b/cmake/hip/CMakeDetermineHIPCompiler.cmake
@@ -74,15 +74,17 @@ endif()
 set( CMAKE_HIP_PLATFORM "${CMAKE_HIP_PLATFORM_DEFAULT}" CACHE STRING
    "Platform to build the HIP code for" )
 set_property( CACHE CMAKE_HIP_PLATFORM
-   PROPERTY STRINGS "hcc" "nvcc" )
+   PROPERTY STRINGS "hcc" "nvcc" "amd" "nvidia" )
 
 # Turn on CUDA support if we use nvcc.
-if( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" )
+if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
+    ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    enable_language( CUDA )
 endif()
 
 # Decide how to do the build for the AMD (hcc) and NVidia (nvcc) backends.
-if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
+if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" ) OR
+    ( "${CMAKE_HIP_PLATFORM}" STREQUAL "amd" ) )
    if( CMAKE_HIP_VERSION VERSION_LESS "3.7" )
       set( CMAKE_HIP_COMPILE_SOURCE_TYPE_FLAG "-x c++" )
    else()
@@ -90,7 +92,8 @@ if( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" )
    endif()
    set( CMAKE_HIP_IMPLICIT_LINK_LIBRARIES "${HIP_amdhip64_LIBRARY}" )
    set( CMAKE_HIP_COMPILE_OPTIONS_PIC "${CMAKE_CXX_COMPILE_OPTIONS_PIC}" )
-elseif( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" )
+elseif( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
+        ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    set( CMAKE_HIP_COMPILE_SOURCE_TYPE_FLAG "-x cu" )
    find_package( CUDAToolkit QUIET REQUIRED )
    set( CMAKE_HIP_IMPLICIT_LINK_LIBRARIES "${CUDA_cudart_LIBRARY}" )


### PR DESCRIPTION
Made the project's CMake code compatible with [ROCm/HIP](https://rocmdocs.amd.com) 4.1.

In ROCm/HIP 4.1 the previous `"hcc"` and `"nvcc"` values of the `HIP_PLATFORM` environment variable (for the `hipcc` compiler) were replaced with `"amd"` and `"nvidia"` respectively. With no backwards compatibility for `"hcc"` or `"nvcc"`. :frowning: (I just keep being surprised by AMD's software team...)

Seemingly this was the only UI change made. :confused: The macros in the HIP headers still use the `HCC` and `NVCC` naming internally.

For now I kept the default platform on `"hcc"`. So HIP 4.1 users will have to actively set their `HIP_PLATFORM` environment variable to something else.

Note that I switched to HIP 4.1 myself hoping that `printf` would start working better with it. But it didn't. :frowning: The only thing I got out of the update was that I needed to update this CMake code. :frowning: