### PR TITLE
CMake Patches, main branch (2021.04.10.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 # Set up the project.
 cmake_minimum_required( VERSION 3.10 )
-project( vecmem VERSION 0.0.1 LANGUAGES CXX )
+project( vecmem VERSION 0.2.0 LANGUAGES CXX )
 
 # Standard CMake include(s).
 include( GNUInstallDirs )
@@ -26,7 +26,6 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 
 # Include the VecMem CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
-include( vecmem-compiler-options-cpp )
 include( vecmem-functions )
 include( vecmem-options )
 

--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -21,8 +21,6 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wall" )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wextra" )
-      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode}
-         "-Wno-gnu-zero-variadic-macro-arguments" )
    endforeach()
 
    # More rigorous tests for the Debug builds.

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -90,7 +90,6 @@ function( vecmem_add_flag name value )
    endif()
 
    # If not, then let's add it now:
-   set( ${name} "${${name}} ${value}" CACHE STRING
-      "Compiler setting" FORCE )
+   set( ${name} "${${name}} ${value}" PARENT_SCOPE )
 
 endfunction( vecmem_add_flag )

--- a/cmake/vecmem-googletest.cmake
+++ b/cmake/vecmem-googletest.cmake
@@ -27,6 +27,10 @@ FetchContent_Declare( GoogleTest
    URL "https://github.com/google/googletest/archive/release-1.10.0.tar.gz"
    URL_MD5 "ecd1fa65e7de707cd5c00bdac56022cd" )
 
+# Options used in the build of GoogleTest.
+set( BUILD_GMOCK FALSE CACHE BOOL "Turn off the build of GMock" )
+set( INSTALL_GTEST FALSE CACHE BOOL "Turn off the installation of GoogleTest" )
+
 # Get it into the current directory.
 FetchContent_Populate( GoogleTest )
 add_subdirectory( "${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Project include(s).
+include( vecmem-compiler-options-cpp )
+
 # Set up the build of the VecMem core library.
 vecmem_add_library( vecmem_core core SHARED
    # STL mimicking containers.

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -11,6 +11,7 @@ cmake_minimum_required( VERSION 3.17 )
 enable_language( CUDA )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-cuda )
 
 # External dependency/dependencies.

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -8,6 +8,7 @@
 enable_language( HIP )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-hip )
 
 # External dependency/dependencies.

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -8,6 +8,7 @@
 enable_language( SYCL )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
 
 # Set up the build of the VecMem SYCL library.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,8 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
-# Build GoogleTest.
+# Project include(s).
 include( vecmem-googletest )
+include( vecmem-compiler-options-cpp )
 
 # Build a common, helper library.
 add_library( vecmem_testing_common STATIC

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# Project include(s).
+include( vecmem-compiler-options-cpp )
+
 # Test all of the core library's features.
 vecmem_add_test( core
    "test_core_allocator.cpp" "test_core_array.cpp" "test_core_containers.cpp"

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -8,6 +8,7 @@
 enable_language( CUDA )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-cuda )
 
 # Test all of the CUDA library's features.

--- a/tests/hip/CMakeLists.txt
+++ b/tests/hip/CMakeLists.txt
@@ -8,6 +8,7 @@
 enable_language( HIP )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-hip )
 
 # Test all of the HIP library's features.

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -8,6 +8,7 @@
 enable_language( SYCL )
 
 # Project include(s).
+include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
 
 # Test all of the SYCL library's features.


### PR DESCRIPTION
Modified `vecmem_add_flag(...)` not to modify flags "globally", but only in a given context. So that when we build VecMem as part of another project (let's say [acts-project/traccc](https://github.com/acts-project/traccc) :wink:), it wouldn't pollute the other project's build options with its own. This required explicit include of `vecmem-compiler-options-cpp.cmake` in a number of additional places.

At the same time I made some additional changes as well:
  - Updated the project's "build version" to `0.2.0`, to be in sync with the previously created [v0.1.0 git tag](https://github.com/acts-project/vecmem/releases/tag/v0.1.0);
  - With the "bleeding" now stopped, I could remove the very specific C\+\+ build flag (`-Wno-gnu-zero-variadic-macro-arguments`) that I had to add earlier to be able to compile GTest with the `-pedantic` flag;
  - Explicitly turned off the build (and the configuration) of the GoogleTest components that VecMem doesn't need. Including the installation of the GoogleTest libraries.

Pinging @stephenswat and @paulgessinger. Though I doubt you guys will have strong opinions about the build system's configuration in such details...