### PR TITLE
Fix inclusion of PMR headers on C++14

### DIFF
--- a/core/include/vecmem/memory/memory_resource.hpp
+++ b/core/include/vecmem/memory/memory_resource.hpp
@@ -14,13 +14,13 @@
  * depending on the GCC version used, so we try to unify them by aliassing
  * depending on the compiler feature flags.
  */
-#if __has_include(<memory_resource>)
+#if __cplusplus >= 201703L && __has_include(<memory_resource>)
 #include <memory_resource>
 
 namespace vecmem {
 using memory_resource = std::pmr::memory_resource;
 }
-#elif __has_include(<experimental/memory_resource>)
+#elif __cplusplus == 201402L || (__cplusplus >= 201703L && __has_include(<experimental/memory_resource>))
 #include <experimental/memory_resource>
 
 namespace vecmem {

--- a/core/include/vecmem/memory/polymorphic_allocator.hpp
+++ b/core/include/vecmem/memory/polymorphic_allocator.hpp
@@ -14,14 +14,14 @@
  * depending on the GCC version used, so we try to unify them by aliassing
  * depending on the compiler feature flags.
  */
-#if __has_include(<memory_resource>)
+#if __cplusplus >= 201703L && __has_include(<memory_resource>)
 #include <memory_resource>
 
 namespace vecmem {
 template <typename T>
 using polymorphic_allocator = std::pmr::polymorphic_allocator<T>;
 }
-#elif __has_include(<experimental/memory_resource>)
+#elif __cplusplus == 201402L || (__cplusplus >= 201703L && __has_include(<experimental/memory_resource>))
 #include <experimental/memory_resource>
 
 namespace vecmem {


### PR DESCRIPTION
It appears that the logic we use to determine whether we can import the "real" or the experimental version of the standard PMR library is a little broken. It does not seem to work on C++14, probably because `__has_include` is a C++17 feature. However, I am not one hundred percent sure what the exact problem is here. Adding these additional checks on the C++ version seems to resolve the problem.

This commit fixes the issues outlined in acts-project/traccc#78.