### PR TITLE
Debug Message Handling Tests, main branch (2021.04.21.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         BUILD_TYPE: [ "Release", "Debug" ]
+        DEBUG_MSG_LVL: [ 0, 5 ]
 
     # The build/test steps to execute.
     steps:
@@ -30,7 +31,9 @@ jobs:
     - uses: actions/checkout@v2
     # Run the CMake configuration.
     - name: Configure
-      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -S $GITHUB_WORKSPACE -B build
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
+                 -DVECMEM_DEBUG_MSG_LVL=${{ matrix.DEBUG_MSG_LVL }}
+                 -S $GITHUB_WORKSPACE -B build
     # Perform the build.
     - name: Build
       run: cmake --build build
@@ -41,7 +44,7 @@ jobs:
         ctest --output-on-failure
 
   # Builds inside of a CUDA or ROCm/HIP Docker image.
-  cuda_hip:
+  cuda-and-hip:
 
     # The different build modes to test.
     strategy:
@@ -49,6 +52,7 @@ jobs:
         CONTAINER: [ "ghcr.io/acts-project/ubuntu1804_cuda:v11",
                      "ghcr.io/acts-project/ubuntu1804_rocm:v11" ]
         BUILD_TYPE: [ "Release", "Debug" ]
+        DEBUG_MSG_LVL: [ 0, 5 ]
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -61,6 +65,7 @@ jobs:
     # Run the CMake configuration.
     - name: Configure
       run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
+                 -DVECMEM_DEBUG_MSG_LVL=${{ matrix.DEBUG_MSG_LVL }}
                  -S $GITHUB_WORKSPACE -B build
     # Perform the build.
     - name: Build
@@ -77,6 +82,7 @@ jobs:
     strategy:
       matrix:
         BUILD_TYPE: [ "Release", "Debug" ]
+        DEBUG_MSG_LVL: [ 0, 5 ]
 
     # Use BASH as the shell from the image.
     defaults:
@@ -92,7 +98,7 @@ jobs:
       run: |
         source /opt/intel/oneapi/setvars.sh
         export CXX=`which clang++`
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -S $GITHUB_WORKSPACE -B build
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }} -DVECMEM_DEBUG_MSG_LVL=${{ matrix.DEBUG_MSG_LVL }} -S $GITHUB_WORKSPACE -B build
     # Perform the build.
     - name: Build
       run: |


### PR DESCRIPTION
Added builds with all debug messages enabled. So that formatting mistakes in the debug message declarations would be detected by the CI. Plus to check that the results of the unit tests do not change because of turning on the debug messages.

At the same time renamed the "cuda_hip" build to "cuda-and-hip". I just didn't like the "cuda_hip" name all too much... (Yes, I was the one who introduced the "cuda_hip" name. But I changed my mind since. :stuck_out_tongue:)

This was triggered by me realising that #76 is actually not able to compile with `-DVECMEM_DEBUG_MSG_LVL=2` at the moment. :frowning: (I forgot about some minor updates...)