### PR TITLE
CUDA 10.1 Compatibility Fix, main branch (2021.05.18.)

### DIFF
--- a/cmake/vecmem-compiler-options-cuda.cmake
+++ b/cmake/vecmem-compiler-options-cuda.cmake
@@ -7,6 +7,9 @@
 # Include the helper function(s).
 include( vecmem-functions )
 
+# Figure out the properties of CUDA being used.
+find_package( CUDAToolkit REQUIRED )
+
 # Set up the used C++ standard(s).
 set( CMAKE_CUDA_STANDARD 14 CACHE STRING "The (CUDA) C++ standard to use" )
 
@@ -19,4 +22,6 @@ set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
 vecmem_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-G" )
 
 # More rigorous tests for the Debug builds.
-vecmem_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "10.2" )
+   vecmem_add_flag( CMAKE_CUDA_FLAGS_DEBUG "-Werror all-warnings" )
+endif()


### PR DESCRIPTION
While looking at an issue reported by Gabriel Carmona, I had to realise that the code would not build in "Debug" mode with CUDA 10.1. :frowning:

```
nvcc fatal   : Value 'all-warnings' is not defined for option 'Werror'
tests/cuda/CMakeFiles/vecmem_test_cuda.dir/build.make:103: recipe for target 'tests/cuda/CMakeFiles/vecmem_test_cuda.dir/test_cuda_containers_kernels.cu.o' failed
make[2]: *** [tests/cuda/CMakeFiles/vecmem_test_cuda.dir/test_cuda_containers_kernels.cu.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```
This update simply disables the "`-Werror all-warnings`"  flag with CUDA < 10.2 in "Debug" mode. (I didn't think it would be worth figuring out a "proper replacement" for this for older CUDA versions.)