### PR TITLE
Use `auto func() -> return_t` signature to improve legibility

### DIFF
--- a/core/include/vecmem/containers/impl/array.ipp
+++ b/core/include/vecmem/containers/impl/array.ipp
@@ -34,9 +34,7 @@ allocate_array_memory(vecmem::memory_resource& resource,
 
 /// Helper function used in the @c vecmem::array constructors
 template <typename T, std::size_t N>
-std::unique_ptr<typename vecmem::array<T, N>::value_type,
-                typename vecmem::array<T, N>::deleter>
-initialize_array_memory(
+auto initialize_array_memory(
     std::unique_ptr<typename vecmem::array<T, N>::value_type,
                     typename vecmem::array<T, N>::deleter>
         memory,
@@ -93,7 +91,7 @@ array<T, N>::array(memory_resource& resource, size_type size)
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reference array<T, N>::at(size_type pos) {
+auto array<T, N>::at(size_type pos) -> reference {
 
     if (pos >= m_size) {
         throw std::out_of_range("Requested element " + std::to_string(pos) +
@@ -104,7 +102,7 @@ typename array<T, N>::reference array<T, N>::at(size_type pos) {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reference array<T, N>::at(size_type pos) const {
+auto array<T, N>::at(size_type pos) const -> const_reference {
 
     if (pos >= m_size) {
         throw std::out_of_range("Requested element " + std::to_string(pos) +
@@ -115,20 +113,19 @@ typename array<T, N>::const_reference array<T, N>::at(size_type pos) const {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reference array<T, N>::operator[](size_type pos) {
+auto array<T, N>::operator[](size_type pos) -> reference {
 
     return m_memory.get()[pos];
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reference array<T, N>::operator[](
-    size_type pos) const {
+auto array<T, N>::operator[](size_type pos) const -> const_reference {
 
     return m_memory.get()[pos];
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reference array<T, N>::front() {
+auto array<T, N>::front() -> reference {
 
     if (m_size == 0) {
         throw std::out_of_range(
@@ -139,7 +136,7 @@ typename array<T, N>::reference array<T, N>::front() {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reference array<T, N>::front() const {
+auto array<T, N>::front() const -> const_reference {
 
     if (m_size == 0) {
         throw std::out_of_range(
@@ -150,7 +147,7 @@ typename array<T, N>::const_reference array<T, N>::front() const {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reference array<T, N>::back() {
+auto array<T, N>::back() -> reference {
 
     if (m_size == 0) {
         throw std::out_of_range(
@@ -161,7 +158,7 @@ typename array<T, N>::reference array<T, N>::back() {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reference array<T, N>::back() const {
+auto array<T, N>::back() const -> const_reference {
 
     if (m_size == 0) {
         throw std::out_of_range(
@@ -172,85 +169,85 @@ typename array<T, N>::const_reference array<T, N>::back() const {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::pointer array<T, N>::data() {
+auto array<T, N>::data() -> pointer {
 
     return m_memory.get();
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_pointer array<T, N>::data() const {
+auto array<T, N>::data() const -> const_pointer {
 
     return m_memory.get();
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::iterator array<T, N>::begin() {
+auto array<T, N>::begin() -> iterator {
 
     return m_memory.get();
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_iterator array<T, N>::begin() const {
+auto array<T, N>::begin() const -> const_iterator {
 
     return m_memory.get();
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_iterator array<T, N>::cbegin() const {
+auto array<T, N>::cbegin() const -> const_iterator {
 
     return m_memory.get();
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::iterator array<T, N>::end() {
+auto array<T, N>::end() -> iterator {
 
     return (m_memory.get() + m_size);
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_iterator array<T, N>::end() const {
+auto array<T, N>::end() const -> const_iterator {
 
     return (m_memory.get() + m_size);
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_iterator array<T, N>::cend() const {
+auto array<T, N>::cend() const -> const_iterator {
 
     return (m_memory.get() + m_size);
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reverse_iterator array<T, N>::rbegin() {
+auto array<T, N>::rbegin() -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reverse_iterator array<T, N>::rbegin() const {
+auto array<T, N>::rbegin() const -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reverse_iterator array<T, N>::crbegin() const {
+auto array<T, N>::crbegin() const -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::reverse_iterator array<T, N>::rend() {
+auto array<T, N>::rend() -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reverse_iterator array<T, N>::rend() const {
+auto array<T, N>::rend() const -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::const_reverse_iterator array<T, N>::crend() const {
+auto array<T, N>::crend() const -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
@@ -262,7 +259,7 @@ bool array<T, N>::empty() const noexcept {
 }
 
 template <typename T, std::size_t N>
-typename array<T, N>::size_type array<T, N>::size() const noexcept {
+auto array<T, N>::size() const noexcept -> size_type {
 
     return m_size;
 }

--- a/core/include/vecmem/containers/impl/device_array.ipp
+++ b/core/include/vecmem/containers/impl/device_array.ipp
@@ -51,8 +51,7 @@ VECMEM_HOST_AND_DEVICE device_array<T, N>& device_array<T, N>::operator=(
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reference
-device_array<T, N>::at(size_type pos) {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::at(size_type pos) -> reference {
 
     // Check if the index is valid.
     assert(pos < N);
@@ -62,8 +61,8 @@ device_array<T, N>::at(size_type pos) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reference
-device_array<T, N>::at(size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::at(size_type pos) const
+    -> const_reference {
 
     // Check if the index is valid.
     assert(pos < N);
@@ -73,24 +72,23 @@ device_array<T, N>::at(size_type pos) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reference
-device_array<T, N>::operator[](size_type pos) {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::operator[](size_type pos)
+    -> reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reference
-device_array<T, N>::operator[](size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::operator[](size_type pos) const
+    -> const_reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reference
-device_array<T, N>::front() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::front() -> reference {
 
     // Make sure that there is at least one element in the vector.
     static_assert(N > 0, "Cannot return first element of empty array");
@@ -100,8 +98,8 @@ device_array<T, N>::front() {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reference
-device_array<T, N>::front() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::front() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the vector.
     static_assert(N > 0, "Cannot return first element of empty array");
@@ -111,8 +109,7 @@ device_array<T, N>::front() const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reference
-device_array<T, N>::back() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::back() -> reference {
 
     // Make sure that there is at least one element in the vector.
     static_assert(N > 0, "Cannot return last element of empty array");
@@ -122,8 +119,8 @@ device_array<T, N>::back() {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reference
-device_array<T, N>::back() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::back() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the vector.
     static_assert(N > 0, "Cannot return last element of empty array");
@@ -133,99 +130,91 @@ device_array<T, N>::back() const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::pointer
-device_array<T, N>::data() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::data() -> pointer {
 
     return m_ptr;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_pointer
-device_array<T, N>::data() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::data() const -> const_pointer {
 
     return m_ptr;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::iterator
-device_array<T, N>::begin() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::begin() -> iterator {
 
     return iterator(m_ptr);
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_iterator
-device_array<T, N>::begin() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::begin() const
+    -> const_iterator {
 
     return const_iterator(m_ptr);
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_iterator
-device_array<T, N>::cbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::cbegin() const
+    -> const_iterator {
 
     return begin();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::iterator
-device_array<T, N>::end() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::end() -> iterator {
 
     return iterator(m_ptr + N);
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_iterator
-device_array<T, N>::end() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::end() const -> const_iterator {
 
     return const_iterator(m_ptr + N);
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_iterator
-device_array<T, N>::cend() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::cend() const -> const_iterator {
 
     return end();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reverse_iterator
-device_array<T, N>::rbegin() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::rbegin() -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reverse_iterator
-device_array<T, N>::rbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::rbegin() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reverse_iterator
-device_array<T, N>::crbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::crbegin() const
+    -> const_reverse_iterator {
 
     return rbegin();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::reverse_iterator
-device_array<T, N>::rend() {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::rend() -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reverse_iterator
-device_array<T, N>::rend() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::rend() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE typename device_array<T, N>::const_reverse_iterator
-device_array<T, N>::crend() const {
+VECMEM_HOST_AND_DEVICE auto device_array<T, N>::crend() const
+    -> const_reverse_iterator {
 
     return rend();
 }
@@ -237,15 +226,15 @@ VECMEM_HOST_AND_DEVICE constexpr bool device_array<T, N>::empty() const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename device_array<T, N>::size_type
-device_array<T, N>::size() const {
+VECMEM_HOST_AND_DEVICE constexpr auto device_array<T, N>::size() const
+    -> size_type {
 
     return N;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename device_array<T, N>::size_type
-device_array<T, N>::max_size() const {
+VECMEM_HOST_AND_DEVICE constexpr auto device_array<T, N>::max_size() const
+    -> size_type {
 
     return size();
 }

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -73,8 +73,8 @@ VECMEM_HOST_AND_DEVICE device_vector<TYPE>& device_vector<TYPE>::operator=(
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reference
-device_vector<TYPE>::at(size_type pos) {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::at(size_type pos)
+    -> reference {
 
     // Check if the index is valid.
     assert(pos < size());
@@ -84,8 +84,8 @@ device_vector<TYPE>::at(size_type pos) {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reference
-device_vector<TYPE>::at(size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::at(size_type pos) const
+    -> const_reference {
 
     // Check if the index is valid.
     assert(pos < size());
@@ -95,24 +95,23 @@ device_vector<TYPE>::at(size_type pos) const {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reference
-device_vector<TYPE>::operator[](size_type pos) {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::operator[](size_type pos)
+    -> reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reference
-device_vector<TYPE>::operator[](size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::operator[](size_type pos) const
+    -> const_reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reference
-device_vector<TYPE>::front() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::front() -> reference {
 
     // Make sure that there is at least one element in the vector.
     assert(size() > 0);
@@ -122,8 +121,8 @@ device_vector<TYPE>::front() {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reference
-device_vector<TYPE>::front() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::front() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the vector.
     assert(size() > 0);
@@ -133,8 +132,7 @@ device_vector<TYPE>::front() const {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reference
-device_vector<TYPE>::back() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::back() -> reference {
 
     // Make sure that there is at least one element in the vector.
     assert(size() > 0);
@@ -144,8 +142,8 @@ device_vector<TYPE>::back() {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reference
-device_vector<TYPE>::back() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::back() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the vector.
     assert(size() > 0);
@@ -155,15 +153,13 @@ device_vector<TYPE>::back() const {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::pointer
-device_vector<TYPE>::data() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::data() -> pointer {
 
     return m_ptr;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_pointer
-device_vector<TYPE>::data() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::data() const -> const_pointer {
 
     return m_ptr;
 }
@@ -190,8 +186,8 @@ VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::assign(size_type count,
 
 template <typename TYPE>
 template <typename... Args>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reference
-device_vector<TYPE>::emplace_back(Args&&... args) {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::emplace_back(Args&&... args)
+    -> reference {
 
     // This can only be done on a resizable vector.
     assert(m_size != nullptr);
@@ -210,8 +206,8 @@ device_vector<TYPE>::emplace_back(Args&&... args) {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::size_type
-device_vector<TYPE>::push_back(const_reference value) {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::push_back(
+    const_reference value) -> size_type {
 
     // This can only be done on a resizable vector.
     assert(m_size != nullptr);
@@ -230,8 +226,7 @@ device_vector<TYPE>::push_back(const_reference value) {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::size_type
-device_vector<TYPE>::pop_back() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::pop_back() -> size_type {
 
     // This can only be done on a resizable vector.
     assert(m_size != nullptr);
@@ -305,85 +300,80 @@ VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::resize(size_type new_size,
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::iterator
-device_vector<TYPE>::begin() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::begin() -> iterator {
 
     return iterator(m_ptr);
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_iterator
-device_vector<TYPE>::begin() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::begin() const
+    -> const_iterator {
 
     return const_iterator(m_ptr);
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_iterator
-device_vector<TYPE>::cbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::cbegin() const
+    -> const_iterator {
 
     return begin();
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::iterator
-device_vector<TYPE>::end() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::end() -> iterator {
 
     return iterator(m_ptr + size());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_iterator
-device_vector<TYPE>::end() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::end() const -> const_iterator {
 
     return const_iterator(m_ptr + size());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_iterator
-device_vector<TYPE>::cend() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::cend() const
+    -> const_iterator {
 
     return end();
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reverse_iterator
-device_vector<TYPE>::rbegin() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::rbegin() -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reverse_iterator
-device_vector<TYPE>::rbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::rbegin() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reverse_iterator
-device_vector<TYPE>::crbegin() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::crbegin() const
+    -> const_reverse_iterator {
 
     return rbegin();
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::reverse_iterator
-device_vector<TYPE>::rend() {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::rend() -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reverse_iterator
-device_vector<TYPE>::rend() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::rend() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::const_reverse_iterator
-device_vector<TYPE>::crend() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::crend() const
+    -> const_reverse_iterator {
 
     return rend();
 }
@@ -395,8 +385,7 @@ VECMEM_HOST_AND_DEVICE bool device_vector<TYPE>::empty() const {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::size_type
-device_vector<TYPE>::size() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::size() const -> size_type {
 
     if (m_size == nullptr) {
         return m_capacity;
@@ -412,15 +401,13 @@ device_vector<TYPE>::size() const {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::size_type
-device_vector<TYPE>::max_size() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::max_size() const -> size_type {
 
     return capacity();
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename device_vector<TYPE>::size_type
-device_vector<TYPE>::capacity() const {
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::capacity() const -> size_type {
 
     return m_capacity;
 }

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -54,8 +54,8 @@ jagged_device_vector<T>::operator=(const jagged_device_vector& rhs) {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reference
-jagged_device_vector<T>::at(size_type pos) {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::at(size_type pos)
+    -> reference {
 
     // Check if the index is valid.
     assert(pos < m_size);
@@ -65,8 +65,8 @@ jagged_device_vector<T>::at(size_type pos) {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reference
-jagged_device_vector<T>::at(size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::at(size_type pos) const
+    -> const_reference {
 
     // Check if the index is valid.
     assert(pos < m_size);
@@ -76,24 +76,23 @@ jagged_device_vector<T>::at(size_type pos) const {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reference
-jagged_device_vector<T>::operator[](size_type pos) {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::operator[](size_type pos)
+    -> reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reference
-jagged_device_vector<T>::operator[](size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::operator[](
+    size_type pos) const -> const_reference {
 
     // Return a reference to the vector element.
     return m_ptr[pos];
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reference
-jagged_device_vector<T>::front() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::front() -> reference {
 
     // Make sure that there is at least one element in the outer vector.
     assert(m_size > 0);
@@ -103,8 +102,8 @@ jagged_device_vector<T>::front() {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reference
-jagged_device_vector<T>::front() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::front() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the outer vector.
     assert(m_size > 0);
@@ -114,8 +113,7 @@ jagged_device_vector<T>::front() const {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reference
-jagged_device_vector<T>::back() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::back() -> reference {
 
     // Make sure that there is at least one element in the outer vector.
     assert(m_size > 0);
@@ -125,8 +123,8 @@ jagged_device_vector<T>::back() {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reference
-jagged_device_vector<T>::back() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::back() const
+    -> const_reference {
 
     // Make sure that there is at least one element in the outer vector.
     assert(m_size > 0);
@@ -136,85 +134,83 @@ jagged_device_vector<T>::back() const {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::iterator
-jagged_device_vector<T>::begin() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::begin() -> iterator {
 
     return iterator(m_ptr);
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_iterator
-jagged_device_vector<T>::begin() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::begin() const
+    -> const_iterator {
 
     return const_iterator(m_ptr);
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_iterator
-jagged_device_vector<T>::cbegin() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::cbegin() const
+    -> const_iterator {
 
     return begin();
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::iterator
-jagged_device_vector<T>::end() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::end() -> iterator {
 
     return iterator(m_ptr + m_size);
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_iterator
-jagged_device_vector<T>::end() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::end() const
+    -> const_iterator {
 
     return const_iterator(m_ptr + m_size);
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_iterator
-jagged_device_vector<T>::cend() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::cend() const
+    -> const_iterator {
 
     return end();
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reverse_iterator
-jagged_device_vector<T>::rbegin() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::rbegin()
+    -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reverse_iterator
-jagged_device_vector<T>::rbegin() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::rbegin() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reverse_iterator
-jagged_device_vector<T>::crbegin() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::crbegin() const
+    -> const_reverse_iterator {
 
     return rbegin();
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::reverse_iterator
-jagged_device_vector<T>::rend() {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::rend()
+    -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reverse_iterator
-jagged_device_vector<T>::rend() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::rend() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::const_reverse_iterator
-jagged_device_vector<T>::crend() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::crend() const
+    -> const_reverse_iterator {
 
     return rend();
 }
@@ -225,21 +221,21 @@ VECMEM_HOST_AND_DEVICE bool jagged_device_vector<T>::empty(void) const {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::size_type
-jagged_device_vector<T>::size(void) const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::size(void) const
+    -> size_type {
     return m_size;
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::size_type
-jagged_device_vector<T>::max_size() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::max_size() const
+    -> size_type {
 
     return m_size;
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector<T>::size_type
-jagged_device_vector<T>::capacity() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::capacity() const
+    -> size_type {
 
     return m_size;
 }

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -16,16 +16,16 @@ VECMEM_HOST_AND_DEVICE jagged_device_vector_iterator<TYPE>::pointer::pointer(
     : m_vec(*data) {}
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector_iterator<TYPE>::value_type*
-jagged_device_vector_iterator<TYPE>::pointer::operator->() {
+VECMEM_HOST_AND_DEVICE auto
+jagged_device_vector_iterator<TYPE>::pointer::operator->() -> value_type* {
 
     return &m_vec;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE const typename jagged_device_vector_iterator<
-    TYPE>::value_type*
-jagged_device_vector_iterator<TYPE>::pointer::operator->() const {
+VECMEM_HOST_AND_DEVICE auto
+jagged_device_vector_iterator<TYPE>::pointer::operator->() const
+    -> const value_type* {
 
     return &m_vec;
 }
@@ -72,22 +72,22 @@ jagged_device_vector_iterator<TYPE>::operator=(
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector_iterator<TYPE>::reference
-jagged_device_vector_iterator<TYPE>::operator*() const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector_iterator<TYPE>::operator*()
+    const -> reference {
 
     return *m_ptr;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector_iterator<TYPE>::pointer
-jagged_device_vector_iterator<TYPE>::operator->() const {
+VECMEM_HOST_AND_DEVICE auto
+jagged_device_vector_iterator<TYPE>::operator->() const -> pointer {
 
     return m_ptr;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename jagged_device_vector_iterator<TYPE>::reference
-jagged_device_vector_iterator<TYPE>::operator[](difference_type n) const {
+VECMEM_HOST_AND_DEVICE auto jagged_device_vector_iterator<TYPE>::operator[](
+    difference_type n) const -> reference {
 
     return *(*this + n);
 }

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -147,8 +147,7 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
 }
 
 template <typename TYPE>
-typename jagged_vector_buffer<TYPE>::pointer
-jagged_vector_buffer<TYPE>::host_ptr() const {
+auto jagged_vector_buffer<TYPE>::host_ptr() const -> pointer {
 
     return m_outer_host_memory.get();
 }

--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -24,8 +24,7 @@ VECMEM_HOST_AND_DEVICE static_array<T, N>::static_array(void) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST constexpr typename static_array<T, N>::reference
-static_array<T, N>::at(size_type i) {
+VECMEM_HOST constexpr auto static_array<T, N>::at(size_type i) -> reference {
     /*
      * The at function is bounds-checking in the standard library, so we
      * do a boundary check in our code, too. This makes this method
@@ -39,8 +38,8 @@ static_array<T, N>::at(size_type i) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST constexpr typename static_array<T, N>::const_reference
-static_array<T, N>::at(size_type i) const {
+VECMEM_HOST constexpr auto static_array<T, N>::at(size_type i) const
+    -> const_reference {
     /*
      * Same thing as with the other at function, we do a bounds check in
      * accordance with the standard library.
@@ -53,8 +52,8 @@ static_array<T, N>::at(size_type i) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reference
-static_array<T, N>::operator[](size_type i) {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::operator[](
+    size_type i) -> reference {
     /*
      * Non-bounds checking access, which could cause a segmentation
      * violation.
@@ -63,8 +62,8 @@ static_array<T, N>::operator[](size_type i) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_reference
-static_array<T, N>::operator[](size_type i) const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::operator[](
+    size_type i) const -> const_reference {
     /*
      * Return an element as constant.
      */
@@ -72,8 +71,8 @@ static_array<T, N>::operator[](size_type i) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reference
-static_array<T, N>::front(void) {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::front(void)
+    -> reference {
     /*
      * Return the first element.
      */
@@ -81,8 +80,8 @@ static_array<T, N>::front(void) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_reference
-static_array<T, N>::front(void) const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::front(void) const
+    -> const_reference {
     /*
      * Return the first element, but it's const.
      */
@@ -90,8 +89,8 @@ static_array<T, N>::front(void) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reference
-static_array<T, N>::back(void) {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::back(void)
+    -> reference {
     /*
      * Return the last element.
      */
@@ -99,8 +98,8 @@ static_array<T, N>::back(void) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_reference
-static_array<T, N>::back(void) const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::back(void) const
+    -> const_reference {
     /*
      * Return the last element, but it's const.
      */
@@ -108,8 +107,8 @@ static_array<T, N>::back(void) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::pointer
-static_array<T, N>::data(void) {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::data(void)
+    -> pointer {
     /*
      * Return a pointer to the underlying data.
      */
@@ -117,8 +116,8 @@ static_array<T, N>::data(void) {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_pointer
-static_array<T, N>::data(void) const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::data(void) const
+    -> const_pointer {
     /*
      * Return a pointer to the underlying data, but the elements are const.
      */
@@ -126,89 +125,83 @@ static_array<T, N>::data(void) const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::iterator
-static_array<T, N>::begin() {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::begin() -> iterator {
 
     return m_array;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
-static_array<T, N>::begin() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::begin() const
+    -> const_iterator {
 
     return m_array;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
-static_array<T, N>::cbegin() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::cbegin() const
+    -> const_iterator {
 
     return begin();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::iterator
-static_array<T, N>::end() {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::end() -> iterator {
 
     return m_array + N;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
-static_array<T, N>::end() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::end() const
+    -> const_iterator {
 
     return m_array + N;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::const_iterator
-static_array<T, N>::cend() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::cend() const
+    -> const_iterator {
 
     return end();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reverse_iterator
-static_array<T, N>::rbegin() {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::rbegin()
+    -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr
-    typename static_array<T, N>::const_reverse_iterator
-    static_array<T, N>::rbegin() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::rbegin() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr
-    typename static_array<T, N>::const_reverse_iterator
-    static_array<T, N>::crbegin() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::crbegin() const
+    -> const_reverse_iterator {
 
     return rbegin();
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::reverse_iterator
-static_array<T, N>::rend() {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::rend()
+    -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr
-    typename static_array<T, N>::const_reverse_iterator
-    static_array<T, N>::rend() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::rend() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr
-    typename static_array<T, N>::const_reverse_iterator
-    static_array<T, N>::crend() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::crend() const
+    -> const_reverse_iterator {
 
     return rend();
 }
@@ -220,15 +213,15 @@ VECMEM_HOST_AND_DEVICE constexpr bool static_array<T, N>::empty() const {
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::size_type
-static_array<T, N>::size() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::size() const
+    -> size_type {
 
     return N;
 }
 
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr typename static_array<T, N>::size_type
-static_array<T, N>::max_size() const {
+VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::max_size() const
+    -> size_type {
 
     return N;
 }

--- a/core/include/vecmem/containers/impl/static_vector.ipp
+++ b/core/include/vecmem/containers/impl/static_vector.ipp
@@ -54,8 +54,8 @@ static_vector<TYPE, MAX_SIZE>::at(size_type pos) {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_reference
-static_vector<TYPE, MAX_SIZE>::at(size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::at(
+    size_type pos) const -> const_reference {
 
     // Make sure that the element exists.
     assert(pos < m_size);
@@ -65,24 +65,24 @@ static_vector<TYPE, MAX_SIZE>::at(size_type pos) const {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reference
-static_vector<TYPE, MAX_SIZE>::operator[](size_type pos) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::operator[](
+    size_type pos) -> reference {
 
     // Return the element.
     return *(reinterpret_cast<pointer>(m_elements) + pos);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_reference
-static_vector<TYPE, MAX_SIZE>::operator[](size_type pos) const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::operator[](
+    size_type pos) const -> const_reference {
 
     // Return the element.
     return *(reinterpret_cast<const_pointer>(m_elements) + pos);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reference
-static_vector<TYPE, MAX_SIZE>::front() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::front()
+    -> reference {
 
     // Make sure that the element exists.
     assert(m_size > 0);
@@ -92,8 +92,8 @@ static_vector<TYPE, MAX_SIZE>::front() {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_reference
-static_vector<TYPE, MAX_SIZE>::front() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::front() const
+    -> const_reference {
 
     // Make sure that the element exists.
     assert(m_size > 0);
@@ -103,8 +103,7 @@ static_vector<TYPE, MAX_SIZE>::front() const {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reference
-static_vector<TYPE, MAX_SIZE>::back() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::back() -> reference {
 
     // Make sure that the element exists.
     assert(m_size > 0);
@@ -114,8 +113,8 @@ static_vector<TYPE, MAX_SIZE>::back() {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_reference
-static_vector<TYPE, MAX_SIZE>::back() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::back() const
+    -> const_reference {
 
     // Make sure that the element exists.
     assert(m_size > 0);
@@ -125,15 +124,14 @@ static_vector<TYPE, MAX_SIZE>::back() const {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::pointer
-static_vector<TYPE, MAX_SIZE>::data() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::data() -> pointer {
 
     return reinterpret_cast<pointer>(m_elements);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_pointer
-static_vector<TYPE, MAX_SIZE>::data() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::data() const
+    -> const_pointer {
 
     return reinterpret_cast<const_pointer>(m_elements);
 }
@@ -158,9 +156,8 @@ VECMEM_HOST_AND_DEVICE void static_vector<TYPE, MAX_SIZE>::assign(
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::insert(const_iterator pos,
-                                      const_reference value) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::insert(
+    const_iterator pos, const_reference value) -> iterator {
 
     // Make sure that one more position is available.
     assert(m_size < array_max_size);
@@ -184,9 +181,8 @@ static_vector<TYPE, MAX_SIZE>::insert(const_iterator pos,
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::insert(const_iterator pos, size_type count,
-                                      const_reference value) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::insert(
+    const_iterator pos, size_type count, const_reference value) -> iterator {
 
     // Make sure that the requested number of positions are still available.
     assert(m_size + count <= array_max_size);
@@ -213,8 +209,8 @@ static_vector<TYPE, MAX_SIZE>::insert(const_iterator pos, size_type count,
 
 template <typename TYPE, std::size_t MAX_SIZE>
 template <typename... Args>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::emplace(const_iterator pos, Args&&... args) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::emplace(
+    const_iterator pos, Args&&... args) -> iterator {
 
     // Make sure that one more position is available.
     assert(m_size < array_max_size);
@@ -239,8 +235,8 @@ static_vector<TYPE, MAX_SIZE>::emplace(const_iterator pos, Args&&... args) {
 
 template <typename TYPE, std::size_t MAX_SIZE>
 template <typename... Args>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reference
-static_vector<TYPE, MAX_SIZE>::emplace_back(Args&&... args) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::emplace_back(
+    Args&&... args) -> reference {
 
     return *(emplace(end(), std::forward<Args>(args)...));
 }
@@ -253,8 +249,8 @@ VECMEM_HOST_AND_DEVICE void static_vector<TYPE, MAX_SIZE>::push_back(
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::erase(const_iterator pos) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::erase(
+    const_iterator pos) -> iterator {
 
     // Find the index of this iterator inside of the vector.
     auto id = element_id(pos);
@@ -275,9 +271,8 @@ static_vector<TYPE, MAX_SIZE>::erase(const_iterator pos) {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::erase(const_iterator first,
-                                     const_iterator last) {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::erase(
+    const_iterator first, const_iterator last) -> iterator {
 
     // Find the indices and pointers of the iterators.
     auto first_id = element_id(first);
@@ -347,89 +342,83 @@ VECMEM_HOST_AND_DEVICE void static_vector<TYPE, MAX_SIZE>::resize(
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::begin() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::begin() -> iterator {
 
     return reinterpret_cast<iterator>(m_elements);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_iterator
-static_vector<TYPE, MAX_SIZE>::begin() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::begin() const
+    -> const_iterator {
 
     return reinterpret_cast<const_iterator>(m_elements);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_iterator
-static_vector<TYPE, MAX_SIZE>::cbegin() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::cbegin() const
+    -> const_iterator {
 
     return begin();
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::iterator
-static_vector<TYPE, MAX_SIZE>::end() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::end() -> iterator {
 
     return (reinterpret_cast<iterator>(m_elements) + m_size);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_iterator
-static_vector<TYPE, MAX_SIZE>::end() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::end() const
+    -> const_iterator {
 
     return (reinterpret_cast<const_iterator>(m_elements) + m_size);
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::const_iterator
-static_vector<TYPE, MAX_SIZE>::cend() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::cend() const
+    -> const_iterator {
 
     return end();
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reverse_iterator
-static_vector<TYPE, MAX_SIZE>::rbegin() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::rbegin()
+    -> reverse_iterator {
 
     return reverse_iterator(end());
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE
-    typename static_vector<TYPE, MAX_SIZE>::const_reverse_iterator
-    static_vector<TYPE, MAX_SIZE>::rbegin() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::rbegin() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(end());
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE
-    typename static_vector<TYPE, MAX_SIZE>::const_reverse_iterator
-    static_vector<TYPE, MAX_SIZE>::crbegin() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::crbegin() const
+    -> const_reverse_iterator {
 
     return rbegin();
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::reverse_iterator
-static_vector<TYPE, MAX_SIZE>::rend() {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::rend()
+    -> reverse_iterator {
 
     return reverse_iterator(begin());
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE
-    typename static_vector<TYPE, MAX_SIZE>::const_reverse_iterator
-    static_vector<TYPE, MAX_SIZE>::rend() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::rend() const
+    -> const_reverse_iterator {
 
     return const_reverse_iterator(begin());
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE
-    typename static_vector<TYPE, MAX_SIZE>::const_reverse_iterator
-    static_vector<TYPE, MAX_SIZE>::crend() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::crend() const
+    -> const_reverse_iterator {
 
     return rend();
 }
@@ -441,22 +430,22 @@ VECMEM_HOST_AND_DEVICE bool static_vector<TYPE, MAX_SIZE>::empty() const {
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::size_type
-static_vector<TYPE, MAX_SIZE>::size() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::size() const
+    -> size_type {
 
     return m_size;
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::size_type
-static_vector<TYPE, MAX_SIZE>::max_size() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::max_size() const
+    -> size_type {
 
     return array_max_size;
 }
 
 template <typename TYPE, std::size_t MAX_SIZE>
-VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::size_type
-static_vector<TYPE, MAX_SIZE>::capacity() const {
+VECMEM_HOST_AND_DEVICE auto static_vector<TYPE, MAX_SIZE>::capacity() const
+    -> size_type {
 
     return array_max_size;
 }

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -33,43 +33,38 @@ VECMEM_HOST_AND_DEVICE vector_view<TYPE>::vector_view(
       m_ptr(parent.ptr()) {}
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::size_type
-vector_view<TYPE>::size() const {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size() const -> size_type {
 
     return (m_size == nullptr ? m_capacity : *m_size);
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::size_type
-vector_view<TYPE>::capacity() const {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::capacity() const -> size_type {
 
     return m_capacity;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::size_pointer
-vector_view<TYPE>::size_ptr() {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size_ptr() -> size_pointer {
 
     return m_size;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::const_size_pointer
-vector_view<TYPE>::size_ptr() const {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size_ptr() const
+    -> const_size_pointer {
 
     return m_size;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::pointer
-vector_view<TYPE>::ptr() {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::ptr() -> pointer {
 
     return m_ptr;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE typename vector_view<TYPE>::const_pointer
-vector_view<TYPE>::ptr() const {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::ptr() const -> const_pointer {
 
     return m_ptr;
 }

--- a/core/include/vecmem/memory/impl/atomic.ipp
+++ b/core/include/vecmem/memory/impl/atomic.ipp
@@ -47,7 +47,7 @@ VECMEM_HOST_AND_DEVICE void atomic<T>::store(value_type data) {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::load() const {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::load() const -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     volatile pointer addr = m_ptr;
@@ -63,8 +63,7 @@ VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::load() const {
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::exchange(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::exchange(value_type data) -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicExch(m_ptr, data);
@@ -98,8 +97,8 @@ VECMEM_HOST_AND_DEVICE bool atomic<T>::compare_exchange_strong(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_add(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_add(value_type data)
+    -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicAdd(m_ptr, data);
@@ -113,8 +112,8 @@ VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_add(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_sub(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_sub(value_type data)
+    -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicSub(m_ptr, data);
@@ -128,8 +127,8 @@ VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_sub(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_and(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_and(value_type data)
+    -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicAnd(m_ptr, data);
@@ -143,8 +142,7 @@ VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_and(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_or(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_or(value_type data) -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicOr(m_ptr, data);
@@ -158,8 +156,8 @@ VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_or(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename atomic<T>::value_type atomic<T>::fetch_xor(
-    value_type data) {
+VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_xor(value_type data)
+    -> value_type {
 
 #if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
     return atomicXor(m_ptr, data);


### PR DESCRIPTION
As I mentioned in a PR comment, while clang-format sometimes struggles with formatting complex function signatures, there is a way to reduce the signature complexity and improve legibility by using `auto func() -> return_t` signature. This is possible because the type behind `->` is evaluated **in the scope of the method**, as opposed to the classical return type.

This PR does this for all cases where it's possible (and that I saw), mostly in `ipp` files, as in class signature declaration the scope is obvious anyway.

Let me know what you think.