### PR TITLE
Extendable Device Vectors - Part 3, vecmem::copy Updates, main branch (2021.04.20.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -60,6 +60,10 @@ namespace vecmem {
       /// @name 1-dimensional vector data handling functions
       /// @{
 
+      /// Set up the internal state of a vector buffer correctly on a device
+      template< typename TYPE >
+      void setup( data::vector_view< TYPE >& data );
+
       /// Copy a 1-dimensional vector to the specified memory resource
       template< typename TYPE >
       data::vector_buffer< TYPE >
@@ -134,6 +138,8 @@ namespace vecmem {
       /// Perform a "low level" memory copy
       virtual void do_copy( std::size_t size, const void* from, void* to,
                             type::copy_type cptype );
+      /// Perform a "low level" memory filling operation
+      virtual void do_memset( std::size_t size, void* ptr, int value );
 
    private:
       /// Helper function performing the copy of a jagged array/vector
@@ -141,6 +147,10 @@ namespace vecmem {
       void copy_views( std::size_t size, const data::vector_view< TYPE >* from,
                        data::vector_view< TYPE >* to,
                        type::copy_type cptype );
+      /// Helper function for getting the size of a resizable 1D buffer
+      template< typename TYPE >
+      typename data::vector_view< TYPE >::size_type
+      get_size( const data::vector_view< TYPE >& data );
 
    }; // class copy
 

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -26,4 +26,14 @@ namespace vecmem {
                         "to %p", size, from, to );
    }
 
+   void copy::do_memset( std::size_t size, void* ptr, int value ) {
+
+      // Perform the POSIX memory setting operation.
+      memset( ptr, value, size );
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 4, "Set %lu bytes to %i at %p with POSIX memset", size,
+                        value, ptr );
+   }
+
 } // namespace vecmem

--- a/cuda/include/vecmem/utils/cuda/copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/copy.hpp
@@ -19,6 +19,8 @@ namespace vecmem::cuda {
       /// Perform a memory copy using CUDA
       virtual void do_copy( std::size_t size, const void* from, void* to,
                             type::copy_type cptype ) override;
+      /// Fill a memory area using CUDA
+      virtual void do_memset( std::size_t size, void* ptr, int value ) override;
 
    }; // class copy
 

--- a/cuda/src/utils/cuda/copy.cpp
+++ b/cuda/src/utils/cuda/copy.cpp
@@ -65,4 +65,23 @@ namespace vecmem::cuda {
                         to );
    }
 
+   void copy::do_memset( std::size_t size, void* ptr, int value ) {
+
+      // Check if anything needs to be done.
+      if( size == 0 ) {
+         VECMEM_DEBUG_MSG( 5, "Skipping unnecessary memory filling" );
+         return;
+      }
+
+      // Some sanity checks.
+      assert( ptr != nullptr );
+
+      // Perform the operation.
+      VECMEM_CUDA_ERROR_CHECK( cudaMemset( ptr, value, size ) );
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 4, "Set %lu bytes to %i at %p with CUDA", size, value,
+                        ptr );
+   }
+
 } // namespace vecmem::cuda

--- a/hip/include/vecmem/utils/hip/copy.hpp
+++ b/hip/include/vecmem/utils/hip/copy.hpp
@@ -19,6 +19,8 @@ namespace vecmem::hip {
       /// Perform a memory copy using HIP
       virtual void do_copy( std::size_t size, const void* from, void* to,
                             type::copy_type cptype ) override;
+      /// Fill a memory area using HIP
+      virtual void do_memset( std::size_t size, void* ptr, int value ) override;
 
    }; // class copy
 

--- a/hip/src/utils/hip/copy.cpp
+++ b/hip/src/utils/hip/copy.cpp
@@ -65,4 +65,23 @@ namespace vecmem::hip {
                         to );
    }
 
+   void copy::do_memset( std::size_t size, void* ptr, int value ) {
+
+      // Check if anything needs to be done.
+      if( size == 0 ) {
+         VECMEM_DEBUG_MSG( 5, "Skipping unnecessary memory filling" );
+         return;
+      }
+
+      // Some sanity checks.
+      assert( ptr != nullptr );
+
+      // Perform the operation.
+      VECMEM_HIP_ERROR_CHECK( hipMemset( ptr, value, size ) );
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 4, "Set %lu bytes to %i at %p with HIP", size, value,
+                        ptr );
+   }
+
 } // namespace vecmem::hip

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -30,6 +30,8 @@ namespace vecmem::sycl {
       /// Perform a memory copy using SYCL
       virtual void do_copy( std::size_t size, const void* from, void* to,
                             type::copy_type cptype ) override;
+      /// Fill a memory area using SYCL
+      virtual void do_memset( std::size_t size, void* ptr, int value ) override;
 
    private:
       /// The queue that the copy operations are made with/for

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -24,12 +24,43 @@ namespace vecmem::sycl {
    void copy::do_copy( std::size_t size, const void* from, void* to,
                        type::copy_type ) {
 
+      // Check if anything needs to be done.
+      if( size == 0 ) {
+         VECMEM_DEBUG_MSG( 5, "Skipping unnecessary memory copy" );
+         return;
+      }
+
+      // Some sanity checks.
+      assert( from != nullptr );
+      assert( to != nullptr );
+
       // Perform the copy.
-      details::get_queue( m_queue ).memcpy( to, from, size );
+      auto event = details::get_queue( m_queue ).memcpy( to, from, size );
+      event.wait_and_throw();
 
       // Let the user know what happened.
       VECMEM_DEBUG_MSG( 4, "Performed memory copy of %lu bytes from %p to %p",
                         size, from, to );
+   }
+
+   void copy::do_memset( std::size_t size, void* ptr, int value ) {
+
+      // Check if anything needs to be done.
+      if( size == 0 ) {
+         VECMEM_DEBUG_MSG( 5, "Skipping unnecessary memory filling" );
+         return;
+      }
+
+      // Some sanity checks.
+      assert( ptr != nullptr );
+
+      // Perform the operation.
+      auto event = details::get_queue( m_queue ).memset( ptr, value, size );
+      event.wait_and_throw();
+
+      // Let the user know what happened.
+      VECMEM_DEBUG_MSG( 4, "Set %lu bytes to %i at %p with SYCL", size, value,
+                        ptr );
    }
 
 } // namespace vecmem::sycl


### PR DESCRIPTION
I taught the copy classes how to deal with resizable vector buffers. Since the size of such buffers is not necessarily host accessible, one needs to be careful with both their initial setup, and copying data to/from them.

This meant adding a new `setup(...)` function to `vecmem::copy`, and introducing the `do_memset(...)` virtual function for all of the copy classes, as a small optimisation over only using `do_copy(...)`.

Note that my idea here is that the "inner vectors" of jagged vectors could become resizable eventually. Not the outer vectors, as doing that in a thread-safe way would be pretty impossible. But the inner vectors should be possible to handle like this. (In the Acts seed finding code such output arrays are used in a few places...)