### PR TITLE
SYCL Copy Code, main branch (2021.04.12.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -18,7 +18,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
    /// Object owning all the data of a jagged vector
    ///
@@ -101,7 +101,19 @@ namespace vecmem::data {
 
    }; // class jagged_vector_buffer
 
-} // namespace vecmem::data
+} // namespace data
+
+   /// Helper function creating a @c vecmem::data::jagged_vector_view object
+   template< typename TYPE >
+   data::jagged_vector_view< TYPE >&
+   get_data( data::jagged_vector_buffer< TYPE >& data );
+
+   /// Helper function creating a @c vecmem::data::jagged_vector_view object
+   template< typename TYPE >
+   const data::jagged_vector_view< TYPE >&
+   get_data( const data::jagged_vector_buffer< TYPE >& data );
+
+} // namespace vecmem
 
 // Include the implementation.
 #include "vecmem/containers/impl/jagged_vector_buffer.ipp"

--- a/core/include/vecmem/containers/data/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_data.hpp
@@ -16,7 +16,7 @@
 // System include(s).
 #include <memory>
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
     /**
      * @brief A data wrapper for jagged vectors.
@@ -56,7 +56,19 @@ namespace vecmem::data {
 
     }; // class jagged_vector_data
 
-} // namespace vecmem::data
+} // namespace data
+
+   /// Helper function creating a @c vecmem::data::jagged_vector_view object
+   template< typename TYPE >
+   data::jagged_vector_view< TYPE >&
+   get_data( data::jagged_vector_data< TYPE >& data );
+
+   /// Helper function creating a @c vecmem::data::jagged_vector_view object
+   template< typename TYPE >
+   const data::jagged_vector_view< TYPE >&
+   get_data( const data::jagged_vector_data< TYPE >& data );
+
+} // namespace vecmem
 
 // Include the implementation.
 #include "vecmem/containers/impl/jagged_vector_data.ipp"

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -10,14 +10,13 @@
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/memory/deallocator.hpp"
-#include "vecmem/utils/types.hpp"
 
 // System include(s).
 #include <cstddef>
 #include <memory>
 #include <type_traits>
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
    /// Object owning the data held by it
    ///
@@ -45,7 +44,6 @@ namespace vecmem::data {
       ///
       /// It is left up to external code to copy data into the allocated memory.
       ///
-      VECMEM_HOST
       vector_buffer( std::size_t size, memory_resource& resource );
 
    private:
@@ -54,7 +52,19 @@ namespace vecmem::data {
 
    }; // class vector_buffer
 
-} // namespace vecmem::data
+} // namespace data
+
+   /// Helper function creating a @c vecmem::data::vector_view object
+   template< typename TYPE >
+   data::vector_view< TYPE >&
+   get_data( data::vector_buffer< TYPE >& data );
+
+   /// Helper function creating a @c vecmem::data::vector_view object
+   template< typename TYPE >
+   const data::vector_view< TYPE >&
+   get_data( const data::vector_buffer< TYPE >& data );
+
+} // namespace vecmem
 
 // Include the implementation.
 #include "vecmem/containers/impl/vector_buffer.ipp"

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -63,7 +63,7 @@ namespace {
 
 } // private namespace
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
    template< typename TYPE >
    template< typename OTHERTYPE,
@@ -119,4 +119,20 @@ namespace vecmem::data {
       return m_outer_host_memory.get();
    }
 
-} // namespace vecmem::data
+} // namespace data
+
+   template< typename TYPE >
+   data::jagged_vector_view< TYPE >&
+   get_data( data::jagged_vector_buffer< TYPE >& data ) {
+
+      return data;
+   }
+
+   template< typename TYPE >
+   const data::jagged_vector_view< TYPE >&
+   get_data( const data::jagged_vector_buffer< TYPE >& data ) {
+
+      return data;
+   }
+
+} // namespace vecmem

--- a/core/include/vecmem/containers/impl/jagged_vector_data.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_data.ipp
@@ -35,7 +35,7 @@ namespace {
 
 } // private namespace
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
     template<typename T>
     jagged_vector_data<T>::jagged_vector_data(
@@ -65,4 +65,20 @@ namespace vecmem::data {
         }
     }
 
-} // namespace vecmem::data
+} // namespace data
+
+    template< typename TYPE >
+    data::jagged_vector_view< TYPE >&
+    get_data( data::jagged_vector_data< TYPE >& data ) {
+
+        return data;
+    }
+
+    template< typename TYPE >
+    const data::jagged_vector_view< TYPE >&
+    get_data( const data::jagged_vector_data< TYPE >& data ) {
+
+        return data;
+    }
+
+} // namespace vecmem

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -24,10 +24,9 @@ namespace {
 
 } // private namespace
 
-namespace vecmem::data {
+namespace vecmem { namespace data {
 
    template< typename TYPE >
-   VECMEM_HOST
    vector_buffer< TYPE >::
    vector_buffer( std::size_t size, memory_resource& resource )
    : base_type( size, nullptr ),
@@ -38,4 +37,20 @@ namespace vecmem::data {
       base_type::m_ptr = m_memory.get();
    }
 
-} // namespace vecmem::data
+} // namespace data
+
+   template< typename TYPE >
+   data::vector_view< TYPE >&
+   get_data( data::vector_buffer< TYPE >& data ) {
+
+      return data;
+   }
+
+   template< typename TYPE >
+   const data::vector_view< TYPE >&
+   get_data( const data::vector_buffer< TYPE >& data ) {
+
+      return data;
+   }
+
+} // namespace vecmem

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -23,6 +23,8 @@ vecmem_add_library( vecmem_sycl sycl SHARED
    "include/vecmem/memory/sycl/shared_memory_resource.hpp"
    "src/memory/sycl/shared_memory_resource.sycl"
    # Utilities.
+   "include/vecmem/utils/sycl/copy.hpp"
+   "src/utils/sycl/copy.sycl"
    "include/vecmem/utils/sycl/queue_wrapper.hpp"
    "src/utils/sycl/queue_wrapper.sycl"
    "src/utils/sycl/device_selector.hpp"

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -27,7 +27,7 @@ namespace vecmem::sycl {
       copy( const queue_wrapper& queue = { "" } );
 
    protected:
-      /// Perform a memory copy using CUDA
+      /// Perform a memory copy using SYCL
       virtual void do_copy( std::size_t size, const void* from, void* to,
                             type::copy_type cptype ) override;
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -1,0 +1,40 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/utils/copy.hpp"
+#include "vecmem/utils/sycl/queue_wrapper.hpp"
+
+namespace vecmem::sycl {
+
+   /// Specialisation of @c vecmem::copy for SYCL
+   ///
+   /// Unlike @c vecmem::cuda::copy and @c vecmem::hip::copy, this object does
+   /// have a state. As USM memory operations in SYCL happen through a
+   /// @c cl::sycl::queue object. So this object needs to point to a valid
+   /// queue object itself.
+   ///
+   class copy : public vecmem::copy {
+
+   public:
+      /// Constructor on top of a user-provided queue
+      copy( const queue_wrapper& queue = { "" } );
+
+   protected:
+      /// Perform a memory copy using CUDA
+      virtual void do_copy( std::size_t size, const void* from, void* to,
+                            type::copy_type cptype ) override;
+
+   private:
+      /// The queue that the copy operations are made with/for
+      queue_wrapper m_queue;
+
+   }; // class copy
+
+} // namespace vecmem::sycl

--- a/sycl/src/memory/sycl/details/memory_resource_base.sycl
+++ b/sycl/src/memory/sycl/details/memory_resource_base.sycl
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/details/memory_resource_base.hpp"
+#include "vecmem/utils/debug.hpp"
 #include "../../../utils/sycl/get_queue.hpp"
 
 // SYCL include(s).
@@ -23,9 +24,13 @@ namespace vecmem::sycl::details {
    }
 
    void memory_resource_base::do_deallocate( void* ptr, std::size_t,
-                                               std::size_t ) {
+                                             std::size_t ) {
 
+      // Free the memory.
       cl::sycl::free( ptr, get_queue( m_queue ) );
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 5, "Freed the memory block at %p", ptr );
    }
 
    bool memory_resource_base::do_is_equal(

--- a/sycl/src/memory/sycl/device_memory_resource.sycl
+++ b/sycl/src/memory/sycl/device_memory_resource.sycl
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/device_memory_resource.hpp"
+#include "vecmem/utils/debug.hpp"
 #include "../../utils/sycl/get_queue.hpp"
 
 // SYCL include(s).
@@ -17,7 +18,18 @@ namespace vecmem::sycl {
    void* device_memory_resource::do_allocate( std::size_t nbytes,
                                               std::size_t ) {
 
-      return cl::sycl::malloc_device( nbytes, details::get_queue( m_queue ) );
+      // Allocate the memory.
+      void* result = cl::sycl::malloc_device( nbytes,
+                                              details::get_queue( m_queue ) );
+
+      // Let the user know what's happening.
+      VECMEM_DEBUG_MSG( 5, "Allocated %ld bytes of device memory on \"%s\" "
+                        "at %p", nbytes,
+                        details::get_queue( m_queue ).get_device().get_info<
+                           cl::sycl::info::device::name >().c_str(), result );
+
+      // Return the allocated block's pointer.
+      return result;
    }
 
 } // namespace vecmem::sycl

--- a/sycl/src/memory/sycl/host_memory_resource.sycl
+++ b/sycl/src/memory/sycl/host_memory_resource.sycl
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/host_memory_resource.hpp"
+#include "vecmem/utils/debug.hpp"
 #include "../../utils/sycl/get_queue.hpp"
 
 // SYCL include(s).
@@ -16,7 +17,16 @@ namespace vecmem::sycl {
 
    void* host_memory_resource::do_allocate( std::size_t nbytes, std::size_t ) {
 
-      return cl::sycl::malloc_host( nbytes, details::get_queue( m_queue ) );
+      // Allocate the memory.
+      void* result = cl::sycl::malloc_host( nbytes,
+                                            details::get_queue( m_queue ) );
+
+      // Let the user know what's happening.
+      VECMEM_DEBUG_MSG( 5, "Allocated %ld bytes of host memory at %p", nbytes,
+                        result );
+
+      // Return the allocated block's pointer.
+      return result;
    }
 
 } // namespace vecmem::sycl

--- a/sycl/src/memory/sycl/shared_memory_resource.sycl
+++ b/sycl/src/memory/sycl/shared_memory_resource.sycl
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
+#include "vecmem/utils/debug.hpp"
 #include "../../utils/sycl/get_queue.hpp"
 
 // SYCL include(s).
@@ -17,7 +18,18 @@ namespace vecmem::sycl {
    void* shared_memory_resource::do_allocate( std::size_t nbytes,
                                               std::size_t ) {
 
-      return cl::sycl::malloc_shared( nbytes, details::get_queue( m_queue ) );
+      // Allocate the memory.
+      void* result = cl::sycl::malloc_shared( nbytes,
+                                              details::get_queue( m_queue ) );
+
+      // Let the user know what's happening.
+      VECMEM_DEBUG_MSG( 5, "Allocated %ld bytes of shared memory on \"%s\" "
+                        "at %p", nbytes,
+                        details::get_queue( m_queue ).get_device().get_info<
+                           cl::sycl::info::device::name >().c_str(), result );
+
+      // Return the allocated block's pointer.
+      return result;
    }
 
 } // namespace vecmem::sycl

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -1,0 +1,35 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// VecMem include(s).
+#include "vecmem/utils/sycl/copy.hpp"
+#include "vecmem/utils/debug.hpp"
+#include "get_queue.hpp"
+
+namespace vecmem::sycl {
+
+   copy::copy( const queue_wrapper& queue )
+   : m_queue( queue ) {
+
+   }
+
+   void copy::do_copy( std::size_t size, const void* from, void* to,
+                       type::copy_type ) {
+
+      // Perform the copy.
+      details::get_queue( m_queue ).memcpy( to, from, size );
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 4, "Performed memory copy of %lu bytes from %p to %p",
+                        size, from, to );
+   }
+
+} // namespace vecmem::sycl

--- a/sycl/src/utils/sycl/queue_wrapper.sycl
+++ b/sycl/src/utils/sycl/queue_wrapper.sycl
@@ -6,8 +6,10 @@
  */
 
 // Local include(s).
+#include "vecmem/utils/debug.hpp"
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
 #include "device_selector.hpp"
+#include "get_queue.hpp"
 #include "opaque_queue.hpp"
 
 // SYCL include(s).
@@ -21,11 +23,19 @@ namespace vecmem::sycl {
         device_selector( deviceName ) ) ) {
 
       m_queue = m_managedQueue.get();
+      VECMEM_DEBUG_MSG( 2, "Created an \"owning wrapper\" around a queue on "
+                        "device: %s",
+                        details::get_queue( *this ).get_device().get_info<
+                           cl::sycl::info::device::name >().c_str() );
    }
 
    queue_wrapper::queue_wrapper( void* queue )
    : m_queue( queue ), m_managedQueue() {
 
+      VECMEM_DEBUG_MSG( 2, "Created a \"view wrapper\" around a queue on "
+                        "device: %s",
+                        details::get_queue( *this ).get_device().get_info<
+                           cl::sycl::info::device::name >().c_str() );
    }
 
    queue_wrapper::queue_wrapper( const queue_wrapper& parent )

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -14,7 +14,10 @@
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/sycl/device_memory_resource.hpp"
+#include "vecmem/memory/sycl/host_memory_resource.hpp"
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
+#include "vecmem/utils/sycl/copy.hpp"
 #include "../../sycl/src/utils/sycl/device_selector.hpp"
 
 // GoogleTest include(s).
@@ -47,7 +50,7 @@ TEST_F( sycl_containers_test, shared_memory ) {
    queue.submit( [ &constants, &inputvec, &outputvec ]( cl::sycl::handler& h ) {
 
       // Run the kernel.
-      h.parallel_for< class LinearTransform >(
+      h.parallel_for< class LinearTransform1 >(
          cl::sycl::range< 1 >( inputvec.size() ),
          [ constants = vecmem::get_data( constants ),
            input = vecmem::get_data( inputvec ),
@@ -70,6 +73,83 @@ TEST_F( sycl_containers_test, shared_memory ) {
             return;
          } );
    } );
+   queue.wait();
+
+   // Check the output.
+   EXPECT_EQ( inputvec.size(), outputvec.size() );
+   for( std::size_t i = 0; i < outputvec.size(); ++i ) {
+      EXPECT_EQ( outputvec.at( i ),
+                 inputvec.at( i ) * constants[ 0 ] + constants[ 1 ] );
+   }
+}
+
+/// Test a linear transformation using the host/device memory resources
+TEST_F( sycl_containers_test, device_memory ) {
+
+   // Create the SYCL queue that we'll be using in the test.
+   cl::sycl::queue queue{ vecmem::sycl::device_selector() };
+
+   // The memory resources.
+   vecmem::sycl::host_memory_resource host_resource( &queue );
+   vecmem::sycl::device_memory_resource device_resource( &queue );
+
+   // Helper object for performing memory copies.
+   vecmem::sycl::copy copy( &queue );
+
+   // Create an input and an output vector in host memory.
+   vecmem::vector< int > inputvec( { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
+                                   &host_resource );
+   vecmem::vector< int > outputvec( inputvec.size(), &host_resource );
+   EXPECT_EQ( inputvec.size(), outputvec.size() );
+
+   // Allocate a device memory block for the output container.
+   auto outputvechost = vecmem::get_data( outputvec );
+   vecmem::data::vector_buffer< int >
+      outputvecdevice( outputvec.size(), device_resource );
+
+   // Create the array that is used in the linear transformation.
+   vecmem::array< int, 2 > constants( host_resource );
+   constants[ 0 ] = 2;
+   constants[ 1 ] = 3;
+
+   // Explicitly copy the input objects to the device. We need to do it outside
+   // of the @c sycl::queue::submit call, as the local variables of the lambda
+   // given to that function are deleted before the kernel would run.
+   auto const_data = copy.to( vecmem::get_data( constants ),
+                              device_resource );
+   auto input_data = copy.to( vecmem::get_data( inputvec ),
+                              device_resource );
+
+   // Perform a linear transformation using the vecmem vector helper types.
+   queue.submit( [ &const_data, &input_data,
+                   &outputvecdevice ]( cl::sycl::handler& h ) {
+
+      // Run the kernel.
+      h.parallel_for< class LinearTransform2 >(
+         cl::sycl::range< 1 >( input_data.m_size ),
+         [ constants = vecmem::get_data( const_data ),
+           input = vecmem::get_data( input_data ),
+           output = vecmem::get_data( outputvecdevice ) ]( cl::sycl::id< 1 > id ) {
+
+            // Skip invalid indices.
+            if( id >= input.m_size ) {
+               return;
+            }
+
+            // Create the helper containers.
+            const vecmem::const_device_array< int, 2 >
+               constantarray( constants );
+            const vecmem::const_device_vector< int > inputvec( input );
+            vecmem::device_vector< int > outputvec( output );
+
+            // Perform the linear transformation.
+            outputvec.at( id ) = inputvec.at( id ) * constantarray.at( 0 ) +
+                                 constantarray.at( 1 );
+            return;
+         } );
+   } );
+   queue.wait(); // This is needed just for the OpenCL CPU driver...
+   copy( outputvecdevice, outputvechost );
    queue.wait();
 
    // Check the output.

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -148,7 +148,7 @@ TEST_F( sycl_containers_test, device_memory ) {
             return;
          } );
    } );
-   queue.wait(); // This is needed just for the OpenCL CPU driver...
+   queue.wait();
    copy( outputvecdevice, outputvechost );
    queue.wait();
 


### PR DESCRIPTION
As I said in #67, I wrote a `vecmem::sycl::copy` class as well. But to make it convenient to use in our tests, I added some more code as well.

Basically, I added `vecmem::get_data(...)` functions for some more types. To be able to express in a convenient way that I want to pass "view types" to the SYCL device code, and not host-only types. This could of course be done without the `vecmem::get_data(...)` functions as well, but I thought this would be a bit more elegant than having to create temporary reference variables in the code explicitly.

The `vecmem::sycl::copy` class is pretty much the same as `vecmem::cuda::copy` and `vecmem::hip::copy`. Though unlike those, it actually does have a state. As it needs to hold on to a `sycl::queue` object to be able to perform the memory copies.

And the thing that I learned during these developments, which may be obvious to everybody else, but it wasn't to me... :stuck_out_tongue:  At first I was trying to implement the test for the SYCL copy functionality like:

```c++
   queue.submit( [ &constants, &inputvec,
                   &outputvecdevice ]( cl::sycl::handler& h ) {

      // Create buffer objects for the input data.
      auto const_data = copy.to( vecmem::get_data( constants ),
                                 device_resource );
      auto input_data = copy.to( vecmem::get_data( inputvec ),
                                 device_resource );

      // Run the kernel.
      h.parallel_for< class LinearTransform2 >(
         cl::sycl::range< 1 >( input_data.m_size ),
         [ constants = vecmem::get_data( const_data ),
           input = vecmem::get_data( input_data ),
           output = vecmem::get_data( outputvecdevice ) ]( cl::sycl::id< 1 > id ) {
```

I.e. I tried to create the buffer objects inside the lambda that I would give to `sycl::queue::submit`. Not realising that in such a setup the buffers would be deleted already before the kernel code would start to run. Which lead to a lot of errors in the code of course. Which is why I ended up adding quite some debug output in this PR. :stuck_out_tongue:

Long story short, one must create "buffer objects" outside of `sycl::queue::submit`. :wink: