### PR TITLE
vecmem::atomic Fixes, main branch (2021.04.20.)

### DIFF
--- a/core/include/vecmem/memory/impl/atomic.ipp
+++ b/core/include/vecmem/memory/impl/atomic.ipp
@@ -12,27 +12,17 @@
 #   include <CL/sycl/atomic.hpp>
 #endif
 
-/// Helpers for super explicit calls to the SYCL atomic functions
+/// Helpers for explicit calls to the SYCL atomic functions
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
 #   define __VECMEM_SYCL_ATOMIC_CALL0( FNAME, PTR )                            \
-   cl::sycl::atomic_##FNAME< value_type,                                       \
-                             cl::sycl::access::address_space::global_space >(  \
-      cl::sycl::atomic< value_type >(                                          \
-         cl::sycl::multi_ptr< value_type,                                      \
-            cl::sycl::access::address_space::global_space >( PTR ) ) )
+   cl::sycl::atomic_##FNAME< value_type >( cl::sycl::atomic< value_type >(     \
+         cl::sycl::global_ptr< value_type >( PTR ) ) )
 #   define __VECMEM_SYCL_ATOMIC_CALL1( FNAME, PTR, ARG1 )                      \
-   cl::sycl::atomic_##FNAME< value_type,                                       \
-                             cl::sycl::access::address_space::global_space >(  \
-      cl::sycl::atomic< value_type >(                                          \
-         cl::sycl::multi_ptr< value_type,                                      \
-            cl::sycl::access::address_space::global_space >( PTR ) ), ARG1 )
+   cl::sycl::atomic_##FNAME< value_type >( cl::sycl::atomic< value_type >(     \
+         cl::sycl::global_ptr< value_type >( PTR ) ), ARG1 )
 #   define __VECMEM_SYCL_ATOMIC_CALL2( FNAME, PTR, ARG1, ARG2 )                \
-   cl::sycl::atomic_##FNAME< value_type,                                       \
-                             cl::sycl::access::address_space::global_space >(  \
-      cl::sycl::atomic< value_type >(                                          \
-         cl::sycl::multi_ptr< value_type,                                      \
-            cl::sycl::access::address_space::global_space >( PTR ) ), ARG1,    \
-            ARG2 )
+   cl::sycl::atomic_##FNAME< value_type >( cl::sycl::atomic< value_type >(     \
+         cl::sycl::global_ptr< value_type >( PTR ) ), ARG1, ARG2 )
 #endif
 
 namespace vecmem {
@@ -124,7 +114,9 @@ namespace vecmem {
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
       return __VECMEM_SYCL_ATOMIC_CALL1( fetch_add, m_ptr, data );
 #else
-      return ( *m_ptr += data );
+      const value_type result = *m_ptr;
+      *m_ptr += data;
+      return result;
 #endif
    }
 
@@ -138,7 +130,9 @@ namespace vecmem {
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
       return __VECMEM_SYCL_ATOMIC_CALL1( fetch_sub, m_ptr, data );
 #else
-      return ( *m_ptr -= data );
+      const value_type result = *m_ptr;
+      *m_ptr -= data;
+      return result;
 #endif
    }
 
@@ -152,7 +146,9 @@ namespace vecmem {
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
       return __VECMEM_SYCL_ATOMIC_CALL1( fetch_and, m_ptr, data );
 #else
-      return ( *m_ptr &= data );
+      const value_type result = *m_ptr;
+      *m_ptr &= data;
+      return result;
 #endif
    }
 
@@ -166,7 +162,9 @@ namespace vecmem {
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
       return __VECMEM_SYCL_ATOMIC_CALL1( fetch_or, m_ptr, data );
 #else
-      return ( *m_ptr |= data );
+      const value_type result = *m_ptr;
+      *m_ptr |= data;
+      return result;
 #endif
    }
 
@@ -180,7 +178,9 @@ namespace vecmem {
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
       return __VECMEM_SYCL_ATOMIC_CALL1( fetch_xor, m_ptr, data );
 #else
-      return ( *m_ptr ^= data );
+      const value_type result = *m_ptr;
+      *m_ptr ^= data;
+      return result;
 #endif
    }
 


### PR DESCRIPTION
Fixed the host implementation of `vecmem::atomic`, as I had to find while starting to use it in `vemcem::device_vector`, that it was not correct. :frowning:

At the same time simplified the incantations for the SYCL atomic calls a little bit. (Now that I understand a bit better how the oneAPI atomic implementation is designed.)

Note that  the current scope of the SYCL atomic calls is wider than those used in the CUDA and HIP code. The CUDA and HIP atomic calls are "device specific". While the SYCL calls, in their current form, are "global". Since this is the default for SYCL atomics, I didn't want to change it for now. But we'll probably want to think about using `sycl::device_ptr` instead of the current `sycl::global_ptr` later on, once we start any performance measurements.