### PR TITLE
Library Build Options Update, main branch (2021.04.29.)

### DIFF
--- a/cmake/vecmem-options.cmake
+++ b/cmake/vecmem-options.cmake
@@ -4,29 +4,37 @@
 #
 # Mozilla Public License Version 2.0
 
+# Guard against multiple includes.
+include_guard( GLOBAL )
+
 # Look for the supported GPU languages.
 include( vecmem-check-language )
 vecmem_check_language( CUDA )
 vecmem_check_language( HIP )
 vecmem_check_language( SYCL )
 
-# Set up the project's options.
-include( CMakeDependentOption )
+# Helper function for setting up the library building flags.
+function( vecmem_lib_option language descr )
+
+   # Figure out what the default value should be for the variable.
+   set( _default FALSE )
+   if( CMAKE_${language}_COMPILER )
+      set( _default TRUE )
+   endif()
+
+   # Set up the configuration option.
+   option( VECMEM_BUILD_${language}_LIBRARY "${descr}" ${_default} )
+
+endfunction( vecmem_lib_option )
 
 # Flag specifying whether CUDA support should be built.
-cmake_dependent_option( VECMEM_BUILD_CUDA_LIBRARY
-   "Build the vecmem::cuda library" ON
-   "CMAKE_CUDA_COMPILER" OFF )
+vecmem_lib_option( CUDA "Build the vecmem::cuda library" )
 
 # Flag specifying whether HIP support should be built.
-cmake_dependent_option( VECMEM_BUILD_HIP_LIBRARY
-   "Build the vecmem::hip library" ON
-   "CMAKE_HIP_COMPILER" OFF )
+vecmem_lib_option( HIP "Build the vecmem::hip library" )
 
 # Flag specifying whether SYCL support should be built.
-cmake_dependent_option( VECMEM_BUILD_SYCL_LIBRARY
-   "Build the vecmem::sycl library" ON
-   "CMAKE_SYCL_COMPILER" OFF )
+vecmem_lib_option( SYCL "Build the vecmem::sycl library" )
 
 # Debug message output level in the code.
 set( VECMEM_DEBUG_MSG_LVL 0 CACHE STRING


### PR DESCRIPTION
This makes it possible to turn library builds on, even if the necessary compiler is missing.

This can be useful for debugging issues with a build. It should also allow us using [triSYCL](https://github.com/triSYCL/triSYCL) (or other non-compiler-based SYCL implementations) in the build later on. Once/if I figure out a good way of doing that... (I have ideas, but they all seem uncomfortably complicated right now...)