### PR TITLE
Extendable Device Vectors - Part 1, main branch (2021.04.13.)

### DIFF
--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -30,6 +30,12 @@ namespace vecmem::data {
    public:
       /// The base type used by this class
       typedef vector_view< TYPE > base_type;
+      /// Size type definition coming from the base class
+      typedef typename base_type::size_type size_type;
+      /// Size pointer type definition coming from the base class
+      typedef typename base_type::size_pointer size_pointer;
+      /// Pointer type definition coming from the base class
+      typedef typename base_type::pointer pointer;
 
       /// @name Checks on the type of the array element
       /// @{
@@ -41,16 +47,17 @@ namespace vecmem::data {
 
       /// @}
 
-      /// Constructor with a size
-      ///
-      /// It is left up to external code to copy data into the allocated memory.
-      ///
+      /// Constant size data constructor
       VECMEM_HOST
-      vector_buffer( std::size_t size, memory_resource& resource );
+      vector_buffer( size_type size, memory_resource& resource );
+      /// Resizable data constructor
+      VECMEM_HOST
+      vector_buffer( size_type capacity, size_type size,
+                     memory_resource& resource );
 
    private:
       /// Data object owning the allocated memory
-      std::unique_ptr< TYPE, details::deallocator > m_memory;
+      std::unique_ptr< char, details::deallocator > m_memory;
 
    }; // class vector_buffer
 

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -16,7 +16,7 @@
 
 namespace vecmem { namespace data {
 
-   /// Simple struct holding data about a 1 dimensional vector/array
+   /// Class holding data about a 1 dimensional vector/array
    ///
    /// This type is meant to "formalise" the communication of data between
    /// @c vecmem::vector, @c vecmem::array ("host types") and
@@ -27,18 +27,31 @@ namespace vecmem { namespace data {
    /// "view" of that data.
    ///
    template< typename TYPE >
-   struct vector_view {
+   class vector_view {
 
+   public:
       /// Size type used in the class
       typedef std::size_t size_type;
+      /// Pointer type to the size of the array
+      typedef typename std::conditional< std::is_const< TYPE >::value,
+                                         const size_type*,
+                                         size_type* >::type size_pointer;
+      /// Constant pointer type to the size of the array
+      typedef const typename std::remove_const< size_pointer >::type
+         const_size_pointer;
       /// Pointer type to the array
       typedef TYPE* pointer;
+      /// Constant pointer to the array
+      typedef const typename std::remove_const< pointer >::type const_pointer;
 
       /// Default constructor
       vector_view() = default;
-      /// Constructor from "raw data"
+      /// Constant size data constructor
       VECMEM_HOST_AND_DEVICE
       vector_view( size_type size, pointer ptr );
+      /// Resizable data constructor
+      VECMEM_HOST_AND_DEVICE
+      vector_view( size_type capacity, size_pointer size, pointer ptr );
 
       /// Constructor from a "slightly different" @c vecmem::details::vector_view object
       ///
@@ -54,8 +67,32 @@ namespace vecmem { namespace data {
       VECMEM_HOST_AND_DEVICE
       vector_view( const vector_view< OTHERTYPE >& parent );
 
-      /// Size of the array in memory
-      size_type m_size;
+      /// Get the size of the vector
+      VECMEM_HOST_AND_DEVICE
+      size_type size() const;
+      /// Get the maximum capacity of the vector
+      VECMEM_HOST_AND_DEVICE
+      size_type capacity() const;
+
+      /// Get a pointer to the size of the vector (non-const)
+      VECMEM_HOST_AND_DEVICE
+      size_pointer size_ptr();
+      /// Get a pointer to the size of the vector (const)
+      VECMEM_HOST_AND_DEVICE
+      const_size_pointer size_ptr() const;
+
+      /// Get a pointer to the vector elements (non-const)
+      VECMEM_HOST_AND_DEVICE
+      pointer ptr();
+      /// Get a pointer to the vector elements (const)
+      VECMEM_HOST_AND_DEVICE
+      const_pointer ptr() const;
+
+   protected:
+      /// Maximum capacity of the array
+      size_type m_capacity;
+      /// Pointer to the size of the array in memory
+      size_pointer m_size;
       /// Pointer to the start of the memory block/array
       pointer m_ptr;
 

--- a/core/include/vecmem/containers/impl/device_array.ipp
+++ b/core/include/vecmem/containers/impl/device_array.ipp
@@ -15,9 +15,9 @@ namespace vecmem {
    VECMEM_HOST_AND_DEVICE
    device_array< T, N >::
    device_array( const data::vector_view< value_type >& data )
-   : m_ptr( data.m_ptr ) {
+   : m_ptr( data.ptr() ) {
 
-      assert( data.m_size >= N );
+      assert( data.size() >= N );
    }
 
    template< typename T, std::size_t N >
@@ -28,8 +28,9 @@ namespace vecmem {
    VECMEM_HOST_AND_DEVICE
    device_array< T, N >::
    device_array( const data::vector_view< OTHERTYPE >& data )
-   : m_ptr( data.m_ptr ) {
+   : m_ptr( data.ptr() ) {
 
+      assert( data.size() >= N );
    }
 
    template< typename T, std::size_t N >

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -18,7 +18,7 @@ namespace vecmem {
    VECMEM_HOST_AND_DEVICE
    device_vector< TYPE >::
    device_vector( const data::vector_view< value_type >& data )
-   : m_size( data.m_size ), m_ptr( data.m_ptr ) {
+   : m_size( data.size() ), m_ptr( data.ptr() ) {
 
       VECMEM_DEBUG_MSG( 5, "Created vecmem::device_vector with size %i from "
                         "pointer %p", static_cast< int >( m_size ),
@@ -33,7 +33,7 @@ namespace vecmem {
    VECMEM_HOST_AND_DEVICE
    device_vector< TYPE >::
    device_vector( const data::vector_view< OTHERTYPE >& data )
-   : m_size( data.m_size ), m_ptr( data.m_ptr ) {
+   : m_size( data.size() ), m_ptr( data.ptr() ) {
 
       VECMEM_DEBUG_MSG( 5, "Created vecmem::device_vector with size %i from "
                         "pointer %p", static_cast< int >( m_size ),

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -24,10 +24,12 @@ namespace vecmem {
          result( size, ( resource != nullptr ? *resource :
                          *( vec.get_allocator().resource() ) ) );
 
+      // Helper local type definition.
+      typedef typename data::jagged_vector_data< TYPE >::value_type value_type;
+
       // Fill the result object with information.
       for( std::size_t i = 0; i < size; ++i ) {
-         result.m_ptr[ i ].m_size = vec[ i ].size();
-         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+         result.m_ptr[ i ] = value_type( vec[ i ].size(), vec[ i ].data() );
       }
 
       // Return the created object.
@@ -48,10 +50,12 @@ namespace vecmem {
       // Construct the object to be returned.
       data::jagged_vector_data< TYPE > result( size, *resource );
 
+      // Helper local type definition.
+      typedef typename data::jagged_vector_data< TYPE >::value_type value_type;
+
       // Fill the result object with information.
       for( std::size_t i = 0; i < size; ++i ) {
-         result.m_ptr[ i ].m_size = vec[ i ].size();
-         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+         result.m_ptr[ i ] = value_type( vec[ i ].size(), vec[ i ].data() );
       }
 
       // Return the created object.
@@ -70,10 +74,13 @@ namespace vecmem {
          result( size, ( resource != nullptr ? *resource :
                          *( vec.get_allocator().resource() ) ) );
 
+      // Helper local type definition.
+      typedef typename data::jagged_vector_data< const TYPE >::value_type
+         value_type;
+
       // Fill the result object with information.
       for( std::size_t i = 0; i < size; ++i ) {
-         result.m_ptr[ i ].m_size = vec[ i ].size();
-         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+         result.m_ptr[ i ] = value_type( vec[ i ].size(), vec[ i ].data() );
       }
 
       // Return the created object.
@@ -94,10 +101,13 @@ namespace vecmem {
       // Construct the object to be returned.
       data::jagged_vector_data< const TYPE > result( size, *resource );
 
+      // Helper local type definition.
+      typedef typename data::jagged_vector_data< const TYPE >::value_type
+         value_type;
+
       // Fill the result object with information.
       for( std::size_t i = 0; i < size; ++i ) {
-         result.m_ptr[ i ].m_size = vec[ i ].size();
-         result.m_ptr[ i ].m_ptr = vec[ i ].data();
+         result.m_ptr[ i ] = value_type( vec[ i ].size(), vec[ i ].data() );
       }
 
       // Return the created object.

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -21,7 +21,7 @@ namespace {
 
       std::vector< std::size_t > result( jvv.m_size );
       for( std::size_t i = 0; i < jvv.m_size; ++i ) {
-         result[ i ] = jvv.m_ptr[ i ].m_size;
+         result[ i ] = jvv.m_ptr[ i ].size();
       }
       return result;
    }
@@ -96,18 +96,15 @@ namespace vecmem::data {
         ::allocate_jagged_buffer_inner_memory< TYPE >( sizes, resource ) ) {
 
       // Point the base class at the newly allocated memory.
-      if( host_access_resource != nullptr ) {
-         base_type::m_ptr = m_outer_memory.get();
-      } else {
-         base_type::m_ptr = m_outer_host_memory.get();
-      }
+      base_type::m_ptr = ( ( host_access_resource != nullptr ) ?
+                           m_outer_memory.get() : m_outer_host_memory.get() );
 
       // Set up the host accessible memory array.
       std::ptrdiff_t ptrdiff = 0;
       for( std::size_t i = 0; i < sizes.size(); ++i ) {
-         new( m_outer_host_memory.get() + i ) value_type();
-         m_outer_host_memory.get()[ i ].m_size = sizes[ i ];
-         m_outer_host_memory.get()[ i ].m_ptr = m_inner_memory.get() + ptrdiff;
+         new( host_ptr() + i ) value_type();
+         host_ptr()[ i ] =
+            value_type( sizes[ i ], m_inner_memory.get() + ptrdiff );
          ptrdiff += sizes[ i ];
       }
    }

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -6,19 +6,30 @@
  */
 #pragma once
 
+// System include(s).
+#include <cassert>
+
 namespace {
 
    /// Function creating the smart pointer for @c vecmem::data::vector_buffer
    template< typename TYPE >
-   std::unique_ptr< TYPE, vecmem::details::deallocator >
+   std::unique_ptr< char, vecmem::details::deallocator >
    allocate_buffer_memory(
+      typename vecmem::data::vector_buffer< TYPE >::size_type capacity,
       typename vecmem::data::vector_buffer< TYPE >::size_type size,
       vecmem::memory_resource& resource ) {
 
-      const typename vecmem::data::vector_buffer< TYPE >::size_type
-         byteSize = size * sizeof( TYPE );
-      return { size == 0 ? nullptr :
-               static_cast< TYPE* >( resource.allocate( byteSize ) ),
+      // A sanity check.
+      assert( capacity >= size );
+
+      // Decide how many bytes to allocate.
+      const std::size_t byteSize =
+         ( ( capacity == size ) ? ( size * sizeof( TYPE ) ) :
+           ( sizeof( std::size_t ) + size * sizeof( TYPE ) ) );
+
+      // Return the appropriate smart pointer.
+      return { capacity == 0 ? nullptr :
+               static_cast< char* >( resource.allocate( byteSize ) ),
                { byteSize, resource } };
    }
 
@@ -29,13 +40,31 @@ namespace vecmem::data {
    template< typename TYPE >
    VECMEM_HOST
    vector_buffer< TYPE >::
-   vector_buffer( std::size_t size, memory_resource& resource )
-   : base_type( size, nullptr ),
-     m_memory( ::allocate_buffer_memory< TYPE >( size, resource ) ) {
+   vector_buffer( size_type size, memory_resource& resource )
+   : vector_buffer( size, size, resource ) {
 
-      // Weirdly enough Clang doesn't understand what "m_ptr" by itself would
-      // refer to... :-/
-      base_type::m_ptr = m_memory.get();
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST
+   vector_buffer< TYPE >::
+   vector_buffer( size_type capacity, size_type size,
+                  memory_resource& resource )
+   : base_type( capacity, nullptr, nullptr ),
+     m_memory( ::allocate_buffer_memory< TYPE >( capacity, size, resource ) ) {
+
+      // Set the base class's pointers correctly.
+      if( capacity > 0 ) {
+         if( size == capacity ) {
+            base_type::m_ptr = reinterpret_cast< pointer >( m_memory.get() );
+         } else {
+            base_type::m_size =
+               reinterpret_cast< size_pointer >( m_memory.get() );
+            base_type::m_ptr =
+               reinterpret_cast< pointer >( m_memory.get() +
+                                            sizeof( size_type ) );
+         }
+      }
    }
 
 } // namespace vecmem::data

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -6,13 +6,27 @@
  */
 #pragma once
 
+// System include(s).
+#include <cassert>
+
 namespace vecmem { namespace data {
 
    template< typename TYPE >
    VECMEM_HOST_AND_DEVICE
    vector_view< TYPE >::vector_view( size_type size, pointer ptr )
-   : m_size( size ), m_ptr( ptr ) {
+   : m_capacity( size ), m_size( nullptr ), m_ptr( ptr ) {
 
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   vector_view< TYPE >::vector_view( size_type capacity, size_pointer size,
+                                     pointer ptr )
+   : m_capacity( capacity ), m_size( size ), m_ptr( ptr ) {
+
+      // A sanity check.
+      assert( ( ( m_size != nullptr ) && ( m_capacity >= *m_size ) ) ||
+              ( m_size == nullptr ) );
    }
 
    template< typename TYPE >
@@ -22,8 +36,57 @@ namespace vecmem { namespace data {
                 bool > >
    VECMEM_HOST_AND_DEVICE
    vector_view< TYPE >::vector_view( const vector_view< OTHERTYPE >& parent )
-   : m_size( parent.m_size ), m_ptr( parent.m_ptr ) {
+   : m_capacity( parent.capacity() ), m_size( parent.size_ptr() ),
+     m_ptr( parent.ptr() ) {
 
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::size_type
+   vector_view< TYPE >::size() const {
+
+      return ( m_size == nullptr ? m_capacity : *m_size );
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::size_type
+   vector_view< TYPE >::capacity() const {
+
+      return m_capacity;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::size_pointer
+   vector_view< TYPE >::size_ptr() {
+
+      return m_size;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::const_size_pointer
+   vector_view< TYPE >::size_ptr() const {
+
+      return m_size;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::pointer
+   vector_view< TYPE >::ptr() {
+
+      return m_ptr;
+   }
+
+   template< typename TYPE >
+   VECMEM_HOST_AND_DEVICE
+   typename vector_view< TYPE >::const_pointer
+   vector_view< TYPE >::ptr() const {
+
+      return m_ptr;
    }
 
 } } // namespace vecmem::data

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -20,10 +20,11 @@ namespace vecmem {
    copy::to( const vecmem::data::vector_view< TYPE >& data,
              memory_resource& resource, type::copy_type cptype ) {
 
-      data::vector_buffer< TYPE > result( data.m_size, resource );
-      do_copy( data.m_size * sizeof( TYPE ), data.m_ptr, result.m_ptr, cptype );
+      data::vector_buffer< TYPE > result( data.capacity(), data.size(),
+                                          resource );
+      this->operator()< TYPE >( data, result, cptype );
       VECMEM_DEBUG_MSG( 2, "Created a vector buffer of type \"%s\" with "
-                        "size %lu", typeid( TYPE ).name(), data.m_size );
+                        "size %lu", typeid( TYPE ).name(), data.size() );
       return result;
    }
 
@@ -32,8 +33,8 @@ namespace vecmem {
                           data::vector_view< TYPE >& to,
                           type::copy_type cptype ) {
 
-      assert( from.m_size == to.m_size );
-      do_copy( from.m_size * sizeof( TYPE ), from.m_ptr, to.m_ptr, cptype );
+      assert( from.size() == to.size() );
+      do_copy( from.size() * sizeof( TYPE ), from.ptr(), to.ptr(), cptype );
    }
 
    template< typename TYPE >
@@ -162,12 +163,12 @@ namespace vecmem {
             // current one.
             std::size_t j = i + 1;
             while( j < size ) {
-               if( array[ j ].m_size == 0 ) {
+               if( array[ j ].size() == 0 ) {
                   ++j;
                   continue;
                }
-               return ( ( array[ i ].m_ptr + array[ i ].m_size ) ==
-                        array[ j ].m_ptr );
+               return ( ( array[ i ].ptr() + array[ i ].size() ) ==
+                        array[ j ].ptr() );
             }
             // If we got here, then the answer is no...
             return false;
@@ -177,27 +178,27 @@ namespace vecmem {
       for( std::size_t i = 0; i < size; ++i ) {
 
          // Skip empty "inner vectors".
-         if( ( from[ i ].m_size == 0 ) && ( to[ i ].m_size == 0 ) ) {
+         if( ( from[ i ].size() == 0 ) && ( to[ i ].size() == 0 ) ) {
             continue;
          }
 
          // Some sanity checks.
-         assert( from[ i ].m_ptr != nullptr );
-         assert( to[ i ].m_ptr != nullptr );
-         assert( from[ i ].m_size != 0 );
-         assert( from[ i ].m_size == to[ i ].m_size );
+         assert( from[ i ].ptr() != nullptr );
+         assert( to[ i ].ptr() != nullptr );
+         assert( from[ i ].size() != 0 );
+         assert( from[ i ].size() == to[ i ].size() );
 
          // Set/update the helper variables.
          if( ( from_ptr == nullptr ) && ( to_ptr == nullptr ) &&
              ( copy_size == 0 ) ) {
-            from_ptr = from[ i ].m_ptr;
-            to_ptr = to[ i ].m_ptr;
-            copy_size = from[ i ].m_size * sizeof( TYPE );
+            from_ptr = from[ i ].ptr();
+            to_ptr = to[ i ].ptr();
+            copy_size = from[ i ].size() * sizeof( TYPE );
          } else {
             assert( from_ptr != nullptr );
             assert( to_ptr != nullptr );
             assert( copy_size != 0 );
-            copy_size += from[ i ].m_size * sizeof( TYPE );
+            copy_size += from[ i ].size() * sizeof( TYPE );
          }
 
          // Check if the next vector element connects to this one. If not,

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -72,14 +72,14 @@ TEST_F( core_device_container_test, vector_buffer ) {
 
    // Create an "owning copy" of the host vector's memory.
    vecmem::data::vector_buffer< int >
-      device_data( host_data.m_size, m_resource );
-   memcpy( device_data.m_ptr, host_data.m_ptr,
-           host_data.m_size * sizeof( int ) );
+      device_data( host_data.size(), m_resource );
+   memcpy( device_data.ptr(), host_data.ptr(),
+           host_data.size() * sizeof( int ) );
 
    // Do some basic tests.
-   EXPECT_EQ( device_data.m_size, host_vector.size() );
-   EXPECT_EQ( memcmp( host_data.m_ptr, device_data.m_ptr,
-                      host_data.m_size * sizeof( int ) ), 0 );
+   EXPECT_EQ( device_data.size(), host_vector.size() );
+   EXPECT_EQ( memcmp( host_data.ptr(), device_data.ptr(),
+                      host_data.size() * sizeof( int ) ), 0 );
 }
 
 /// Test(s) for @c vecmem::data::jagged_vector_buffer
@@ -110,13 +110,13 @@ TEST_F( core_device_container_test, jagged_vector_buffer ) {
    EXPECT_NE( device_data2.m_ptr, device_data2.host_ptr() );
    EXPECT_EQ( device_data2.m_size, host_vector.size() );
    for( std::size_t i = 0; i < host_vector.size(); ++i ) {
-      EXPECT_EQ( device_data1.host_ptr()[ i ].m_size, host_vector[ i ].size() );
-      EXPECT_EQ( device_data2.host_ptr()[ i ].m_size, host_vector[ i ].size() );
+      EXPECT_EQ( device_data1.host_ptr()[ i ].size(), host_vector[ i ].size() );
+      EXPECT_EQ( device_data2.host_ptr()[ i ].size(), host_vector[ i ].size() );
    }
    for( std::size_t i = 0; i < host_vector.size() - 1; ++i ) {
-      EXPECT_EQ( device_data1.host_ptr()[ i ].m_ptr + host_vector[ i ].size(),
-                 device_data1.host_ptr()[ i + 1 ].m_ptr );
-      EXPECT_EQ( device_data2.host_ptr()[ i ].m_ptr + host_vector[ i ].size(),
-                 device_data2.host_ptr()[ i + 1 ].m_ptr );
+      EXPECT_EQ( device_data1.host_ptr()[ i ].ptr() + host_vector[ i ].size(),
+                 device_data1.host_ptr()[ i + 1 ].ptr() );
+      EXPECT_EQ( device_data2.host_ptr()[ i ].ptr() + host_vector[ i ].size(),
+                 device_data2.host_ptr()[ i + 1 ].ptr() );
    }
 }

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -20,7 +20,7 @@ void linearTransformKernel( vecmem::data::vector_view< const int > constants,
 
    // Find the current index.
    const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-   if( i >= input.m_size ) {
+   if( i >= input.size() ) {
       return;
    }
 
@@ -40,7 +40,7 @@ void linearTransform( vecmem::data::vector_view< const int > constants,
                       vecmem::data::vector_view< int > output ) {
 
    // Launch the kernel.
-   linearTransformKernel<<< 1, input.m_size >>>( constants, input, output );
+   linearTransformKernel<<< 1, input.size() >>>( constants, input, output );
    // Check whether it succeeded to run.
    VECMEM_CUDA_ERROR_CHECK( cudaGetLastError() );
    VECMEM_CUDA_ERROR_CHECK( cudaDeviceSynchronize() );

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -24,7 +24,7 @@ void linearTransformKernel( vecmem::data::vector_view< const int > constants,
 
    // Find the current index.
    const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-   if( i >= input.m_size ) {
+   if( i >= input.size() ) {
       return;
    }
 
@@ -44,7 +44,7 @@ void linearTransform( vecmem::data::vector_view< const int > constants,
                       vecmem::data::vector_view< int > output ) {
 
    // Launch the kernel.
-   hipLaunchKernelGGL( linearTransformKernel, 1, input.m_size, 0, nullptr,
+   hipLaunchKernelGGL( linearTransformKernel, 1, input.size(), 0, nullptr,
                        constants, input, output );
    // Check whether it succeeded to run.
    VECMEM_HIP_ERROR_CHECK( hipGetLastError() );

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -54,7 +54,7 @@ TEST_F( sycl_containers_test, shared_memory ) {
            output = vecmem::get_data( outputvec ) ]( cl::sycl::id< 1 > id ) {
 
             // Skip invalid indices.
-            if( id >= input.m_size ) {
+            if( id >= input.size() ) {
                return;
             }
 


### PR DESCRIPTION
Made `vecmem::data::vector_view` hold a separate size and capacity variable. This is meant as a first step towards "extendable" device vectors.

The intended logic is the following:
  - For fixed size device vectors the code's logic pretty much stays as it is now. `vecmem::data::vector_view` holds on to an `std::size_t` variable that describes both the capacity and the size of the array, and a `T*` pointer that points at the array.
  - For "resizable" device vectors `vecmem::data::vector_view` continues to hold the maximum capacity of the vector as a regular `std::size_t` member variable, since the vector capacities inside of the device code will be fixed still. However the actual size of the vector is held in global memory by `vecmem::data::vector_view` in such a case. Opening the possibility for `vecmem::device_vector` to modify the vector size from device code.

This is just the very first step in adding this non-trivial new functionality. We'll need to:
  - Update the code to correctly create "resizable versions" of the data objects;
  - Teach `vecmem::device_vector` how to extend existing vectors in a safe way;
  - Teach the memory copy code some new tricks. (This feature will of course only work with separate host and device memory allocations. We can't have device code try to resize a vector whose memory is owned by a host vector...)

At the same time found a bug in the `vecmem::data::jagged_vector_buffer` code, and cleaned up the `vecmem::copy` implementation a little. Other than those, most of the updates are just to switch from accessing the `vecmem::data::vector_view` variables directly, to using the new accessor functions of the class.

P.S. I only really foresee adding `push_back(...)` and `emplace_back(...)` functions to `vecmem::device_vector`. Removing elements from the vector, or inserting new elements in the middle of it, is off the table. (That could just not be done efficiently in a thread-safe way. But for `push_back(...)` and `emplace_back(...)` we "just" need a few atomic operations...)