### PR TITLE
Clang Format Update, main branch (2021.07.15.)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,5 +9,5 @@ AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 PointerAlignment: Left
 ColumnLimit: 80
-AccessModifierOffset: 0
+AccessModifierOffset: -4
 KeepEmptyLinesAtTheStartOfBlocks: true

--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -39,7 +39,7 @@ static constexpr std::size_t array_invalid_size = static_cast<std::size_t>(-1);
 template <typename T, std::size_t N = details::array_invalid_size>
 class array {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::array
     /// @{
 
@@ -86,7 +86,7 @@ class array {
     /// Struct used for deleting the allocated memory block
     class deleter {
 
-        public:
+    public:
         /// Constructor
         deleter(size_type size, memory_resource& resource);
 
@@ -102,7 +102,7 @@ class array {
         /// Operator performing the deletion of the object.
         void operator()(void* ptr);
 
-        private:
+    private:
         /// The number of elements in the array
         size_type m_size;
         /// The memory resource used for deleting the memory block
@@ -214,7 +214,7 @@ class array {
 
     /// @}
 
-    private:
+private:
     /// The size of the allocated array
     size_type m_size;
     /// The allocated array

--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -28,7 +28,7 @@ namespace data {
 template <typename TYPE>
 class jagged_vector_buffer : public jagged_vector_view<TYPE> {
 
-    public:
+public:
     /// The base type used by this class
     typedef jagged_vector_view<TYPE> base_type;
     /// Use the base class's @c size_type
@@ -107,7 +107,7 @@ class jagged_vector_buffer : public jagged_vector_view<TYPE> {
     ///
     pointer host_ptr() const;
 
-    private:
+private:
     /// Data object for the @c vecmem::data::vector_view array
     std::unique_ptr<value_type, details::deallocator> m_outer_memory;
     /// Data object for the @c vecmem::data::vector_view array on the host

--- a/core/include/vecmem/containers/data/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_data.hpp
@@ -29,7 +29,7 @@ namespace data {
 template <typename T>
 class jagged_vector_data : public jagged_vector_view<T> {
 
-    public:
+public:
     /// Type of the base class
     using base_type = jagged_vector_view<T>;
     /// Use the base class's @c size_type
@@ -48,7 +48,7 @@ class jagged_vector_data : public jagged_vector_view<T> {
      */
     jagged_vector_data(size_type size, memory_resource& mem);
 
-    private:
+private:
     /// Data object owning the allocated memory
     std::unique_ptr<value_type, details::deallocator> m_memory;
 

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -27,7 +27,7 @@ namespace data {
 template <typename TYPE>
 class vector_buffer : public vector_view<TYPE> {
 
-    public:
+public:
     /// The base type used by this class
     typedef vector_view<TYPE> base_type;
     /// Size type definition coming from the base class
@@ -53,7 +53,7 @@ class vector_buffer : public vector_view<TYPE> {
     vector_buffer(size_type capacity, size_type size,
                   memory_resource& resource);
 
-    private:
+private:
     /// Data object owning the allocated memory
     std::unique_ptr<char, details::deallocator> m_memory;
 

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -30,7 +30,7 @@ namespace data {
 template <typename TYPE>
 class vector_view {
 
-    public:
+public:
     /// Size type used in the class
     typedef unsigned int size_type;
     /// Pointer type to the size of the array
@@ -88,7 +88,7 @@ class vector_view {
     VECMEM_HOST_AND_DEVICE
     const_pointer ptr() const;
 
-    protected:
+protected:
     /// Maximum capacity of the array
     size_type m_capacity;
     /// Pointer to the size of the array in memory

--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -32,7 +32,7 @@ namespace details {
 template <typename TYPE>
 class jagged_device_vector_iterator {
 
-    public:
+public:
     /// @name Types describing the underlying data
     /// @{
 
@@ -61,7 +61,7 @@ class jagged_device_vector_iterator {
     ///
     class pointer {
 
-        public:
+    public:
         /// Constructor from a data pointer
         ///
         /// Used a pointer instead of a reference to make the rest of the code
@@ -78,7 +78,7 @@ class jagged_device_vector_iterator {
         VECMEM_HOST_AND_DEVICE
         const value_type* operator->() const;
 
-        private:
+    private:
         /// Temporary device vector created on the stack
         value_type m_vec;
 
@@ -165,7 +165,7 @@ class jagged_device_vector_iterator {
 
     /// @}
 
-    private:
+private:
     /// Pointer to the data (in an array)
     data_pointer m_ptr;
 

--- a/core/include/vecmem/containers/details/reverse_iterator.hpp
+++ b/core/include/vecmem/containers/details/reverse_iterator.hpp
@@ -24,7 +24,7 @@ namespace details {
 template <typename Iterator>
 class reverse_iterator {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::reverse_iterator
     /// @{
 
@@ -112,7 +112,7 @@ class reverse_iterator {
 
     /// @}
 
-    private:
+private:
     /// Helper function producing a pointer from a forward iterator
     template <typename T>
     VECMEM_HOST_AND_DEVICE static T* to_pointer(T* ptr);

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -27,7 +27,7 @@ namespace vecmem {
 template <typename T, std::size_t N>
 class device_array {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::array
     /// @{
 
@@ -180,7 +180,7 @@ class device_array {
 
     /// @}
 
-    private:
+private:
     /// Pointer to the start of the array
     pointer m_ptr;
 

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -29,7 +29,7 @@ namespace vecmem {
 template <typename TYPE>
 class device_vector {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::vector
     /// @{
 
@@ -242,7 +242,7 @@ class device_vector {
 
     /// @}
 
-    private:
+private:
     /// Construct a new vector element
     VECMEM_HOST_AND_DEVICE
     void construct(size_type pos, const_reference value);

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -46,7 +46,7 @@ namespace vecmem {
 template <typename T>
 class jagged_device_vector {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::vector
     /// @{
 
@@ -205,7 +205,7 @@ class jagged_device_vector {
 
     /// @}
 
-    private:
+private:
     /**
      * The number of rows in this jagged vector.
      */

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -31,7 +31,7 @@ namespace vecmem {
  */
 template <typename T, std::size_t N>
 class static_array {
-    public:
+public:
     /// @name Type definitions, mimicking @c std::array
     /// @{
 
@@ -278,7 +278,7 @@ class static_array {
 
     /// @}
 
-    private:
+private:
     /**
      * @brief Private helper-constructor for the parameter pack constructor.
      */

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -28,7 +28,7 @@ namespace vecmem {
 template <typename TYPE, std::size_t MAX_SIZE>
 class static_vector {
 
-    public:
+public:
     /// @name Type definitions, mimicking @c std::vector
     /// @{
 
@@ -295,7 +295,7 @@ class static_vector {
 
     /// @}
 
-    private:
+private:
     /// Construct a new vector element
     VECMEM_HOST_AND_DEVICE
     void construct(size_type pos, const_reference value);

--- a/core/include/vecmem/memory/allocator.hpp
+++ b/core/include/vecmem/memory/allocator.hpp
@@ -31,7 +31,7 @@ namespace vecmem {
  * avoided.
  */
 class allocator {
-    public:
+public:
     /**
      * @brief Construct an allocator.
      *
@@ -127,7 +127,7 @@ class allocator {
     template <typename T>
     void delete_object(T* p);
 
-    private:
+private:
     memory_resource& m_mem;
 };
 }  // namespace vecmem

--- a/core/include/vecmem/memory/atomic.hpp
+++ b/core/include/vecmem/memory/atomic.hpp
@@ -28,7 +28,7 @@ namespace vecmem {
 template <typename T>
 class atomic {
 
-    public:
+public:
     /// @name Type definitions
     /// @{
 
@@ -97,7 +97,7 @@ class atomic {
 
     /// @}
 
-    private:
+private:
     /// Pointer to the value to perform atomic operations on
     pointer m_ptr;
 

--- a/core/include/vecmem/memory/binary_page_memory_resource.hpp
+++ b/core/include/vecmem/memory/binary_page_memory_resource.hpp
@@ -27,7 +27,7 @@ namespace vecmem {
  * split.
  */
 class binary_page_memory_resource : public memory_resource {
-    public:
+public:
     /**
      * @brief Initialize a binary page memory manager depending on an
      * upstream memory resource.
@@ -40,7 +40,7 @@ class binary_page_memory_resource : public memory_resource {
      */
     ~binary_page_memory_resource();
 
-    private:
+private:
     /**
      * @brief The different possible states a page can be in.
      *

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -29,7 +29,7 @@ namespace vecmem {
  * resource.
  */
 class contiguous_memory_resource : public memory_resource {
-    public:
+public:
     /**
      * @brief Constructs the contiguous memory resource.
      *
@@ -45,7 +45,7 @@ class contiguous_memory_resource : public memory_resource {
      */
     ~contiguous_memory_resource();
 
-    private:
+private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;

--- a/core/include/vecmem/memory/deallocator.hpp
+++ b/core/include/vecmem/memory/deallocator.hpp
@@ -23,7 +23,7 @@ namespace vecmem::details {
 ///
 class deallocator {
 
-    public:
+public:
     /// Constructor
     deallocator(std::size_t bytes, memory_resource& resource);
 
@@ -39,7 +39,7 @@ class deallocator {
     /// Operator performing the deletion of the object.
     void operator()(void* ptr);
 
-    private:
+private:
     /// The number of bytes allocated for the memory block
     std::size_t m_bytes;
     /// The memory resource used for deleting the memory block

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -22,7 +22,7 @@ namespace vecmem {
  * is state-free (on the relevant levels of abstraction).
  */
 class host_memory_resource : public vecmem::memory_resource {
-    private:
+private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -32,7 +32,7 @@ namespace vecmem {
 ///
 class copy {
 
-    public:
+public:
     /// Wrapper struct around the @c copy_type enumeration
     ///
     /// The code does not use "enum struct type" to declare the copy type, as
@@ -143,14 +143,14 @@ class copy {
 
     /// @}
 
-    protected:
+protected:
     /// Perform a "low level" memory copy
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype);
     /// Perform a "low level" memory filling operation
     virtual void do_memset(std::size_t size, void* ptr, int value);
 
-    private:
+private:
     /// Helper function performing the copy of a jagged array/vector
     template <typename TYPE>
     void copy_views(std::size_t size, const data::vector_view<TYPE>* from,

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -19,7 +19,7 @@ namespace vecmem::cuda {
  * for CUDA device memory. Each instance is bound to a specific device.
  */
 class device_memory_resource : public memory_resource {
-    public:
+public:
     /**
      * @brief Construct a CUDA device resource for a specific device.
      *
@@ -33,7 +33,7 @@ class device_memory_resource : public memory_resource {
      */
     device_memory_resource(int device = -1);
 
-    private:
+private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;

--- a/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
@@ -19,7 +19,7 @@ namespace vecmem::cuda {
  * CUDA devices.
  */
 class host_memory_resource : public memory_resource {
-    private:
+private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;

--- a/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
@@ -18,7 +18,7 @@ namespace vecmem::cuda {
  * memory, which is accessible directly to devices as well as to the host.
  */
 class managed_memory_resource : public memory_resource {
-    private:
+private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;

--- a/cuda/include/vecmem/utils/cuda/copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/copy.hpp
@@ -15,7 +15,7 @@ namespace vecmem::cuda {
 /// Specialisation of @c vecmem::copy for CUDA
 class copy : public vecmem::copy {
 
-    protected:
+protected:
     /// Perform a memory copy using CUDA
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) override;

--- a/cuda/src/utils/select_device.hpp
+++ b/cuda/src/utils/select_device.hpp
@@ -24,7 +24,7 @@ namespace vecmem::cuda::details {
  * more than one in the same scope.
  */
 class select_device {
-    public:
+public:
     /**
      * @brief Constructs the object, switching the current CUDA device
      * to the requested number.
@@ -39,7 +39,7 @@ class select_device {
      */
     ~select_device();
 
-    private:
+private:
     /**
      * @brief The old device number, this is what we restore when the
      * object goes out of scope.

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -14,14 +14,14 @@ namespace vecmem::hip {
 /// Memory resource for a specific HIP device
 class device_memory_resource final : public memory_resource {
 
-    public:
+public:
     /// Invalid/default device identifier
     static constexpr int INVALID_DEVICE = -1;
 
     /// Constructor, allowing the specification of the device to use
     device_memory_resource(int device = INVALID_DEVICE);
 
-    private:
+private:
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -14,7 +14,7 @@ namespace vecmem::hip {
 /// Memory resource for HIP shared host/device memory
 class host_memory_resource final : public memory_resource {
 
-    private:
+private:
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 

--- a/hip/include/vecmem/utils/hip/copy.hpp
+++ b/hip/include/vecmem/utils/hip/copy.hpp
@@ -15,7 +15,7 @@ namespace vecmem::hip {
 /// Specialisation of @c vecmem::copy for HIP
 class copy : public vecmem::copy {
 
-    protected:
+protected:
     /// Perform a memory copy using HIP
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) override;

--- a/hip/src/utils/run_on_device.hpp
+++ b/hip/src/utils/run_on_device.hpp
@@ -18,7 +18,7 @@ namespace vecmem::hip::details {
 /// Helper functor used for running a piece of code on a given device
 class run_on_device {
 
-    public:
+public:
     /// Constructor, with the device that code should run on
     run_on_device(int device) : m_device(device) {}
 
@@ -33,7 +33,7 @@ class run_on_device {
         exe();
     }
 
-    private:
+private:
     /// The device to run the code on
     const int m_device;
 

--- a/hip/src/utils/select_device.hpp
+++ b/hip/src/utils/select_device.hpp
@@ -24,7 +24,7 @@ namespace vecmem::hip::details {
  */
 class select_device {
 
-    public:
+public:
     /**
      * @brief Constructs the object, switching the current HIP device
      * to the requested number.
@@ -39,7 +39,7 @@ class select_device {
      */
     ~select_device();
 
-    private:
+private:
     /**
      * @brief The old device number, this is what we restore when the
      * object goes out of scope.

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -19,15 +19,15 @@ namespace vecmem::sycl::details {
 ///
 class memory_resource_base : public memory_resource {
 
-    public:
+public:
     /// Constructor on top of a user-provided queue
     memory_resource_base(const queue_wrapper& queue = {""});
 
-    protected:
+protected:
     /// The queue that the allocations are made for/on
     queue_wrapper m_queue;
 
-    private:
+private:
     /// Function performing the memory de-allocation
     void do_deallocate(void* ptr, std::size_t nbytes,
                        std::size_t alignment) override final;

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -14,11 +14,11 @@ namespace vecmem::sycl {
 /// Memory resource for a specific SYCL device
 class device_memory_resource final : public details::memory_resource_base {
 
-    public:
+public:
     // Inherit the base class's constructor(s).
     using details::memory_resource_base::memory_resource_base;
 
-    private:
+private:
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -14,11 +14,11 @@ namespace vecmem::sycl {
 /// Host memory resource, connected to a specific SYCL device
 class host_memory_resource final : public details::memory_resource_base {
 
-    public:
+public:
     // Inherit the base class's constructor(s).
     using details::memory_resource_base::memory_resource_base;
 
-    private:
+private:
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -14,11 +14,11 @@ namespace vecmem::sycl {
 /// Memory resource shared between the host and a specific SYCL device
 class shared_memory_resource final : public details::memory_resource_base {
 
-    public:
+public:
     // Inherit the base class's constructor(s).
     using details::memory_resource_base::memory_resource_base;
 
-    private:
+private:
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -22,18 +22,18 @@ namespace vecmem::sycl {
 ///
 class copy : public vecmem::copy {
 
-    public:
+public:
     /// Constructor on top of a user-provided queue
     copy(const queue_wrapper& queue = {""});
 
-    protected:
+protected:
     /// Perform a memory copy using SYCL
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) override;
     /// Fill a memory area using SYCL
     virtual void do_memset(std::size_t size, void* ptr, int value) override;
 
-    private:
+private:
     /// The queue that the copy operations are made with/for
     queue_wrapper m_queue;
 

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -24,7 +24,7 @@ class opaque_queue;
 ///
 class queue_wrapper {
 
-    public:
+public:
     /// Construct a queue for a device with a specific name
     queue_wrapper(const std::string& deviceName = "");
     /// Wrap an existing @c cl::sycl::queue object
@@ -51,7 +51,7 @@ class queue_wrapper {
     /// Access a typeless pointer to the managed @c cl::sycl::queue object
     const void* queue() const;
 
-    private:
+private:
     /// Bare pointer to the wrapped @c cl::sycl::queue object
     void* m_queue;
     /// Smart pointer to the managed @c cl::sycl::queue object

--- a/sycl/src/utils/sycl/device_selector.hpp
+++ b/sycl/src/utils/sycl/device_selector.hpp
@@ -17,14 +17,14 @@ namespace vecmem::sycl {
 /// Device selector used by the VecMem SYCL library by default
 class device_selector : public cl::sycl::device_selector {
 
-    public:
+public:
     /// Constructor, with an optional device name
     device_selector(const std::string& deviceName = "");
 
     /// Operator used to "grade" the available devices
     int operator()(const cl::sycl::device& device) const override;
 
-    private:
+private:
     /// Default device selector used internally
     cl::sycl::default_selector m_defaultSelector;
 

--- a/sycl/src/utils/sycl/opaque_queue.hpp
+++ b/sycl/src/utils/sycl/opaque_queue.hpp
@@ -13,7 +13,7 @@ namespace vecmem::sycl::details {
 
 /// Helper class for managing queue objects in memory
 class opaque_queue : public cl::sycl::queue {
-    public:
+public:
     using cl::sycl::queue::queue;
 };
 

--- a/tests/common/memory_resource_name_gen.hpp
+++ b/tests/common/memory_resource_name_gen.hpp
@@ -26,7 +26,7 @@ namespace vecmem::testing {
 ///
 class memory_resource_name_gen {
 
-    public:
+public:
     /// Storage type for the memory resource names
     typedef std::map<memory_resource*, std::string> storage_type;
 
@@ -37,7 +37,7 @@ class memory_resource_name_gen {
     std::string operator()(
         const ::testing::TestParamInfo<memory_resource*>& info);
 
-    private:
+private:
     /// Internal map keeping track of the user readable names of the resources
     storage_type m_names;
     /// Unknown name counter

--- a/tests/core/test_core_allocator.cpp
+++ b/tests/core/test_core_allocator.cpp
@@ -16,7 +16,7 @@
 #include "vecmem/memory/host_memory_resource.hpp"
 
 class test_class {
-    public:
+public:
     test_class() : m_int_2(11), m_bool_2(true) {}
     test_class(int n) : m_int_2(n), m_bool_2(false) {}
     test_class(int n, int m) : m_int_2(n), m_bool_2(m > 100) {}
@@ -29,7 +29,7 @@ class test_class {
 };
 
 class core_allocator_test : public testing::Test {
-    protected:
+protected:
     vecmem::host_memory_resource m_upstream;
     vecmem::allocator* m_alloc;
 

--- a/tests/core/test_core_array.cpp
+++ b/tests/core/test_core_array.cpp
@@ -41,7 +41,7 @@ bool operator==(const TestType1& value1, const TestType1& value2) {
 class core_array_test
     : public testing::TestWithParam<vecmem::memory_resource*> {
 
-    protected:
+protected:
     /// Function testing a particular array object.
     template <typename T, std::size_t N>
     void test_array(vecmem::array<T, N>& a) {

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -26,7 +26,7 @@
 /// Test case for the custom container types
 class core_container_test : public testing::Test {
 
-    protected:
+protected:
     /// Memory resource to use in the tests
     vecmem::host_memory_resource m_resource;
     /// Test vector used for testing all of the custom containers

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -19,7 +19,7 @@
 /// Test case for @c vecmem::contiguous_memory_resource
 class core_contiguous_memory_resource_test : public testing::Test {
 
-    protected:
+protected:
     /// The base memory resource
     vecmem::host_memory_resource m_upstream;
     /// The contiguous memory resource

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -21,7 +21,7 @@
 /// Test case for testing @c vecmem::copy
 class core_copy_test : public testing::Test {
 
-    protected:
+protected:
     /// Memory resource for the test(s)
     vecmem::host_memory_resource m_resource;
     /// Copy object for the test(s)

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -27,7 +27,7 @@
 /// Test case for the custom device container types
 class core_device_container_test : public testing::Test {
 
-    protected:
+protected:
     /// Memory resource for the test(s)
     vecmem::host_memory_resource m_resource;
     /// Helper object for the memory copies.

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -22,7 +22,7 @@
 #include <set>
 
 class core_jagged_vector_view_test : public testing::Test {
-    protected:
+protected:
     vecmem::host_memory_resource m_mem;
     vecmem::jagged_vector<int> m_vec;
     vecmem::data::jagged_vector_data<int> m_data;

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -56,7 +56,7 @@ bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
 class core_memory_resource_test
     : public testing::TestWithParam<vecmem::memory_resource*> {
 
-    protected:
+protected:
     /// Function performing some basic tests using @c vecmem::vector
     template <typename T>
     void test_resource(vecmem::vector<T>& test_vector) {

--- a/tests/core/test_core_vector.cpp
+++ b/tests/core/test_core_vector.cpp
@@ -15,7 +15,7 @@
 /// Test case for @c vecmem::vector
 class core_vector_test : public testing::Test {
 
-    protected:
+protected:
     /// Memory resource to use in the tests
     vecmem::host_memory_resource m_resource;
 

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -20,7 +20,7 @@
 /// Test fixture for the on-device vecmem container tests
 class cuda_containers_test : public testing::Test {
 
-    protected:
+protected:
     /// Helper object for performing memory copies
     vecmem::cuda::copy m_copy;
 

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -21,7 +21,7 @@
 #include "vecmem/utils/cuda/copy.hpp"
 
 class cuda_jagged_vector_view_test : public testing::Test {
-    protected:
+protected:
     vecmem::cuda::managed_memory_resource m_mem;
     vecmem::jagged_vector<int> m_vec;
     vecmem::array<int, 2> m_constants;

--- a/tests/cuda/test_cuda_memory_resources.cpp
+++ b/tests/cuda/test_cuda_memory_resources.cpp
@@ -87,7 +87,7 @@ bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
 class cuda_host_accessible_memory_resource_test
     : public cuda_memory_resource_test {
 
-    protected:
+protected:
     /// Function performing some basic tests using @c vecmem::vector
     template <typename T>
     void test_host_accessible_resource(vecmem::vector<T>& test_vector) {

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -19,7 +19,7 @@
 /// Test fixture for the on-device vecmem container tests
 class hip_containers_test : public testing::Test {
 
-    protected:
+protected:
     /// Helper object for performing memory copies
     vecmem::hip::copy m_copy;
 

--- a/tests/hip/test_hip_jagged_containers.cpp
+++ b/tests/hip/test_hip_jagged_containers.cpp
@@ -28,7 +28,7 @@
 /// Test fixture for the on-device vecmem jagged container tests
 class hip_jagged_containers_test : public testing::Test {
 
-    public:
+public:
     /// Constructor, setting up the input data for the tests.
     hip_jagged_containers_test()
         : m_mem(),
@@ -44,7 +44,7 @@ class hip_jagged_containers_test : public testing::Test {
         m_constants[1] = 1;
     }
 
-    protected:
+protected:
     /// Host (managed) memory resource
     vecmem::hip::host_memory_resource m_mem;
     /// The base vector to perform tests with

--- a/tests/hip/test_hip_memory_resources.cpp
+++ b/tests/hip/test_hip_memory_resources.cpp
@@ -83,7 +83,7 @@ bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
 class hip_host_accessible_memory_resource_test
     : public hip_memory_resource_test {
 
-    protected:
+protected:
     /// Function performing some basic tests using @c vecmem::vector
     template <typename T>
     void test_host_accessible_resource(vecmem::vector<T>& test_vector) {

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -32,7 +32,7 @@
 /// Test fixture for the on-device vecmem jagged container tests
 class sycl_jagged_containers_test : public testing::Test {
 
-    public:
+public:
     /// Constructor, setting up the input data for the tests.
     sycl_jagged_containers_test()
         : m_queue(vecmem::sycl::device_selector()),
@@ -49,7 +49,7 @@ class sycl_jagged_containers_test : public testing::Test {
         m_constants[1] = 1;
     }
 
-    protected:
+protected:
     // SYCL queue used in the tests
     cl::sycl::queue m_queue;
     /// Shared (managed) memory resource
@@ -63,7 +63,7 @@ class sycl_jagged_containers_test : public testing::Test {
 /// Functor performing a linear transformation on jagged vectors
 class LinearTransformKernel {
 
-    public:
+public:
     /// Constructor with the data objects that the kernel will operate on
     LinearTransformKernel(vecmem::data::vector_view<const int> constants,
                           vecmem::data::jagged_vector_view<const int> input,
@@ -97,7 +97,7 @@ class LinearTransformKernel {
         }
     }
 
-    private:
+private:
     /// Constants used in the "linear" transformation
     vecmem::data::vector_view<const int> m_constants;
     /// Input data used in the transformation
@@ -110,7 +110,7 @@ class LinearTransformKernel {
 /// Functor performing a summation of the jagged vector's elements
 class SummationKernel {
 
-    public:
+public:
     /// Constructor with the jagged vector to operate on
     SummationKernel(vecmem::data::jagged_vector_view<int> data)
         : m_data(data) {}
@@ -141,7 +141,7 @@ class SummationKernel {
         }
     }
 
-    private:
+private:
     /// The data used in the summation
     vecmem::data::jagged_vector_view<int> m_data;
 

--- a/tests/sycl/test_sycl_memory_resources.cpp
+++ b/tests/sycl/test_sycl_memory_resources.cpp
@@ -87,7 +87,7 @@ bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
 class sycl_host_accessible_memory_resource_test
     : public sycl_memory_resource_test {
 
-    protected:
+protected:
     /// Function performing some basic tests using @c vecmem::vector
     template <typename T>
     void test_host_accessible_resource(vecmem::vector<T>& test_vector) {


### PR DESCRIPTION
Tweaked the indentation of the class access modifiers as I hinted at earlier.

Now... Normally my preference would've been to use `AccessModifierOffset: -4`, and have classes look like:

```c++
class MyClass {
public:
    MyClass();
};
```

But as long as we want to stay close to Google's coding format, I thought this would be more appropriate. Since by default Google uses a layout like:

```c++
class MyClass {
 public:
  MyClass();
};
```

I thought that since we use a tab width of 4 spaces instead of Google's default of 2, it would only be fair to double the indentation on the access modifiers as well.

Thoughts?