### PR TITLE
Extendable Device Vectors - Part 5, Jagged Vectors (2021.04.23.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -79,6 +79,21 @@ namespace vecmem { namespace data {
                             memory_resource& resource,
                             memory_resource* host_access_resource = nullptr );
 
+      /// Constructor from a vector of ("inner vector") sizes and capacities
+      ///
+      /// @param sizes Simple vector holding the sizes of the "inner vectors"
+      ///        for the jagged vector buffer.
+      /// @param capacities Simple vector holding the capacities of the
+      ///        "inner vectors" for the jagged vector buffer.
+      /// @param resource The device accessible memory resource, which may also
+      ///        be host accessible.
+      /// @param host_access_resource An optional host accessible memory
+      ///        resource. Needed if @c resource is not host accessible.
+      jagged_vector_buffer( const std::vector< std::size_t >& sizes,
+                            const std::vector< std::size_t >& capacities,
+                            memory_resource& resource,
+                            memory_resource* host_access_resource = nullptr );
+
       /// Access the host accessible array describing the inner vectors
       ///
       /// This may or may not return the same pointer that
@@ -97,7 +112,7 @@ namespace vecmem { namespace data {
       /// Data object for the @c vecmem::data::vector_view array on the host
       std::unique_ptr< value_type, details::deallocator > m_outer_host_memory;
       /// Data object owning the memory of the "inner vectors"
-      std::unique_ptr< TYPE, details::deallocator > m_inner_memory;
+      std::unique_ptr< char, details::deallocator > m_inner_memory;
 
    }; // class jagged_vector_buffer
 

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -8,6 +8,7 @@
 #pragma once
 
 // System include(s).
+#include <cassert>
 #include <cstddef>
 #include <numeric>
 #include <vector>
@@ -48,16 +49,21 @@ namespace {
 
    /// Function allocating memory for @c vecmem::data::jagged_vector_buffer
    template< typename TYPE >
-   std::unique_ptr< TYPE, vecmem::details::deallocator >
+   std::unique_ptr< char, vecmem::details::deallocator >
    allocate_jagged_buffer_inner_memory(
       const std::vector< std::size_t >& sizes,
-      vecmem::memory_resource& resource ) {
+      vecmem::memory_resource& resource, bool isResizable ) {
 
-      const typename vecmem::data::jagged_vector_buffer< TYPE >::size_type
+      typename vecmem::data::jagged_vector_buffer< TYPE >::size_type
          byteSize = std::accumulate( sizes.begin(), sizes.end(), 0 ) *
                     sizeof( TYPE );
+      if( isResizable ) {
+         byteSize += sizes.size() * sizeof(
+            typename
+            vecmem::data::jagged_vector_buffer< TYPE >::value_type::size_type );
+      }
       return { byteSize == 0 ? nullptr :
-               static_cast< TYPE* >( resource.allocate( byteSize ) ),
+               static_cast< char* >( resource.allocate( byteSize ) ),
                { byteSize, resource } };
    }
 
@@ -93,7 +99,8 @@ namespace vecmem { namespace data {
            ( host_access_resource == nullptr ? resource :
              *host_access_resource ) ) ),
      m_inner_memory(
-        ::allocate_jagged_buffer_inner_memory< TYPE >( sizes, resource ) ) {
+        ::allocate_jagged_buffer_inner_memory< TYPE >( sizes, resource,
+                                                       false ) ) {
 
       // Point the base class at the newly allocated memory.
       base_type::m_ptr = ( ( host_access_resource != nullptr ) ?
@@ -102,10 +109,52 @@ namespace vecmem { namespace data {
       // Set up the host accessible memory array.
       std::ptrdiff_t ptrdiff = 0;
       for( std::size_t i = 0; i < sizes.size(); ++i ) {
-         new( host_ptr() + i ) value_type();
-         host_ptr()[ i ] =
-            value_type( sizes[ i ], m_inner_memory.get() + ptrdiff );
-         ptrdiff += sizes[ i ];
+         new( host_ptr() + i )
+         value_type( sizes[ i ],
+                     reinterpret_cast< TYPE* >( m_inner_memory.get() +
+                                                ptrdiff ) );
+         ptrdiff += sizes[ i ] * sizeof( TYPE );
+      }
+   }
+
+   template< typename TYPE >
+   jagged_vector_buffer< TYPE >::
+   jagged_vector_buffer( const std::vector< std::size_t >& sizes,
+                         const std::vector< std::size_t >& capacities,
+                         memory_resource& resource,
+                         memory_resource* host_access_resource )
+   : base_type( sizes.size(), nullptr ),
+     m_outer_memory(
+        ::allocate_jagged_buffer_outer_memory< TYPE >(
+           ( host_access_resource == nullptr ? 0 : sizes.size() ),
+           resource ) ),
+     m_outer_host_memory(
+        ::allocate_jagged_buffer_outer_memory< TYPE >( sizes.size(),
+           ( host_access_resource == nullptr ? resource :
+             *host_access_resource ) ) ),
+     m_inner_memory(
+        ::allocate_jagged_buffer_inner_memory< TYPE >( capacities, resource,
+                                                       true ) ) {
+
+      // Some sanity check.
+      assert( sizes.size() == capacities.size() );
+
+      // Point the base class at the newly allocated memory.
+      base_type::m_ptr = ( ( host_access_resource != nullptr ) ?
+                           m_outer_memory.get() : m_outer_host_memory.get() );
+
+      // Set up the host accessible memory array.
+      std::ptrdiff_t ptrdiff = 0;
+      for( std::size_t i = 0; i < capacities.size(); ++i ) {
+         new( host_ptr() + i )
+         value_type( capacities[ i ],
+                     reinterpret_cast< typename value_type::size_pointer >(
+                        m_inner_memory.get() + ptrdiff ),
+                     reinterpret_cast< TYPE* >(
+                        m_inner_memory.get() + ptrdiff +
+                        sizeof( typename value_type::size_type ) ) );
+         ptrdiff += capacities[ i ] * sizeof( TYPE ) +
+                    sizeof( typename value_type::size_type );
       }
    }
 

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -24,9 +24,6 @@ namespace vecmem { namespace data {
                                      pointer ptr )
    : m_capacity( capacity ), m_size( size ), m_ptr( ptr ) {
 
-      // A sanity check.
-      assert( ( ( m_size != nullptr ) && ( m_capacity >= *m_size ) ) ||
-              ( m_size == nullptr ) );
    }
 
    template< typename TYPE >

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -132,6 +132,20 @@ namespace vecmem {
                        data::jagged_vector_buffer< TYPE >& to,
                        type::copy_type cptype = type::unknown );
 
+      /// Copy a jagged vector's data into a vector object
+      template< typename TYPE1, typename TYPE2,
+                typename ALLOC1, typename ALLOC2 >
+      void operator()( const data::jagged_vector_view< TYPE1 >& from,
+                       std::vector< std::vector< TYPE2, ALLOC2 >, ALLOC1 >& to,
+                       type::copy_type cptype = type::unknown );
+
+      /// Copy a jagged vector's data into a vector object
+      template< typename TYPE1, typename TYPE2,
+                typename ALLOC1, typename ALLOC2 >
+      void operator()( const data::jagged_vector_buffer< TYPE1 >& from,
+                       std::vector< std::vector< TYPE2, ALLOC2 >, ALLOC1 >& to,
+                       type::copy_type cptype = type::unknown );
+
       /// @}
 
    protected:

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -6,14 +6,20 @@
  * Mozilla Public License Version 2.0
  */
 
+// VecMem include(s).
 #include "vecmem/memory/host_memory_resource.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
 #include "vecmem/containers/data/jagged_vector_data.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/utils/copy.hpp"
 
+// GoogleTest include(s).
 #include <gtest/gtest.h>
+
+// System include(s).
+#include <set>
 
 class core_jagged_vector_view_test : public testing::Test {
     protected:
@@ -125,4 +131,44 @@ TEST_F(core_jagged_vector_view_test, value_iteration) {
         i += innerv.size();
     }
     EXPECT_EQ( i, 16 );
+}
+
+TEST_F(core_jagged_vector_view_test, filter) {
+
+    // Helper object for performing memory copies.
+    vecmem::copy copy;
+
+    // Create a resizable buffer for a jagged vector.
+    vecmem::data::jagged_vector_buffer< int >
+        output_data( { 0, 0, 0, 0, 0, 0 }, { 10, 10, 10, 10, 10, 10 }, m_mem );
+    copy.setup( output_data );
+
+    // Fill the jagged vector buffer with just the odd elements.
+    vecmem::jagged_device_vector device_vec( output_data );
+    for( std::size_t i = 0; i < m_vec.size(); ++i ) {
+        for( std::size_t j = 0; j < m_vec.at( i ).size(); ++j ) {
+            if( ( m_vec[ i ][ j ] % 2 ) != 0 ) {
+                device_vec[ i ].push_back( m_vec[ i ][ j ] );
+            }
+        }
+    }
+
+    // Copy the filtered output back into a "host object".
+    vecmem::jagged_vector< int > output( &m_mem );
+    copy( output_data, output );
+
+    // Check the output.
+    EXPECT_EQ( output.size(), 6 );
+    EXPECT_EQ( std::set< int >( output[ 0 ].begin(), output[ 0 ].end() ),
+               std::set< int >( { 1, 3 } ) );
+    EXPECT_EQ( std::set< int >( output[ 1 ].begin(), output[ 1 ].end() ),
+               std::set< int >( { 5 } ) );
+    EXPECT_EQ( std::set< int >( output[ 2 ].begin(), output[ 2 ].end() ),
+               std::set< int >( { 7, 9 } ) );
+    EXPECT_EQ( std::set< int >( output[ 3 ].begin(), output[ 3 ].end() ),
+               std::set< int >( { 11 } ) );
+    EXPECT_EQ( std::set< int >( output[ 4 ].begin(), output[ 4 ].end() ),
+               std::set< int >( {} ) );
+    EXPECT_EQ( std::set< int >( output[ 5 ].begin(), output[ 5 ].end() ),
+               std::set< int >( { 13, 15 } ) );
 }

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -8,6 +8,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
 
 // System include(s).
@@ -25,3 +26,8 @@ void atomicTransform( std::size_t iterations,
 /// Function filtering elements of an input vector into an output vector
 void filterTransform( vecmem::data::vector_view< const int > input,
                       vecmem::data::vector_view< int > output );
+
+/// Function filtering elements of an input vector into an output vector
+void filterTransform( vecmem::data::jagged_vector_view< const int > input,
+                      std::size_t max_vec_size,
+                      vecmem::data::jagged_vector_view< int > output );

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -177,3 +177,43 @@ void filterTransform( vecmem::data::vector_view< const int > input,
    VECMEM_HIP_ERROR_CHECK( hipGetLastError() );
    VECMEM_HIP_ERROR_CHECK( hipDeviceSynchronize() );
 }
+
+/// Kernel filtering the input vector elements into the output vector
+__global__
+void filterTransformKernel( vecmem::data::jagged_vector_view< const int > input,
+                            vecmem::data::jagged_vector_view< int > output ) {
+
+   // Find the current indices.
+   const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+   if( i >= input.m_size ) {
+      return;
+   }
+   const std::size_t j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+   if( j >= input.m_ptr[ i ].size() ) {
+      return;
+   }
+
+   // Set up the vector objects.
+   const vecmem::jagged_device_vector< const int > inputvec( input );
+   vecmem::jagged_device_vector< int > outputvec( output );
+
+   // Keep just the odd elements.
+   const int value = inputvec[ i ][ j ];
+   if( ( value % 2 ) != 0 ) {
+      outputvec.at( i ).push_back( value );
+   }
+   return;
+}
+
+void filterTransform( vecmem::data::jagged_vector_view< const int > input,
+                      std::size_t max_vec_size,
+                      vecmem::data::jagged_vector_view< int > output ) {
+
+   // Launch the kernel.
+   hipLaunchKernelGGL( filterTransformKernel, 1,
+                       dim3( input.m_size, max_vec_size ), 0, nullptr,
+                       input, output );
+   // Check whether it succeeded to run.
+   VECMEM_HIP_ERROR_CHECK( hipGetLastError() );
+   VECMEM_HIP_ERROR_CHECK( hipDeviceSynchronize() );
+}

--- a/tests/hip/test_hip_containers_kernels.hpp
+++ b/tests/hip/test_hip_containers_kernels.hpp
@@ -30,3 +30,8 @@ void atomicTransform( std::size_t iterations,
 /// Function filtering elements of an input vector into an output vector
 void filterTransform( vecmem::data::vector_view< const int > input,
                       vecmem::data::vector_view< int > output );
+
+/// Function filtering elements of an input vector into an output vector
+void filterTransform( vecmem::data::jagged_vector_view< const int > input,
+                      std::size_t max_vec_size,
+                      vecmem::data::jagged_vector_view< int > output );

--- a/tests/hip/test_hip_jagged_containers.cpp
+++ b/tests/hip/test_hip_jagged_containers.cpp
@@ -176,3 +176,41 @@ TEST_F( hip_jagged_containers_test, set_in_contiguous_kernel ) {
    EXPECT_EQ( output[ 5 ][ 3 ], 31 );
    EXPECT_EQ( output[ 5 ][ 4 ], 33 );
 }
+
+/// Test filling a resizable jagged vector
+TEST_F( hip_jagged_containers_test, filter ) {
+
+   // Helper object for performing memory copies.
+   vecmem::hip::copy copy;
+
+   // Create the output data on the device.
+   vecmem::hip::device_memory_resource device_resource;
+   vecmem::data::jagged_vector_buffer< int >
+       output_data_device( { 0, 0, 0, 0, 0, 0 }, { 10, 10, 10, 10, 10, 10 },
+                           device_resource, &m_mem );
+   copy.setup( output_data_device );
+
+   // Run the filtering.
+   filterTransform( vecmem::get_data( m_vec ), 5, output_data_device );
+
+   // Copy the filtered output back into the host's memory.
+   vecmem::jagged_vector< int > output( &m_mem );
+   copy( output_data_device, output );
+
+   // Check the output. Note that the order of elements in the "inner vectors"
+   // is not fixed. And for the single-element and empty vectors I just decided
+   // to use the same formalism simply for symmetry...
+   EXPECT_EQ( output.size(), 6 );
+   EXPECT_EQ( std::set< int >( output[ 0 ].begin(), output[ 0 ].end() ),
+              std::set< int >( { 1, 3 } ) );
+   EXPECT_EQ( std::set< int >( output[ 1 ].begin(), output[ 1 ].end() ),
+              std::set< int >( { 5 } ) );
+   EXPECT_EQ( std::set< int >( output[ 2 ].begin(), output[ 2 ].end() ),
+              std::set< int >( { 7, 9 } ) );
+   EXPECT_EQ( std::set< int >( output[ 3 ].begin(), output[ 3 ].end() ),
+              std::set< int >( { 11 } ) );
+   EXPECT_EQ( std::set< int >( output[ 4 ].begin(), output[ 4 ].end() ),
+              std::set< int >( {} ) );
+   EXPECT_EQ( std::set< int >( output[ 5 ].begin(), output[ 5 ].end() ),
+              std::set< int >( { 13, 15 } ) );
+}

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -330,3 +330,71 @@ TEST_F( sycl_jagged_containers_test, set_in_contiguous_kernel ) {
    EXPECT_EQ( output[ 5 ][ 3 ], 31 );
    EXPECT_EQ( output[ 5 ][ 4 ], 33 );
 }
+
+/// Test filling a resizable jagged vector
+TEST_F( sycl_jagged_containers_test, filter ) {
+
+   // Helper object for performing memory copies.
+   vecmem::sycl::copy copy( &m_queue );
+
+   // Create the output data on the device.
+   vecmem::sycl::device_memory_resource device_resource( &m_queue );
+   vecmem::data::jagged_vector_buffer< int >
+       output_data_device( { 0, 0, 0, 0, 0, 0 }, { 10, 10, 10, 10, 10, 10 },
+                           device_resource, &m_mem );
+   copy.setup( output_data_device );
+
+   // Create the view/data objects of the jagged vector outside of the
+   // submission.
+   auto input_data = vecmem::get_data( m_vec );
+
+   // Run the filtering.
+   m_queue.submit( [ &input_data,
+                     &output_data_device ]( cl::sycl::handler& h ) {
+      h.parallel_for< class FilterKernel >(
+         cl::sycl::range< 2 >( input_data.m_size, 5 ),
+         [ input = vecmem::get_data( input_data ),
+           output = vecmem::get_data( output_data_device ) ](
+            cl::sycl::item< 2 > id ) {
+
+            // Skip invalid indices.
+            if( id[ 0 ] >= input.m_size ) {
+               return;
+            }
+            if( id[ 1 ] >= input.m_ptr[ id[ 0 ] ].size() ) {
+               return;
+            }
+
+            // Set up the vector objects.
+            const vecmem::jagged_device_vector< const int > inputvec( input );
+            vecmem::jagged_device_vector< int > outputvec( output );
+
+            // Keep just the odd elements.
+            const int value = inputvec[ id[ 0 ] ][ id[ 1 ] ];
+            if( ( value % 2 ) != 0 ) {
+               outputvec.at( id[ 0 ] ).push_back( value );
+            }
+         } );
+   } );
+
+   // Copy the filtered output back into the host's memory.
+   vecmem::jagged_vector< int > output( &m_mem );
+   copy( output_data_device, output );
+
+   // Check the output. Note that the order of elements in the "inner vectors"
+   // is not fixed. And for the single-element and empty vectors I just decided
+   // to use the same formalism simply for symmetry...
+   EXPECT_EQ( output.size(), 6 );
+   EXPECT_EQ( std::set< int >( output[ 0 ].begin(), output[ 0 ].end() ),
+              std::set< int >( { 1, 3 } ) );
+   EXPECT_EQ( std::set< int >( output[ 1 ].begin(), output[ 1 ].end() ),
+              std::set< int >( { 5 } ) );
+   EXPECT_EQ( std::set< int >( output[ 2 ].begin(), output[ 2 ].end() ),
+              std::set< int >( { 7, 9 } ) );
+   EXPECT_EQ( std::set< int >( output[ 3 ].begin(), output[ 3 ].end() ),
+              std::set< int >( { 11 } ) );
+   EXPECT_EQ( std::set< int >( output[ 4 ].begin(), output[ 4 ].end() ),
+              std::set< int >( {} ) );
+   EXPECT_EQ( std::set< int >( output[ 5 ].begin(), output[ 5 ].end() ),
+              std::set< int >( { 13, 15 } ) );
+}


### PR DESCRIPTION
With 1D vectors being resizable, the next step is to allow jagged vectors to be resizable inside of device code as well.

For now I only allow the "inner vectors" of a jagged vector to be resized from device code. It would not be impossible to extend this to the "outer vector" later on as well. But most algorithms that I used so far can live with just this functionality already.

The logic in `vecmem::data::jagged_vector_buffer` is pretty much the same as in `vecmem::data::vector_buffer` for making the managed arrays resizable. Just like in #75, I had to teach `vecmem::copy` how to handle resizable jagged vector buffers as well. But notice that `vecmem::jagged_device_vector` did not actually need to be touched in this PR! :smile:

I still have to write the test for CUDA, and test the SYCL code on actual accelerated hardware. So for now this is just a draft.