### PR TITLE
Memory Resource Source Detection Update, main branch (2021.09.06.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -72,3 +72,37 @@ string( LENGTH "${CMAKE_SOURCE_DIR}/" VECMEM_SOURCE_DIR_LENGTH )
 target_compile_definitions( vecmem_core PUBLIC
    $<BUILD_INTERFACE:VECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}>
    $<BUILD_INTERFACE:VECMEM_SOURCE_DIR_LENGTH=${VECMEM_SOURCE_DIR_LENGTH}> )
+
+# Figure out where to get <memory_resource> from.
+include( CheckCXXSourceCompiles )
+check_cxx_source_compiles( "
+   #include <memory_resource>
+   int main() {
+       std::pmr::memory_resource* mr = nullptr;
+       std::pmr::polymorphic_allocator<int> pa(mr);
+       return 0;
+   }
+   " VECMEM_HAVE_PMR_MEMORY_RESOURCE )
+if( VECMEM_HAVE_PMR_MEMORY_RESOURCE )
+   message( STATUS "Using memory resource types from the std::pmr namespace" )
+   target_compile_definitions( vecmem_core PUBLIC
+      VECMEM_HAVE_PMR_MEMORY_RESOURCE )
+else()
+   check_cxx_source_compiles( "
+      #include <experimental/memory_resource>
+      int main() {
+          std::experimental::pmr::memory_resource* mr = nullptr;
+          std::experimental::pmr::polymorphic_allocator<int> pa(mr);
+          return 0;
+      }
+      " VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE )
+   if( VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE )
+      message( STATUS "Using memory resource types from the "
+         "std::experimental::pmr namespace" )
+      target_compile_definitions( vecmem_core PUBLIC
+         VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE )
+   else()
+      message( SEND_ERROR
+         "C++17 LFTS V1 (P0220R1) component memory_resource not found!" )
+   endif()
+endif()

--- a/core/include/vecmem/memory/memory_resource.hpp
+++ b/core/include/vecmem/memory/memory_resource.hpp
@@ -7,6 +7,15 @@
 
 #pragma once
 
+// This header can only be used in C++17 mode. So "device compilers" that
+// can't use C++17, must not see it. Which in practically all cases should
+// "just" be a question of code organisation.
+#if __cplusplus < 201700L
+#error \
+    "This header can only be used in C++17 mode. " \
+         "Ideally it should only be used by the \"host compiler\"."
+#endif  // < C++17
+
 /*
  * The purpose of this file is to provide uniform access (on a source-code
  * level) to the memory_resource type from the standard library. These are
@@ -14,18 +23,18 @@
  * depending on the GCC version used, so we try to unify them by aliassing
  * depending on the compiler feature flags.
  */
-#if __has_include(<memory_resource>)
+#if defined(VECMEM_HAVE_PMR_MEMORY_RESOURCE)
 #include <memory_resource>
 
 namespace vecmem {
 using memory_resource = std::pmr::memory_resource;
 }
-#elif __has_include(<experimental/memory_resource>)
+#elif defined(VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE)
 #include <experimental/memory_resource>
 
 namespace vecmem {
 using memory_resource = std::experimental::pmr::memory_resource;
 }
 #else
-#error "vecmem requires C++17 LFTS V1 (P0220R1) component memory_resource!"
+#error "C++17 LFTS V1 (P0220R1) component memory_resource not found!?!"
 #endif

--- a/core/include/vecmem/memory/polymorphic_allocator.hpp
+++ b/core/include/vecmem/memory/polymorphic_allocator.hpp
@@ -7,6 +7,15 @@
 
 #pragma once
 
+// This header can only be used in C++17 mode. So "device compilers" that
+// can't use C++17, must not see it. Which in practically all cases should
+// "just" be a question of code organisation.
+#if __cplusplus < 201700L
+#error \
+    "This header can only be used in C++17 mode. " \
+         "Ideally it should only be used by the \"host compiler\"."
+#endif  // < C++17
+
 /*
  * The purpose of this file is to provide uniform access (on a source-code
  * level) to the polymorphic_allocator type from the standard library. These are
@@ -14,14 +23,14 @@
  * depending on the GCC version used, so we try to unify them by aliassing
  * depending on the compiler feature flags.
  */
-#if __has_include(<memory_resource>)
+#if defined(VECMEM_HAVE_PMR_MEMORY_RESOURCE)
 #include <memory_resource>
 
 namespace vecmem {
 template <typename T>
 using polymorphic_allocator = std::pmr::polymorphic_allocator<T>;
 }
-#elif __has_include(<experimental/memory_resource>)
+#elif defined(VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE)
 #include <experimental/memory_resource>
 
 namespace vecmem {
@@ -29,5 +38,5 @@ template <typename T>
 using polymorphic_allocator = std::experimental::pmr::polymorphic_allocator<T>;
 }
 #else
-#error "vecmem requires C++17 LFTS V1 (P0220R1) component memory_resource!"
+#error "C++17 LFTS V1 (P0220R1) component memory_resource not found!?!"
 #endif


### PR DESCRIPTION
This is my take on what we should do in response to https://github.com/acts-project/traccc/pull/83, which @stephenswat opened #97 about.

As we discussed with @stephenswat, the `vecmem/memory/memory_resource.hpp` and `vecmem/memory/polymorphic_allocator.hpp` headers can really only be used by a compiler that knows how to handle C\+\+17. CUDA in C\+\+14 mode must not see any of these headers. (In principle these headers should only be used by the "host compiler" in any project anyway.)

To make sure that the build of this project, and any client project, would always use the same source for picking up the memory resource types from, I added some logic to the CMake code to determine at configuration time where these types would be available from. And then the build just forces every compiler to use the types from there.

It's interesting to note that even in our CI, we pick up these types from both of those locations, since `<memory_resource>` only became available in GCC 9. The configuration now provides this type of output as feedback about these choices:

```
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE - Success
-- Using memory resource types from the std::pmr namespace
```

```
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE - Failed
-- Performing Test VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_EXPERIMENTAL_PMR_MEMORY_RESOURCE - Success
-- Using memory resource types from the std::experimental::pmr namespace
```