### PR TITLE
vecmem::static_array Improvements, main branch (2021.07.08.)

### DIFF
--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -59,7 +59,7 @@ static_array<T, N>::operator[](size_type i) {
      * Non-bounds checking access, which could cause a segmentation
      * violation.
      */
-    return v[i];
+    return m_array[i];
 }
 
 template <typename T, std::size_t N>
@@ -68,7 +68,7 @@ static_array<T, N>::operator[](size_type i) const {
     /*
      * Return an element as constant.
      */
-    return v[i];
+    return m_array[i];
 }
 
 template <typename T, std::size_t N>
@@ -77,7 +77,7 @@ static_array<T, N>::front(void) {
     /*
      * Return the first element.
      */
-    return v[0];
+    return m_array[0];
 }
 
 template <typename T, std::size_t N>
@@ -86,7 +86,7 @@ static_array<T, N>::front(void) const {
     /*
      * Return the first element, but it's const.
      */
-    return v[0];
+    return m_array[0];
 }
 
 template <typename T, std::size_t N>
@@ -95,7 +95,7 @@ static_array<T, N>::back(void) {
     /*
      * Return the last element.
      */
-    return v[N - 1];
+    return m_array[N - 1];
 }
 
 template <typename T, std::size_t N>
@@ -104,7 +104,7 @@ static_array<T, N>::back(void) const {
     /*
      * Return the last element, but it's const.
      */
-    return v[N - 1];
+    return m_array[N - 1];
 }
 
 template <typename T, std::size_t N>
@@ -113,7 +113,7 @@ static_array<T, N>::data(void) {
     /*
      * Return a pointer to the underlying data.
      */
-    return v;
+    return m_array;
 }
 
 template <typename T, std::size_t N>
@@ -122,20 +122,141 @@ static_array<T, N>::data(void) const {
     /*
      * Return a pointer to the underlying data, but the elements are const.
      */
-    return v;
+    return m_array;
 }
 
 template <typename T, std::size_t N>
-template <typename std::size_t... Is, typename... Tp>
-VECMEM_HOST_AND_DEVICE static_array<T, N>::static_array(
-    std::index_sequence<Is...>, Tp&&... a) {
-    /*
-     * Construct the array from an enumerated list of elements of arbitrary
-     * size. This is a fold expression which iterates over the elements of
-     * Is (the indices) and Tp (the values), and inserts them into the inner
-     * array using a comma expression.
-     */
-    (static_cast<void>(v[Is] = a), ...);
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::iterator
+static_array<T, N>::begin() {
+
+    return m_array;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
+static_array<T, N>::begin() const {
+
+    return m_array;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
+static_array<T, N>::cbegin() const {
+
+    return begin();
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::iterator
+static_array<T, N>::end() {
+
+    return m_array + N;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
+static_array<T, N>::end() const {
+
+    return m_array + N;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
+static_array<T, N>::cend() const {
+
+    return end();
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reverse_iterator
+static_array<T, N>::rbegin() {
+
+    return reverse_iterator(end());
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr
+    typename static_array<T, N>::const_reverse_iterator
+    static_array<T, N>::rbegin() const {
+
+    return const_reverse_iterator(end());
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr
+    typename static_array<T, N>::const_reverse_iterator
+    static_array<T, N>::crbegin() const {
+
+    return rbegin();
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reverse_iterator
+static_array<T, N>::rend() {
+
+    return reverse_iterator(begin());
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr
+    typename static_array<T, N>::const_reverse_iterator
+    static_array<T, N>::rend() const {
+
+    return const_reverse_iterator(begin());
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr
+    typename static_array<T, N>::const_reverse_iterator
+    static_array<T, N>::crend() const {
+
+    return rend();
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr bool static_array<T, N>::empty() const {
+
+    return N == 0;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::size_type
+static_array<T, N>::size() const {
+
+    return N;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::size_type
+static_array<T, N>::max_size() const {
+
+    return N;
+}
+
+template <typename T, std::size_t N>
+VECMEM_HOST_AND_DEVICE void static_array<T, N>::fill(const_reference value) {
+
+    for (std::size_t i = 0; i < N; ++i) {
+        m_array[i] = value;
+    }
+}
+
+template <typename T, std::size_t N>
+template <typename Tp1, typename... Tp>
+VECMEM_HOST_AND_DEVICE void static_array<T, N>::static_array_impl(size_type i,
+                                                                  Tp1&& a1,
+                                                                  Tp&&... a) {
+
+    m_array[i] = a1;
+    static_array_impl(i + 1, std::forward<Tp>(a)...);
+}
+
+template <typename T, std::size_t N>
+template <typename Tp1>
+VECMEM_HOST_AND_DEVICE void static_array<T, N>::static_array_impl(size_type i,
+                                                                  Tp1&& a1) {
+
+    m_array[i] = a1;
 }
 
 template <typename T, std::size_t N>

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -281,13 +281,13 @@ class static_array {
     private:
     /**
      * @brief Private helper-constructor for the parameter pack constructor.
-     *
-     * HACK: This template pack is defined as std::size_t instead of
-     * size_type because the SYCL compiler refuses to accept it otherwise.
      */
     template <typename Tp1, typename... Tp>
     VECMEM_HOST_AND_DEVICE void static_array_impl(size_type i, Tp1 &&a1,
                                                   Tp &&... a);
+    /**
+     * @brief Private helper-constructor for the parameter pack constructor.
+     */
     template <typename Tp1>
     VECMEM_HOST_AND_DEVICE void static_array_impl(size_type i, Tp1 &&a1);
 

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -57,5 +57,24 @@ struct is_same_nc<const TYPE, TYPE> {
     static constexpr bool value = true;
 };
 
+/// Implementation for @c std::conjunction
+///
+/// Since @c std::conjunction is only available starting with C++17, but it
+/// comes in very handy in some places in the VecMem code, this is a naive
+/// custom implementation for it.
+///
+template <class...>
+struct conjunction : std::true_type {};
+
+template <class B1>
+struct conjunction<B1> : B1 {};
+
+template <class B1, class... Bn>
+struct conjunction<B1, Bn...>
+    : std::conditional_t<bool(B1::value), conjunction<Bn...>, B1> {};
+
+template <class... B>
+constexpr bool conjunction_v = conjunction<B...>::value;
+
 }  // namespace details
 }  // namespace vecmem

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -11,6 +11,7 @@
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_array.hpp"
 #include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/containers/static_vector.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/memory/host_memory_resource.hpp"
@@ -121,4 +122,34 @@ TEST_F(core_container_test, device_array) {
         EXPECT_TRUE(test_array.at(i) == m_reference_vector.at(i));
         EXPECT_TRUE(test_array[i] == m_reference_vector[i]);
     }
+}
+
+/// Test(s) for @c vecmem::static_array
+TEST_F(core_container_test, static_array) {
+
+    static constexpr int ARRAY_SIZE = 10;
+    const vecmem::static_array<int, ARRAY_SIZE> test_array1 = {0, 1, 2, 3, 4,
+                                                               5, 6, 7, 8, 9};
+    EXPECT_EQ(test_array1.size(), ARRAY_SIZE);
+    EXPECT_EQ(test_array1.max_size(), ARRAY_SIZE);
+    EXPECT_FALSE(test_array1.empty());
+    const vecmem::static_array<int, ARRAY_SIZE> test_array2 = test_array1;
+    vecmem::static_array<int, ARRAY_SIZE> test_array3 = {2, 3, 4, 5, 6,
+                                                         7, 8, 9, 0, 1};
+    EXPECT_EQ(test_array1, test_array2);
+    EXPECT_NE(test_array1, test_array3);
+    EXPECT_TRUE(std::equal(test_array1.begin(), test_array1.end(),
+                           test_array2.begin()));
+    EXPECT_FALSE(std::equal(test_array1.begin(), test_array1.end(),
+                            test_array3.begin()));
+    EXPECT_EQ(std::accumulate(test_array1.begin(), test_array1.end(), 0),
+              std::accumulate(test_array2.rbegin(), test_array2.rend(), 0));
+    test_array3.fill(12);
+    for (int i = 0; i < ARRAY_SIZE; ++i) {
+        EXPECT_EQ(test_array3.at(i), 12);
+    }
+    const vecmem::static_array<int, 0> test_array4;
+    EXPECT_EQ(test_array4.size(), 0);
+    EXPECT_EQ(test_array4.max_size(), 0);
+    EXPECT_TRUE(test_array4.empty());
 }

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -12,6 +12,7 @@
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/memory/atomic.hpp"
 
 /// Kernel performing a linear transformation using the vector helper types
@@ -27,13 +28,14 @@ __global__ void linearTransformKernel(
     }
 
     // Create the helper containers.
-    const vecmem::const_device_array<int, 2> constantarray(constants);
+    const vecmem::const_device_array<int, 2> constantarray1(constants);
+    const vecmem::static_array<int, 2> constantarray2 = {constantarray1[0],
+                                                         constantarray1[1]};
     const vecmem::const_device_vector<int> inputvec(input);
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) =
-        inputvec.at(i) * constantarray.at(0) + constantarray.at(1);
+    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) + constantarray2[1];
     return;
 }
 

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -16,6 +16,7 @@
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/memory/atomic.hpp"
 
 /// Kernel performing a linear transformation using the vector helper types
@@ -31,13 +32,14 @@ __global__ void linearTransformKernel(
     }
 
     // Create the helper containers.
-    const vecmem::const_device_array<int, 2> constantarray(constants);
+    const vecmem::const_device_array<int, 2> constantarray1(constants);
+    const vecmem::static_array<int, 2> constantarray2 = {constantarray1[0],
+                                                         constantarray1[1]};
     const vecmem::const_device_vector<int> inputvec(input);
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) =
-        inputvec.at(i) * constantarray.at(0) + constantarray.at(1);
+    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) + constantarray2[1];
     return;
 }
 

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -14,6 +14,7 @@
 #include "vecmem/containers/const_device_array.hpp"
 #include "vecmem/containers/const_device_vector.hpp"
 #include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/memory/atomic.hpp"
 #include "vecmem/memory/sycl/device_memory_resource.hpp"
@@ -60,14 +61,16 @@ TEST_F(sycl_containers_test, shared_memory) {
                 }
 
                 // Create the helper containers.
-                const vecmem::const_device_array<int, 2> constantarray(
+                const vecmem::const_device_array<int, 2> constantarray1(
                     constants);
+                const vecmem::static_array<int, 2> constantarray2 = {
+                    constantarray1[0], constantarray1[1]};
                 const vecmem::const_device_vector<int> inputvec(input);
                 vecmem::device_vector<int> outputvec(output);
 
                 // Perform the linear transformation.
                 outputvec.at(id) =
-                    inputvec.at(id) * constantarray.at(0) + constantarray.at(1);
+                    inputvec.at(id) * constantarray1.at(0) + constantarray2[1];
                 return;
             });
     });


### PR DESCRIPTION
As I noted back in #83, the current implementation of `vecmem::static_array` is missing some things.

First off, I implemented the missing iterator returning and size checking functions on the class. Plus I also added `vecmem::static_array::fill(...)`, as it seemed like it could be useful. (And since there's an [std::array::fill(...)](https://en.cppreference.com/w/cpp/container/array/fill) function as well.)

Then I tried to set up some additional tests for the type, including some minimal tests in device code. And I quickly had to realise that the implementation of the "main constructor" of the class required C\+\+17. Which CUDA and HIP were non too happy with. So after some thinking, I came up with the included re-write of the constructor. I'm also not super happy about it, but I couldn't come up with anything much better with just the C\+\+14 syntax. (The current code is definitely nicer. But if we can't use it in device code in all conditions, then it's no good...)

I also renamed `vecmem::static_array::v` to `vecmem::static_array::m_array`. Just to keep with the ATLAS coding conventions. (Which we are partially following with VecMem, even if not in all aspects.)

I also updated the class to use `vecmem::details::array_type` for the type of `vecmem::static_array::m_array`. Even though I just couldn't really trigger the same issue with zero sized arrays that I wrote that class for in the first place. (In `vecmem::static_vector`...) But I think that's just because I didn't try hard enough...

P.S. The code formatter also touched a couple of lines that I thought it shouldn't have. Hopefully it won't have some weird hysteresis...