### PR TITLE
Add More Warning Checks, main branch (2021.08.06.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -18,6 +18,8 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wall" )
       vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wextra" )
+      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wshadow" )
+      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wunused-local-typedefs" )
    endforeach()
 
    # More rigorous tests for the Debug builds.

--- a/cmake/vecmem-compiler-options-hip.cmake
+++ b/cmake/vecmem-compiler-options-hip.cmake
@@ -16,6 +16,8 @@ if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" ) OR
    foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
       vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wall" )
       vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wextra" )
+      vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wshadow" )
+      vecmem_add_flag( CMAKE_HIP_FLAGS_${mode} "-Wunused-local-typedefs" )
    endforeach()
 endif()
 

--- a/cmake/vecmem-compiler-options-sycl.cmake
+++ b/cmake/vecmem-compiler-options-sycl.cmake
@@ -15,6 +15,8 @@ foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wall" )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wextra" )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wno-unknown-cuda-version" )
+   vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wshadow" )
+   vecmem_add_flag( CMAKE_SYCL_FLAGS_${mode} "-Wunused-local-typedefs" )
 endforeach()
 
 # More rigorous tests for the Debug builds.

--- a/core/src/memory/binary_page_memory_resource.cpp
+++ b/core/src/memory/binary_page_memory_resource.cpp
@@ -112,8 +112,8 @@ void binary_page_memory_resource::do_deallocate(void *p, std::size_t,
      */
     std::stack<page *> rem;
 
-    for (std::unique_ptr<page> &p : m_pages) {
-        rem.push(p.get());
+    for (std::unique_ptr<page> &pg : m_pages) {
+        rem.push(pg.get());
     }
 
     /*

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -16,17 +16,17 @@
 
 namespace vecmem {
 
-void copy::do_copy(std::size_t size, const void* from, void* to,
+void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type) {
 
     // Perform a simple POSIX memory copy.
-    memcpy(to, from, size);
+    memcpy(to_ptr, from_ptr, size);
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4,
                      "Performed POSIX memory copy of %lu bytes from %p "
                      "to %p",
-                     size, from, to);
+                     size, from_ptr, to_ptr);
 }
 
 void copy::do_memset(std::size_t size, void* ptr, int value) {

--- a/cuda/src/utils/cuda/copy.cpp
+++ b/cuda/src/utils/cuda/copy.cpp
@@ -32,7 +32,7 @@ static const std::string copy_type_printer[copy::type::count] = {
     "host to device", "device to host", "host to host", "device to device",
     "unknown"};
 
-void copy::do_copy(std::size_t size, const void* from, void* to,
+void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type cptype) {
 
     // Check if anything needs to be done.
@@ -42,20 +42,20 @@ void copy::do_copy(std::size_t size, const void* from, void* to,
     }
 
     // Some sanity checks.
-    assert(from != nullptr);
-    assert(to != nullptr);
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
     assert(static_cast<int>(cptype) >= 0);
     assert(static_cast<int>(cptype) < static_cast<int>(copy::type::count));
 
     // Perform the copy.
     VECMEM_CUDA_ERROR_CHECK(
-        cudaMemcpy(to, from, size, copy_type_translator[cptype]));
+        cudaMemcpy(to_ptr, from_ptr, size, copy_type_translator[cptype]));
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4,
                      "Performed %s memory copy of %lu bytes from %p to "
                      "%p",
-                     copy_type_printer[cptype].c_str(), size, from, to);
+                     copy_type_printer[cptype].c_str(), size, from_ptr, to_ptr);
 }
 
 void copy::do_memset(std::size_t size, void* ptr, int value) {

--- a/hip/src/utils/hip/copy.cpp
+++ b/hip/src/utils/hip/copy.cpp
@@ -32,7 +32,7 @@ static const std::string copy_type_printer[copy::type::count] = {
     "host to device", "device to host", "host to host", "device to device",
     "unknown"};
 
-void copy::do_copy(std::size_t size, const void* from, void* to,
+void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type cptype) {
 
     // Check if anything needs to be done.
@@ -42,20 +42,20 @@ void copy::do_copy(std::size_t size, const void* from, void* to,
     }
 
     // Some sanity checks.
-    assert(from != nullptr);
-    assert(to != nullptr);
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
     assert(static_cast<int>(cptype) >= 0);
     assert(static_cast<int>(cptype) < static_cast<int>(copy::type::count));
 
     // Perform the copy.
     VECMEM_HIP_ERROR_CHECK(
-        hipMemcpy(to, from, size, copy_type_translator[cptype]));
+        hipMemcpy(to_ptr, from_ptr, size, copy_type_translator[cptype]));
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4,
                      "Performed %s memory copy of %lu bytes from %p to "
                      "%p",
-                     copy_type_printer[cptype].c_str(), size, from, to);
+                     copy_type_printer[cptype].c_str(), size, from_ptr, to_ptr);
 }
 
 void copy::do_memset(std::size_t size, void* ptr, int value) {

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -18,7 +18,7 @@ namespace vecmem::sycl {
 
 copy::copy(const queue_wrapper& queue) : m_queue(queue) {}
 
-void copy::do_copy(std::size_t size, const void* from, void* to,
+void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type) {
 
     // Check if anything needs to be done.
@@ -28,16 +28,16 @@ void copy::do_copy(std::size_t size, const void* from, void* to,
     }
 
     // Some sanity checks.
-    assert(from != nullptr);
-    assert(to != nullptr);
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
 
     // Perform the copy.
-    auto event = details::get_queue(m_queue).memcpy(to, from, size);
+    auto event = details::get_queue(m_queue).memcpy(to_ptr, from_ptr, size);
     event.wait_and_throw();
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4, "Performed memory copy of %lu bytes from %p to %p",
-                     size, from, to);
+                     size, from_ptr, to_ptr);
 }
 
 void copy::do_memset(std::size_t size, void* ptr, int value) {


### PR DESCRIPTION
I have been getting a very annoying compilation warning from @konradkusiak97's Acts code, as it is building VecMem. This is because Acts uses `-Wshadow` in its build (https://github.com/acts-project/acts/blob/main/cmake/ActsCompilerOptions.cmake#L7), which triggered a warning in our code.

So in the end I decided to adopt 2 flags from Acts (`-Wshadow` and `-Wunused-local-typedefs`) into the VecMem build. And then to fix the warning brought forward by `-Wshadow`.