### PR TITLE
vecmem::data::vector_buffer Fix, main branch (2021.04.20.)

### DIFF
--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -24,8 +24,9 @@ namespace {
 
       // Decide how many bytes to allocate.
       const std::size_t byteSize =
-         ( ( capacity == size ) ? ( size * sizeof( TYPE ) ) :
-           ( sizeof( std::size_t ) + size * sizeof( TYPE ) ) );
+         ( ( capacity == size ) ? ( capacity * sizeof( TYPE ) ) :
+           ( sizeof( typename vecmem::data::vector_buffer< TYPE >::size_type ) +
+             capacity * sizeof( TYPE ) ) );
 
       // Return the appropriate smart pointer.
       return { capacity == 0 ? nullptr :


### PR DESCRIPTION
Fixed how `vecmem::data::vector_buffer` allocates memory for itself. Previously it would not behave correctly for "resizable buffers". :frowning:

At the same time notice that I removed the careless usage of `std::size_t` from the allocator helper function. As the size type will be updated to `unsigned int` with the introduction of the resizable `vecmem::device_vector` feature. (GPUs don't like to perform atomic operations on `std::size_t` variables...)