### PR TITLE
Windows Compatibility, main branch (2021.09.11.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -10,6 +10,11 @@ include( vecmem-functions )
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 
+# Turn on the correct setting for the __cplusplus macro with MSVC.
+if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+   vecmem_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
+endif()
+
 # Turn on a number of warnings for the "known compilers".
 if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
     ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -12,7 +12,8 @@ include( CMakeParseArguments )
 
 # Helper function for setting up the VecMem libraries.
 #
-# Usage: vecmem_add_library( vecmem_core core SHARED
+# Usage: vecmem_add_library( vecmem_core core
+#                            [TYPE SHARED/STATIC]
 #                            include/source1.hpp source2.cpp )
 #
 function( vecmem_add_library fullname basename )

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -15,10 +15,13 @@ include( CMakeParseArguments )
 # Usage: vecmem_add_library( vecmem_core core SHARED
 #                            include/source1.hpp source2.cpp )
 #
-function( vecmem_add_library fullname basename type )
+function( vecmem_add_library fullname basename )
+
+   # Parse the function's options.
+   cmake_parse_arguments( ARG "" "TYPE" "" ${ARGN} )
 
    # Create the library.
-   add_library( ${fullname} ${type} ${ARGN} )
+   add_library( ${fullname} ${ARG_TYPE} ${ARG_UNPARSED_ARGUMENTS} )
 
    # Set up how clients should find its headers.
    target_include_directories( ${fullname} PUBLIC

--- a/cmake/vecmem-googletest.cmake
+++ b/cmake/vecmem-googletest.cmake
@@ -30,6 +30,10 @@ FetchContent_Declare( GoogleTest
 # Options used in the build of GoogleTest.
 set( BUILD_GMOCK FALSE CACHE BOOL "Turn off the build of GMock" )
 set( INSTALL_GTEST FALSE CACHE BOOL "Turn off the installation of GoogleTest" )
+if( WIN32 )
+   set( gtest_force_shared_crt TRUE CACHE BOOL
+      "Use shared (DLL) run-time library, even with static libraries" )
+endif()
 
 # Get it into the current directory.
 FetchContent_Populate( GoogleTest )

--- a/cmake/vecmem-options.cmake
+++ b/cmake/vecmem-options.cmake
@@ -39,3 +39,12 @@ vecmem_lib_option( SYCL "Build the vecmem::sycl library" )
 # Debug message output level in the code.
 set( VECMEM_DEBUG_MSG_LVL 0 CACHE STRING
    "Debug message output level" )
+
+# Set the default library type, based on the platform.
+set( _sharedLibDefault TRUE )
+if( WIN32 )
+   set( _sharedLibDefault FALSE )
+endif()
+set( BUILD_SHARED_LIBS ${_sharedLibDefault} CACHE BOOL
+   "Flag for building shared/static libraries" )
+unset( _sharedLibDefault )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -8,7 +8,7 @@
 include( vecmem-compiler-options-cpp )
 
 # Set up the build of the VecMem core library.
-vecmem_add_library( vecmem_core core SHARED
+vecmem_add_library( vecmem_core core
    # STL mimicking containers.
    "include/vecmem/containers/array.hpp"
    "include/vecmem/containers/impl/array.ipp"

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -18,7 +18,7 @@ include( vecmem-compiler-options-cuda )
 find_package( CUDAToolkit REQUIRED )
 
 # Set up the build of the VecMem CUDA library.
-vecmem_add_library( vecmem_cuda cuda SHARED
+vecmem_add_library( vecmem_cuda cuda
    # Memory resources.
    "include/vecmem/memory/cuda/device_memory_resource.hpp"
    "src/memory/cuda/device_memory_resource.cpp"

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -15,7 +15,7 @@ include( vecmem-compiler-options-hip )
 find_package( HIPToolkit REQUIRED )
 
 # Set up the build of the VecMem HIP library.
-vecmem_add_library( vecmem_hip hip SHARED
+vecmem_add_library( vecmem_hip hip
    # Memory management.
    "include/vecmem/memory/hip/device_memory_resource.hpp"
    "src/memory/hip/device_memory_resource.cpp"

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -12,7 +12,7 @@ include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
 
 # Set up the build of the VecMem SYCL library.
-vecmem_add_library( vecmem_sycl sycl SHARED
+vecmem_add_library( vecmem_sycl sycl
    # Memory management.
    "include/vecmem/memory/sycl/details/memory_resource_base.hpp"
    "src/memory/sycl/details/memory_resource_base.sycl"


### PR DESCRIPTION
While I abandoned this silliness for a while, I didn't give completely up on it. 😛

With my new video card fully set up on Windows, I wanted to see if I could make the project functional with as few updates as possible. And as it turns out, I could. 😄

First off, the "main libraries" all need to be compiled as static libraries on Windows. We discussed about this in the past. For the libraries to work as shared libraries (DLLs), we would need to explicitly declare which classes/functions make up their public interfaces. But worse than that, Windows really doesn't like it when a DLL uses STL types in its public interface. So even in the absolute best case scenario, building DLLs would result in a bunch of warnings during the linking.

To get the desired behaviour, I removed the explicit `SHARED` keywords from the `add_library(...)` calls, and set up the code to respect the CMake built-in [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) variable instead. It is still possible to force `vecmem_add_library(...)` to use a specific library type, but this is not used in the code at the moment.

Then, I quickly had to run into this little tidbit:

https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

In order to have MSVC correctly set the `__cplusplus` macro (which we rely on since #98), I had to explicitly add `/Zc:__cplusplus` as a compiler option.

Finally, I also had to make use of GoogleTest's `gtest_force_shared_crt` option, to make it work correctly on Windows.

With all this in place, the code actually works in Release mode! 😃

```
C:\Users\akraszna\ATLAS\VecMem\build>cmake ..\vecmem\
-- Building for: Visual Studio 16 2019
-- Selecting Windows SDK version 10.0.18362.0 to target Windows 10.0.19043.
-- The CXX compiler identification is MSVC 19.29.30133.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.4/bin/nvcc.exe
-- Looking for a HIP compiler
-- Looking for a HIP compiler - NOTFOUND
-- Looking for a SYCL compiler
-- Looking for a SYCL compiler - NOTFOUND
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE - Success
-- Using memory resource types from the std::pmr namespace
CMake Warning at C:/Program Files/CMake/share/cmake-3.21/Modules/CMakeDetermineCUDACompiler.cmake:15 (message):
  Visual Studio does not support specifying CUDAHOSTCXX or
  CMAKE_CUDA_HOST_COMPILER.  Using the C++ compiler provided by Visual
  Studio.
Call Stack (most recent call first):
  cuda/CMakeLists.txt:11 (enable_language)


-- The CUDA compiler identification is NVIDIA 11.4.100
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.4/bin/nvcc.exe - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v11.4/include (found version "11.4.100")
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY)
-- Building GoogleTest as part of the project
-- The C compiler identification is MSVC 19.29.30133.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python: C:/Program Files (x86)/Microsoft Visual Studio/Shared/Python37_64/python.exe (found version "3.7.8") found components: Interpreter
-- Looking for pthread.h
-- Looking for pthread.h - not found
-- Found Threads: TRUE
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/akraszna/ATLAS/VecMem/build

C:\Users\akraszna\ATLAS\VecMem\build>cmake --build . --config Release
Microsoft (R) Build Engine version 16.11.0+0538acc04 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/Users/akraszna/ATLAS/VecMem/vecmem/core/CMakeLists.txt
  allocator.cpp
  deallocator.cpp
  host_memory_resource.cpp
  binary_page_memory_resource.cpp
  contiguous_memory_resource.cpp
...
C:\Users\akraszna\ATLAS\VecMem\vecmem\core\include\vecmem/containers/impl/jagged_vector_buffer.ipp(125): message : see
reference to function template instantiation 'std::unique_ptr<char,vecmem::details::deallocator> `anonymous-namespace':
:allocate_jagged_buffer_inner_memory<TYPE>(const std::vector<size_t,std::allocator<size_t>> &,vecmem::memory_resource &
,bool)' being compiled [C:\Users\akraszna\ATLAS\VecMem\build\tests\cuda\vecmem_test_cuda.vcxproj]
          with
          [
              TYPE=int
          ]
  Generating Code...
  vecmem_test_cuda.vcxproj -> C:\Users\akraszna\ATLAS\VecMem\build\test-bin\vecmem_test_cuda.exe
  Building Custom Rule C:/Users/akraszna/ATLAS/VecMem/vecmem/CMakeLists.txt

C:\Users\akraszna\ATLAS\VecMem\build>ctest -C Release
Test project C:/Users/akraszna/ATLAS/VecMem/build
    Start 1: vecmem_test_core
1/2 Test #1: vecmem_test_core .................   Passed    0.02 sec
    Start 2: vecmem_test_cuda
2/2 Test #2: vecmem_test_cuda .................   Passed    2.52 sec

100% tests passed, 0 tests failed out of 2

Total Test time (real) =   2.56 sec

C:\Users\akraszna\ATLAS\VecMem\build>
```

The build produces a **ton** of warnings, that's why I can only build the code in Release mode for the moment. But I didn't want to include any warning fixes in this PR...

And yeah, I'm pretty stoked about this! 🥳