### PR TITLE
Xcode Compatibility Fixes, main branch (2021.04.01.)

### DIFF
--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -29,7 +29,8 @@ protected:
    /// Memory resource to use in the tests
    vecmem::host_memory_resource m_resource;
    /// Test vector used for testing all of the custom containers
-   vecmem::vector< int > m_reference_vector = { 1, 2, 5, 6, 3, 6, 1, 7, 9 };
+   vecmem::vector< int > m_reference_vector = { { 1, 2, 5, 6, 3, 6, 1, 7, 9 },
+                                                &m_resource };
 
 }; // class core_container_test
 

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -121,7 +121,7 @@ TEST_F(core_jagged_vector_view_test, reverse_iterator) {
 
 TEST_F(core_jagged_vector_view_test, value_iteration) {
     std::size_t i = 0;
-    for( const auto& innerv : m_jag ) {
+    for( auto innerv : m_jag ) {
         i += innerv.size();
     }
     EXPECT_EQ( i, 16 );


### PR DESCRIPTION
Added some fixes for Apple Clang 12.0.0. ([Xcode](https://developer.apple.com/xcode/) 12.4)  Apple's compiler pointed out two actual problems in the code, which this commit should fix.
  - The change in `test_core_containers.cpp` makes sure that the test would use our own host memory resource, instead of the default one. Which is absolutely necessary, since Apple Clang (libc\+\+ in general) does not officially support polymorphic memory resources yet.

https://en.cppreference.com/w/cpp/compiler_support

Luckily the header files that we need, are actually available. But the default memory resource isn't. Which lead to this sort of linking issue before this fix:

```
Undefined symbols for architecture x86_64:
  "std::experimental::fundamentals_v1::pmr::get_default_resource()", referenced from:
      std::experimental::fundamentals_v1::pmr::polymorphic_allocator<int>::polymorphic_allocator() in test_core_containers.cpp.o
ld: symbol(s) not found for architecture x86_64
```

  - The change in `test_core_jagged_vector_view.cpp` is because Clang likes to warn us about the code expecting a reference where none can be given.

```
/Users/krasznaa/ATLAS/sw/projects/vecmem/vecmem/tests/core/test_core_jagged_vector_view.cpp:124:22: error: loop variable
      'innerv' is always a copy because the range of type 'vecmem::jagged_device_vector<int>' does not return a
      reference [-Werror,-Wrange-loop-analysis]
    for( const auto& innerv : m_jag ) {
                     ^
/Users/krasznaa/ATLAS/sw/projects/vecmem/vecmem/tests/core/test_core_jagged_vector_view.cpp:124:10: note: use
      non-reference type 'vecmem::device_vector<int>'
    for( const auto& innerv : m_jag ) {
         ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```

Both of these, I think, were good to be fixed. So we will probably want to add a macOS build to the CI if that's possible. @paulgessinger, what do you know about that, is that easy to do?