### PR TITLE
Jagged Vector Improvements, main branch (2021.08.25.)

### DIFF
--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -133,16 +133,16 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
                                            : m_outer_host_memory.get());
 
     // Set up the host accessible memory array.
-    std::ptrdiff_t ptrdiff = 0;
+    std::ptrdiff_t ptrdiff =
+        (capacities.size() * sizeof(typename value_type::size_type));
     for (std::size_t i = 0; i < capacities.size(); ++i) {
-        new (host_ptr() + i) value_type(
-            capacities[i],
-            reinterpret_cast<typename value_type::size_pointer>(
-                m_inner_memory.get() + ptrdiff),
-            reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff +
-                                    sizeof(typename value_type::size_type)));
-        ptrdiff += capacities[i] * sizeof(TYPE) +
-                   sizeof(typename value_type::size_type);
+        new (host_ptr() + i)
+            value_type(capacities[i],
+                       reinterpret_cast<typename value_type::size_pointer>(
+                           m_inner_memory.get() +
+                           i * sizeof(typename value_type::size_type)),
+                       reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
+        ptrdiff += capacities[i] * sizeof(TYPE);
     }
 }
 

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -82,6 +82,11 @@ public:
                     std::vector<TYPE2, ALLOC>& to,
                     type::copy_type cptype = type::unknown);
 
+    /// Helper function for getting the size of a resizable 1D buffer
+    template <typename TYPE>
+    typename data::vector_view<TYPE>::size_type get_size(
+        const data::vector_view<TYPE>& data);
+
     /// @}
 
     /// @name Jagged vector data handling functions
@@ -141,6 +146,16 @@ public:
                     std::vector<std::vector<TYPE2, ALLOC2>, ALLOC1>& to,
                     type::copy_type cptype = type::unknown);
 
+    /// Helper function for getting the sizes of a resizable jagged vector
+    template <typename TYPE>
+    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
+        const data::jagged_vector_view<TYPE>& data);
+
+    /// Helper function for getting the sizes of a resizable jagged buffer
+    template <typename TYPE>
+    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
+        const data::jagged_vector_buffer<TYPE>& data);
+
     /// @}
 
 protected:
@@ -155,10 +170,10 @@ private:
     template <typename TYPE>
     void copy_views(std::size_t size, const data::vector_view<TYPE>* from,
                     data::vector_view<TYPE>* to, type::copy_type cptype);
-    /// Helper function for getting the size of a resizable 1D buffer
+    /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
-    typename data::vector_view<TYPE>::size_type get_size(
-        const data::vector_view<TYPE>& data);
+    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
+        const data::vector_view<TYPE>* data, std::size_t size);
 
 };  // class copy
 

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -31,8 +31,8 @@ void copy::setup(data::vector_view<TYPE>& data) {
               data.size_ptr(), 0);
     VECMEM_DEBUG_MSG(2,
                      "Prepared a device vector buffer of capacity %u "
-                     "for use on a device",
-                     data.capacity());
+                     "for use on a device (ptr: %p)",
+                     data.capacity(), static_cast<void*>(data.size_ptr()));
 }
 
 template <typename TYPE>
@@ -98,6 +98,25 @@ void copy::operator()(const data::vector_view<TYPE1>& from_view,
 }
 
 template <typename TYPE>
+typename data::vector_view<TYPE>::size_type copy::get_size(
+    const data::vector_view<TYPE>& data) {
+
+    // Handle the simple case, when the view/buffer is not resizable.
+    if (data.size_ptr() == nullptr) {
+        return data.capacity();
+    }
+
+    // If it *is* resizable, don't assume that the size is host-accessible.
+    // Explicitly copy it for access.
+    typename data::vector_view<TYPE>::size_type result = 0;
+    do_copy(sizeof(typename data::vector_view<TYPE>::size_type),
+            data.size_ptr(), &result, type::unknown);
+
+    // Return what we got.
+    return result;
+}
+
+template <typename TYPE>
 void copy::setup(data::jagged_vector_buffer<TYPE>& data) {
 
     // Check if anything needs to be done.
@@ -108,7 +127,18 @@ void copy::setup(data::jagged_vector_buffer<TYPE>& data) {
     // "Set up" the inner vector descriptors, using the host-accessible data.
     for (typename data::jagged_vector_buffer<TYPE>::size_type i = 0;
          i < data.m_size; ++i) {
-        setup(data.host_ptr()[i]);
+        // Find the first "inner vector" that has a non-zero capacity, and is
+        // resizable.
+        if ((data.host_ptr()[i].capacity() != 0) &&
+            (data.host_ptr()[i].size_ptr() != nullptr)) {
+            // Initialise the size values using this "inner vector's" pointer.
+            do_memset(sizeof(typename data::vector_buffer<TYPE>::size_type) *
+                          (data.m_size - i),
+                      data.host_ptr()[i].size_ptr(), 0);
+            // This would have initialised all of the "inner vectors" correctly,
+            // we can end the loop.
+            break;
+        }
     }
 
     // Check if anything else needs to be done.
@@ -232,9 +262,10 @@ void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
 
     // Resize the output object to the correct size.
     to_vec.resize(from_view.m_size);
+    const auto sizes = get_sizes(from_view);
     for (typename data::jagged_vector_view<TYPE1>::size_type i = 0;
          i < from_view.m_size; ++i) {
-        to_vec[i].resize(get_size(from_view.m_ptr[i]));
+        to_vec[i].resize(sizes[i]);
     }
 
     // Perform the memory copy.
@@ -256,14 +287,31 @@ void copy::operator()(const data::jagged_vector_buffer<TYPE1>& from_buffer,
 
     // Resize the output object to the correct size.
     to_vec.resize(from_buffer.m_size);
+    const auto sizes = get_sizes(from_buffer);
     for (typename data::jagged_vector_view<TYPE1>::size_type i = 0;
          i < from_buffer.m_size; ++i) {
-        to_vec[i].resize(get_size(from_buffer.host_ptr()[i]));
+        to_vec[i].resize(sizes[i]);
     }
 
     // Perform the memory copy.
     auto helper = vecmem::get_data(to_vec);
     this->operator()(from_buffer, helper, cptype);
+}
+
+template <typename TYPE>
+std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes(
+    const data::jagged_vector_view<TYPE>& data) {
+
+    // Perform the operation using the private function.
+    return get_sizes(data.m_ptr, data.m_size);
+}
+
+template <typename TYPE>
+std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes(
+    const data::jagged_vector_buffer<TYPE>& data) {
+
+    // Perform the operation using the private function.
+    return get_sizes(data.host_ptr(), data.m_size);
 }
 
 template <typename TYPE>
@@ -278,55 +326,61 @@ void copy::copy_views(std::size_t size,
     std::size_t copy_size = 0;
     [[maybe_unused]] std::size_t copy_ops = 0;
 
+    // Get the sizes of the two views.
+    const auto from_sizes = get_sizes(from_view, size);
+    const auto to_sizes = get_sizes(to_view, size);
+
     // Helper lambda for figuring out if the next vector element is
     // connected to the currently processed one or not.
-    auto next_is_connected = [this, size](const data::vector_view<TYPE>* array,
-                                          std::size_t i) {
-        // Check if the next non-empty vector element is connected to the
-        // current one.
-        std::size_t j = i + 1;
-        while (j < size) {
-            if (this->get_size(array[j]) == 0) {
-                ++j;
-                continue;
+    auto next_is_connected =
+        [size](const data::vector_view<TYPE>* array,
+               const std::vector<typename data::vector_view<TYPE>::size_type>&
+                   sizes,
+               std::size_t i) {
+            // Check if the next non-empty vector element is connected to the
+            // current one.
+            std::size_t j = i + 1;
+            while (j < size) {
+                if (sizes[j] == 0) {
+                    ++j;
+                    continue;
+                }
+                return ((array[i].ptr() + sizes[i]) == array[j].ptr());
             }
-            return ((array[i].ptr() + this->get_size(array[i])) ==
-                    array[j].ptr());
-        }
-        // If we got here, then the answer is no...
-        return false;
-    };
+            // If we got here, then the answer is no...
+            return false;
+        };
 
     // Perform the copy in multiple steps.
     for (std::size_t i = 0; i < size; ++i) {
 
         // Skip empty "inner vectors".
-        if ((get_size(from_view[i]) == 0) && (get_size(to_view[i]) == 0)) {
+        if ((from_sizes[i] == 0) && (to_sizes[i] == 0)) {
             continue;
         }
 
         // Some sanity checks.
         assert(from_view[i].ptr() != nullptr);
         assert(to_view[i].ptr() != nullptr);
-        assert(get_size(from_view[i]) != 0);
-        assert(get_size(from_view[i]) == get_size(to_view[i]));
+        assert(from_sizes[i] != 0);
+        assert(from_sizes[i] == to_sizes[i]);
 
         // Set/update the helper variables.
         if ((from_ptr == nullptr) && (to_ptr == nullptr) && (copy_size == 0)) {
             from_ptr = from_view[i].ptr();
             to_ptr = to_view[i].ptr();
-            copy_size = get_size(from_view[i]) * sizeof(TYPE);
+            copy_size = from_sizes[i] * sizeof(TYPE);
         } else {
             assert(from_ptr != nullptr);
             assert(to_ptr != nullptr);
             assert(copy_size != 0);
-            copy_size += get_size(from_view[i]) * sizeof(TYPE);
+            copy_size += from_sizes[i] * sizeof(TYPE);
         }
 
         // Check if the next vector element connects to this one. If not,
         // perform the copy now.
-        if ((!next_is_connected(from_view, i)) ||
-            (!next_is_connected(to_view, i))) {
+        if ((!next_is_connected(from_view, from_sizes, i)) ||
+            (!next_is_connected(to_view, to_sizes, i))) {
 
             // Perform the copy.
             do_copy(copy_size, from_ptr, to_ptr, cptype);
@@ -347,21 +401,32 @@ void copy::copy_views(std::size_t size,
 }
 
 template <typename TYPE>
-typename data::vector_view<TYPE>::size_type copy::get_size(
-    const data::vector_view<TYPE>& data) {
+std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes(
+    const data::vector_view<TYPE>* data, std::size_t size) {
 
-    // Handle the simple case, when the view/buffer is not resizable.
-    if (data.size_ptr() == nullptr) {
-        return data.capacity();
+    // Create the result vector.
+    std::vector<typename data::vector_view<TYPE>::size_type> result(size, 0);
+
+    // Try to get the "resizable sizes" first.
+    for (std::size_t i = 0; i < size; ++i) {
+        // Find the first "inner vector" that has a non-zero capacity, and is
+        // resizable.
+        if ((data[i].capacity() != 0) && (data[i].size_ptr() != nullptr)) {
+            // Copy the sizes of the inner vectors into the result vector.
+            do_copy(sizeof(typename data::vector_view<TYPE>::size_type) *
+                        (size - i),
+                    data[i].size_ptr(), result.data() + i, type::unknown);
+            // At this point the result vector should have been set up
+            // correctly.
+            return result;
+        }
     }
 
-    // If it *is* resizable, don't assume that the size is host-accessible.
-    // Explicitly copy it for access.
-    typename data::vector_view<TYPE>::size_type result = 0;
-    do_copy(sizeof(typename data::vector_view<TYPE>::size_type),
-            data.size_ptr(), &result, type::unknown);
-
-    // Return what we got.
+    // If we're still here, then the buffer is not resizable. So let's just
+    // collect the capacity of each of the inner vectors.
+    for (std::size_t i = 0; i < size; ++i) {
+        result[i] = data[i].capacity();
+    }
     return result;
 }
 


### PR DESCRIPTION
As @konradkusiak97 found during his updates in the Acts SYCL seedfinder code, the current implementation of resizable `vecmem::data::jagged_vector_buffer` objects is far from ideal. This PR aims to improve upon that...

First off, the internal memory layout of these buffers is updated like the following:

![image](https://user-images.githubusercontent.com/30694331/130799049-a7039ff7-0be8-45e7-9f6a-f0fa5d4d291d.png)

Instead of scattering the "size variables" of the resizable jagged vectors across the allocated blob, now these size variables are put at the beginning of the blob, before all of the payloads of the "internal vectors".

With that update in place, I taught `vecmem::copy` to be able to grab the sizes of resizable jagged vectors with a single operation, minimising the number of copy operations needed to copy a jagged vector. The number of `memset` operations was also reduced to just 1 per jagged vector from previously executing N. (Where N is the size of the "outer vector".)

We managed to learn a bit about GCC and "generic lambdas" with @stephenswat along the way. :smile: