### PR TITLE
Implement a static array type

### DIFF
--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -1,0 +1,237 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/utils/types.hpp"
+
+#include <cstddef>
+#include <type_traits>
+#include <stdexcept>
+
+namespace vecmem {
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    static_array<T, N>::static_array(
+        void
+    ) {
+        /*
+         * This function does quite literally nothing, and leaves the array's
+         * contents uninitialized.
+         */
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST
+    constexpr
+    typename static_array<T, N>::reference
+    static_array<T, N>::at(
+        size_type i
+    ) {
+        /*
+         * The at function is bounds-checking in the standard library, so we
+         * do a boundary check in our code, too. This makes this method
+         * incompatible with device code.
+         */
+        if (i >= N) {
+            throw std::out_of_range("Index greater than size of static array.");
+        }
+
+        return operator[](i);
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST
+    constexpr
+    typename static_array<T, N>::const_reference
+    static_array<T, N>::at(
+        size_type i
+    ) const {
+        /*
+         * Same thing as with the other at function, we do a bounds check in
+         * accordance with the standard library.
+         */
+        if (i >= N) {
+            throw std::out_of_range("Index greater than size of static array.");
+        }
+
+        return operator[](i);
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::reference
+    static_array<T, N>::operator[](
+        size_type i
+    ) {
+        /*
+         * Non-bounds checking access, which could cause a segmentation
+         * violation.
+         */
+        return v[i];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::const_reference
+    static_array<T, N>::operator[](
+        size_type i
+    ) const {
+        /*
+         * Return an element as constant.
+         */
+        return v[i];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::reference
+    static_array<T, N>::front(
+        void
+    ) {
+        /*
+         * Return the first element.
+         */
+        return v[0];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::const_reference
+    static_array<T, N>::front(
+        void
+    ) const {
+        /*
+         * Return the first element, but it's const.
+         */
+        return v[0];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::reference
+    static_array<T, N>::back(
+        void
+    ) {
+        /*
+         * Return the last element.
+         */
+        return v[N - 1];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::const_reference
+    static_array<T, N>::back(
+        void
+    ) const {
+        /*
+         * Return the last element, but it's const.
+         */
+        return v[N - 1];
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::pointer
+    static_array<T, N>::data(
+        void
+    ) {
+        /*
+         * Return a pointer to the underlying data.
+         */
+        return v;
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    constexpr
+    typename static_array<T, N>::const_pointer
+    static_array<T, N>::data(
+        void
+    ) const {
+        /*
+         * Return a pointer to the underlying data, but the elements are const.
+         */
+        return v;
+    }
+
+    template<typename T, std::size_t N>
+    template<
+        typename std::size_t ... Is,
+        typename ... Tp
+    >
+    VECMEM_HOST_AND_DEVICE
+    static_array<T, N>::static_array(
+        std::index_sequence<Is ...>,
+        Tp && ... a
+    ) {
+        /*
+         * Construct the array from an enumerated list of elements of arbitrary
+         * size. This is a fold expression which iterates over the elements of
+         * Is (the indices) and Tp (the values), and inserts them into the inner
+         * array using a comma expression.
+         */
+        (static_cast<void>(v[Is] = a), ...);
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    bool
+    operator==(
+        const static_array<T, N> & lhs,
+        const static_array<T, N> & rhs
+    ) {
+        /*
+         * Iterate over all elements in the arrays, if any of them are unequal
+         * between them, the arrays are not equal.
+         */
+        for (typename static_array<T, N>::size_type i = 0; i < N; ++i) {
+            if (lhs[i] != rhs[i]) {
+                return false;
+            }
+        }
+
+        /*
+         * If we have iterated over the entire array without finding a counter-
+         * example to the equality, the arrays must be equal.
+         */
+        return true;
+    }
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    bool
+    operator!=(
+        const static_array<T, N> & lhs,
+        const static_array<T, N> & rhs
+    ) {
+        /*
+         * Same thing as before, we check all element pairs, if any of them are
+         * unequal, the entire array is unequal. We could also implement this as
+         * return !(lhs == rhs).
+         */
+        for (typename static_array<T, N>::size_type i = 0; i < N; ++i) {
+            if (lhs[i] != rhs[i]) {
+                return true;
+            }
+        }
+
+        /*
+         * No counter example, so the arrays are not unequal.
+         */
+        return false;
+    }
+}

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -1,0 +1,254 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include "vecmem/utils/types.hpp"
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+namespace vecmem {
+    /**
+     * @brief Simple statically-sized array-like class designed for use in
+     * device code.
+     *
+     * This class is designed to be an almost-drop-in replacement for std::array
+     * which can be used in device code.
+     *
+     * @tparam T The array type.
+     * @tparam N The size of the array.
+     */
+    template<typename T, std::size_t N>
+    class static_array {
+    public:
+        using value_type = T;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using reference = value_type &;
+        using const_reference = const value_type &;
+        using pointer = value_type *;
+        using const_pointer = const value_type *;
+
+        /**
+         * @brief Trivial constructor.
+         *
+         * This constructor does nothing, and leaves the inner array
+         * uninitialized.
+         */
+        VECMEM_HOST_AND_DEVICE
+        static_array(
+            void
+        );
+
+        /**
+         * @brief Construct an array from a parameter pack of arbitrary size.
+         *
+         * This constructor is of arbitrary arity, and inserts those elements in
+         * order into the array.
+         *
+         * @tparam Tp The parameter pack for the arguments.
+         *
+         * @warning The std::array implementation of this constructor requires
+         * the parameter list to be of size equal to or less than the array
+         * itself. This class is slightly different, as it requires the argument
+         * list to be exactly the same length. This protects the user from
+         * accidentally initializing an array with fewer values than necessary.
+         *
+         * @note All parameters passed to this function must be convertible to
+         * the array value type, but the values do not need to be homogeneous.
+         */
+        template<
+            typename ... Tp,
+            typename = std::enable_if_t<sizeof ...(Tp) == N>,
+            typename = std::enable_if_t<(std::is_convertible_v<Tp, T> && ...)>
+        >
+        VECMEM_HOST_AND_DEVICE
+        static_array(
+            Tp && ... a
+        )
+            : static_array(std::index_sequence_for<Tp ...>(), std::forward<Tp>(a) ...)
+        {}
+
+        /**
+         * @brief Bounds-checked accessor method.
+         *
+         * Since this method can throw an exception, this is not usable on the
+         * device side.
+         *
+         * @param[in] i The index to access.
+         *
+         * @return The value at index i if i less less than N, otherwise an
+         * exception is thrown.
+         */
+        VECMEM_HOST
+        constexpr
+        reference
+        at(
+            size_type i
+        );
+
+        /**
+         * @brief Constant bounds-checked accessor method.
+         *
+         * Since this method can throw an exception, this is not usable on the
+         * device side.
+         *
+         * @param[in] i The index to access.
+         *
+         * @return The value at index i if i less less than N, otherwise an
+         * exception is thrown.
+         */
+        VECMEM_HOST
+        constexpr
+        const_reference
+        at(
+            size_type i
+        ) const;
+
+        /**
+         * @brief Accessor method.
+         *
+         * @param[in] i The index to access.
+         *
+         * @return The value at index i if i less less than N, otherwise the
+         * behaviour is undefined.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        reference
+        operator[](
+            size_type i
+        );
+
+        /**
+         * @brief Constant accessor method.
+         *
+         * @param[in] i The index to access.
+         *
+         * @return The value at index i if i less less than N, otherwise the
+         * behaviour is undefined.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        const_reference
+        operator[](
+            size_type i
+        ) const;
+
+        /**
+         * @brief Access the front element of the array.
+         *
+         * @return The first element of the array.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        reference
+        front(
+            void
+        );
+
+        /**
+         * @brief Access the front element of the array in a const fashion.
+         *
+         * @return The first element of the array.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        const_reference
+        front(
+            void
+        ) const;
+
+        /**
+         * @brief Access the back element of the array.
+         *
+         * @return The last element of the array.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        reference
+        back(
+            void
+        );
+
+        /**
+         * @brief Access the back element of the array in a const fashion.
+         *
+         * @return The last element of the array.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        const_reference
+        back(
+            void
+        ) const;
+
+        /**
+         * @brief Access the underlying data of the array.
+         *
+         * @return A pointer to the underlying memory.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        pointer
+        data(
+            void
+        );
+
+        /**
+         * @brief Access the underlying data of the array in a const fasion.
+         *
+         * @return A pointer to the underlying memory.
+         */
+        VECMEM_HOST_AND_DEVICE
+        constexpr
+        const_pointer
+        data(
+            void
+        ) const;
+
+    private:
+        /**
+         * @brief Private helper-constructor for the parameter pack constructor.
+         *
+         * HACK: This template pack is defined as std::size_t instead of
+         * size_type because the SYCL compiler refuses to accept it otherwise.
+         */
+        template<
+            std::size_t ... Is,
+            typename ... Tp
+        >
+        VECMEM_HOST_AND_DEVICE
+        static_array(
+            std::index_sequence<Is ...>,
+            Tp && ... a
+        );
+
+        T v[N];
+    };
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    bool
+    operator==(
+        const static_array<T, N> & lhs,
+        const static_array<T, N> & rhs
+    );
+
+    template<typename T, std::size_t N>
+    VECMEM_HOST_AND_DEVICE
+    bool
+    operator!=(
+        const static_array<T, N> & lhs,
+        const static_array<T, N> & rhs
+    );
+}
+
+#include "impl/static_array.ipp"

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -13,5 +13,5 @@ vecmem_add_test( core
    "test_core_contiguous_memory_resource.cpp" "test_core_copy.cpp"
    "test_core_device_containers.cpp" "test_core_memory_resources.cpp"
    "test_core_static_vector.cpp" "test_core_vector.cpp"
-   "test_core_jagged_vector_view.cpp"
+   "test_core_jagged_vector_view.cpp" "test_core_static_array.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_static_array.cpp
+++ b/tests/core/test_core_static_array.cpp
@@ -1,0 +1,131 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/containers/static_array.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+class core_static_array_test : public testing::Test {
+};
+
+TEST_F(core_static_array_test, basic_write_read) {
+    vecmem::static_array<int, 3> arr;
+
+    arr[0] = 5;
+    arr[1] = 11;
+    arr[2] = 3;
+
+    EXPECT_EQ(arr[0], 5);
+    EXPECT_EQ(arr[1], 11);
+    EXPECT_EQ(arr[2], 3);
+}
+
+TEST_F(core_static_array_test, bounds_check_exception) {
+    vecmem::static_array<int, 3> arr;
+
+    EXPECT_NO_THROW(arr.at(2));
+    EXPECT_THROW(arr.at(3), std::out_of_range);
+}
+
+TEST_F(core_static_array_test, initializer) {
+    vecmem::static_array<int, 3> arr(4, 76, 1);
+
+    EXPECT_EQ(arr[0], 4);
+    EXPECT_EQ(arr[1], 76);
+    EXPECT_EQ(arr[2], 1);
+}
+
+TEST_F(core_static_array_test, bracket_initializer) {
+    vecmem::static_array<int, 3> arr({4, 76, 1});
+
+    EXPECT_EQ(arr[0], 4);
+    EXPECT_EQ(arr[1], 76);
+    EXPECT_EQ(arr[2], 1);
+}
+
+TEST_F(core_static_array_test, assignment) {
+    vecmem::static_array<int, 3> proto(4, 76, 1);
+    vecmem::static_array<int, 3> arr = proto;
+
+    EXPECT_EQ(arr[0], 4);
+    EXPECT_EQ(arr[1], 76);
+    EXPECT_EQ(arr[2], 1);
+}
+
+TEST_F(core_static_array_test, copy) {
+    vecmem::static_array<int, 3> proto(4, 76, 1);
+    vecmem::static_array<int, 3> arr(proto);
+
+    EXPECT_EQ(arr[0], 4);
+    EXPECT_EQ(arr[1], 76);
+    EXPECT_EQ(arr[2], 1);
+}
+
+TEST_F(core_static_array_test, equality) {
+    vecmem::static_array<int, 3> a1(4, 76, 1);
+    vecmem::static_array<int, 3> a2(4, 76, 1);
+    vecmem::static_array<int, 3> a3(4, 76, 2);
+
+    EXPECT_TRUE(a1 == a1);
+    EXPECT_TRUE(a2 == a2);
+    EXPECT_TRUE(a3 == a3);
+    EXPECT_TRUE(a1 == a2);
+    EXPECT_TRUE(a2 == a1);
+    EXPECT_FALSE(a1 == a3);
+    EXPECT_FALSE(a2 == a3);
+    EXPECT_FALSE(a3 == a1);
+    EXPECT_FALSE(a3 == a2);
+}
+
+TEST_F(core_static_array_test, inequality) {
+    vecmem::static_array<int, 3> a1(4, 76, 1);
+    vecmem::static_array<int, 3> a2(4, 76, 1);
+    vecmem::static_array<int, 3> a3(4, 76, 2);
+
+    EXPECT_FALSE(a1 != a1);
+    EXPECT_FALSE(a2 != a2);
+    EXPECT_FALSE(a3 != a3);
+    EXPECT_FALSE(a1 != a2);
+    EXPECT_FALSE(a2 != a1);
+    EXPECT_TRUE(a1 != a3);
+    EXPECT_TRUE(a2 != a3);
+    EXPECT_TRUE(a3 != a1);
+    EXPECT_TRUE(a3 != a2);
+}
+
+TEST_F(core_static_array_test, front) {
+    vecmem::static_array<int, 3> arr1(4, 76, 1);
+    vecmem::static_array<int, 1> arr2(7);
+
+    EXPECT_EQ(arr1.front(), 4);
+    EXPECT_EQ(arr2.front(), 7);
+}
+
+TEST_F(core_static_array_test, back) {
+    vecmem::static_array<int, 3> arr1(4, 76, 1);
+    vecmem::static_array<int, 1> arr2(7);
+
+    EXPECT_EQ(arr1.back(), 1);
+    EXPECT_EQ(arr2.back(), 7);
+}
+
+TEST_F(core_static_array_test, matrix) {
+    vecmem::static_array<vecmem::static_array<int, 3>, 3> matrix;
+
+    matrix[0] = {5, 1, 8};
+    matrix[1] = {9, 2, 4};
+    matrix[2] = {0, 3, 7};
+
+    EXPECT_EQ(matrix[0][0], 5);
+    EXPECT_EQ(matrix[0][2], 8);
+    EXPECT_EQ(matrix[1][1], 2);
+    EXPECT_EQ(matrix[2][0], 0);
+    EXPECT_EQ(matrix[2][2], 7);
+}


### PR DESCRIPTION
This new type represents an array with length known at compile time, very similar to how `std::array` works. The difference between this and `std::array` is that this is designed to be device-code friendly, and the functions have been marked as device compatible where applicable.

Continuation of https://github.com/acts-project/traccc/pull/34. 