### PR TITLE
Resolve MSVC Warnings, main branch (2021.09.13.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -30,4 +30,15 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
    # More rigorous tests for the Debug builds.
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "-pedantic" )
+
+elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
+
+   # Basic flags for all build modes.
+   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
+      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "/W4" )
+   endforeach()
+
+   # More rigorous tests for the Debug builds.
+   vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "/WX" )
+
 endif()

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -24,12 +24,14 @@ data::jagged_vector_data<TYPE> get_data(jagged_vector<TYPE>& vec,
         size,
         (resource != nullptr ? *resource : *(vec.get_allocator().resource())));
 
-    // Helper local type definition.
+    // Helper local type definition(s).
     typedef typename data::jagged_vector_data<TYPE>::value_type value_type;
+    typedef typename value_type::size_type size_type;
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] = value_type(vec[i].size(), vec[i].data());
+        result.m_ptr[i] =
+            value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
     // Return the created object.
@@ -50,12 +52,14 @@ data::jagged_vector_data<TYPE> get_data(
     // Construct the object to be returned.
     data::jagged_vector_data<TYPE> result(size, *resource);
 
-    // Helper local type definition.
+    // Helper local type definition(s).
     typedef typename data::jagged_vector_data<TYPE>::value_type value_type;
+    typedef typename value_type::size_type size_type;
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] = value_type(vec[i].size(), vec[i].data());
+        result.m_ptr[i] =
+            value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
     // Return the created object.
@@ -74,13 +78,15 @@ data::jagged_vector_data<const TYPE> get_data(const jagged_vector<TYPE>& vec,
         size,
         (resource != nullptr ? *resource : *(vec.get_allocator().resource())));
 
-    // Helper local type definition.
+    // Helper local type definition(s).
     typedef
         typename data::jagged_vector_data<const TYPE>::value_type value_type;
+    typedef typename value_type::size_type size_type;
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] = value_type(vec[i].size(), vec[i].data());
+        result.m_ptr[i] =
+            value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
     // Return the created object.
@@ -101,13 +107,15 @@ data::jagged_vector_data<const TYPE> get_data(
     // Construct the object to be returned.
     data::jagged_vector_data<const TYPE> result(size, *resource);
 
-    // Helper local type definition.
+    // Helper local type definition(s).
     typedef
         typename data::jagged_vector_data<const TYPE>::value_type value_type;
+    typedef typename value_type::size_type size_type;
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] = value_type(vec[i].size(), vec[i].data());
+        result.m_ptr[i] =
+            value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
     // Return the created object.

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -55,7 +55,9 @@ allocate_jagged_buffer_inner_memory(const std::vector<std::size_t>& sizes,
                                     bool isResizable) {
 
     typename vecmem::data::jagged_vector_buffer<TYPE>::size_type byteSize =
-        std::accumulate(sizes.begin(), sizes.end(), 0) * sizeof(TYPE);
+        std::accumulate(sizes.begin(), sizes.end(),
+                        static_cast<std::size_t>(0)) *
+        sizeof(TYPE);
     if (isResizable) {
         byteSize +=
             sizes.size() * sizeof(typename vecmem::data::jagged_vector_buffer<
@@ -103,8 +105,9 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
     // Set up the host accessible memory array.
     std::ptrdiff_t ptrdiff = 0;
     for (std::size_t i = 0; i < sizes.size(); ++i) {
-        new (host_ptr() + i) value_type(
-            sizes[i], reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
+        new (host_ptr() + i)
+            value_type(static_cast<typename value_type::size_type>(sizes[i]),
+                       reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
         ptrdiff += sizes[i] * sizeof(TYPE);
     }
 }
@@ -136,12 +139,12 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
     std::ptrdiff_t ptrdiff =
         (capacities.size() * sizeof(typename value_type::size_type));
     for (std::size_t i = 0; i < capacities.size(); ++i) {
-        new (host_ptr() + i)
-            value_type(capacities[i],
-                       reinterpret_cast<typename value_type::size_pointer>(
-                           m_inner_memory.get() +
-                           i * sizeof(typename value_type::size_type)),
-                       reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
+        new (host_ptr() + i) value_type(
+            static_cast<typename value_type::size_type>(capacities[i]),
+            reinterpret_cast<typename value_type::size_pointer>(
+                m_inner_memory.get() +
+                i * sizeof(typename value_type::size_type)),
+            reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
         ptrdiff += capacities[i] * sizeof(TYPE);
     }
 }

--- a/tests/core/test_core_array.cpp
+++ b/tests/core/test_core_array.cpp
@@ -47,32 +47,33 @@ protected:
     void test_array(vecmem::array<T, N>& a) {
 
         // Fill the array with some simple values.
-        for (std::size_t i = 0; i < a.size(); ++i) {
+        for (int i = 0; i < static_cast<int>(a.size()); ++i) {
             a.at(i) = T(i);
         }
 
         // Check the contents using iterator based loops.
         {
             auto itr = a.begin();
-            for (std::size_t i = 0; itr != a.end(); ++itr, ++i) {
+            for (int i = 0; itr != a.end(); ++itr, ++i) {
                 EXPECT_EQ(*itr, T(i));
             }
             auto ritr = a.rbegin();
-            for (std::size_t i = a.size() - 1; ritr != a.rend(); ++ritr, --i) {
+            for (int i = static_cast<int>(a.size() - 1); ritr != a.rend();
+                 ++ritr, --i) {
                 EXPECT_EQ(*ritr, T(i));
             }
         }
 
         // Check its contents using a range based loop.
         {
-            std::size_t i = 0;
+            int i = 0;
             for (T value : a) {
                 EXPECT_EQ(value, T(i++));
             }
         }
 
         // Fill the array with a constant value.
-        static constexpr std::size_t VALUE = 123;
+        static constexpr int VALUE = 123;
         a.fill(T(VALUE));
         for (T value : a) {
             EXPECT_EQ(value, T(VALUE));

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -40,15 +40,17 @@ TEST_F(core_container_test, const_device_vector) {
 
     const vecmem::const_device_vector<int> test_vector(
         vecmem::get_data(m_reference_vector));
-    EXPECT_TRUE(test_vector.size() == m_reference_vector.size());
-    EXPECT_TRUE(test_vector.empty() == m_reference_vector.empty());
+    EXPECT_EQ(test_vector.size(), m_reference_vector.size());
+    EXPECT_EQ(test_vector.empty(), m_reference_vector.empty());
     EXPECT_TRUE(std::equal(m_reference_vector.begin(), m_reference_vector.end(),
                            test_vector.begin()));
-    EXPECT_TRUE(std::accumulate(test_vector.begin(), test_vector.end(), 0) ==
-                std::accumulate(test_vector.rbegin(), test_vector.rend(), 0));
+    EXPECT_EQ(std::accumulate(test_vector.begin(), test_vector.end(), 0),
+              std::accumulate(test_vector.rbegin(), test_vector.rend(), 0));
     for (std::size_t i = 0; i < m_reference_vector.size(); ++i) {
-        EXPECT_TRUE(test_vector.at(i) == m_reference_vector.at(i));
-        EXPECT_TRUE(test_vector[i] == m_reference_vector[i]);
+        const vecmem::const_device_vector<int>::size_type ii =
+            static_cast<vecmem::const_device_vector<int>::size_type>(i);
+        EXPECT_EQ(test_vector.at(ii), m_reference_vector.at(i));
+        EXPECT_EQ(test_vector[ii], m_reference_vector[i]);
     }
 }
 
@@ -57,15 +59,17 @@ TEST_F(core_container_test, device_vector) {
 
     const vecmem::device_vector<int> test_vector(
         vecmem::get_data(m_reference_vector));
-    EXPECT_TRUE(test_vector.size() == m_reference_vector.size());
-    EXPECT_TRUE(test_vector.empty() == m_reference_vector.empty());
+    EXPECT_EQ(test_vector.size(), m_reference_vector.size());
+    EXPECT_EQ(test_vector.empty(), m_reference_vector.empty());
     EXPECT_TRUE(std::equal(m_reference_vector.begin(), m_reference_vector.end(),
                            test_vector.begin()));
-    EXPECT_TRUE(std::accumulate(test_vector.begin(), test_vector.end(), 0) ==
-                std::accumulate(test_vector.rbegin(), test_vector.rend(), 0));
+    EXPECT_EQ(std::accumulate(test_vector.begin(), test_vector.end(), 0),
+              std::accumulate(test_vector.rbegin(), test_vector.rend(), 0));
     for (std::size_t i = 0; i < m_reference_vector.size(); ++i) {
-        EXPECT_TRUE(test_vector.at(i) == m_reference_vector.at(i));
-        EXPECT_TRUE(test_vector[i] == m_reference_vector[i]);
+        const vecmem::const_device_vector<int>::size_type ii =
+            static_cast<vecmem::const_device_vector<int>::size_type>(i);
+        EXPECT_EQ(test_vector.at(ii), m_reference_vector.at(i));
+        EXPECT_EQ(test_vector[ii], m_reference_vector[i]);
     }
 }
 
@@ -95,15 +99,15 @@ TEST_F(core_container_test, const_device_array) {
 
     const vecmem::const_device_array<int, 9> test_array(
         vecmem::get_data(m_reference_vector));
-    EXPECT_TRUE(test_array.size() == m_reference_vector.size());
-    EXPECT_TRUE(test_array.empty() == m_reference_vector.empty());
+    EXPECT_EQ(test_array.size(), m_reference_vector.size());
+    EXPECT_EQ(test_array.empty(), m_reference_vector.empty());
     EXPECT_TRUE(std::equal(m_reference_vector.begin(), m_reference_vector.end(),
                            test_array.begin()));
-    EXPECT_TRUE(std::accumulate(test_array.begin(), test_array.end(), 0) ==
-                std::accumulate(test_array.rbegin(), test_array.rend(), 0));
+    EXPECT_EQ(std::accumulate(test_array.begin(), test_array.end(), 0),
+              std::accumulate(test_array.rbegin(), test_array.rend(), 0));
     for (std::size_t i = 0; i < m_reference_vector.size(); ++i) {
-        EXPECT_TRUE(test_array.at(i) == m_reference_vector.at(i));
-        EXPECT_TRUE(test_array[i] == m_reference_vector[i]);
+        EXPECT_EQ(test_array.at(i), m_reference_vector.at(i));
+        EXPECT_EQ(test_array[i], m_reference_vector[i]);
     }
 }
 
@@ -112,15 +116,15 @@ TEST_F(core_container_test, device_array) {
 
     const vecmem::device_array<int, 9> test_array(
         vecmem::get_data(m_reference_vector));
-    EXPECT_TRUE(test_array.size() == m_reference_vector.size());
-    EXPECT_TRUE(test_array.empty() == m_reference_vector.empty());
+    EXPECT_EQ(test_array.size(), m_reference_vector.size());
+    EXPECT_EQ(test_array.empty(), m_reference_vector.empty());
     EXPECT_TRUE(std::equal(m_reference_vector.begin(), m_reference_vector.end(),
                            test_array.begin()));
-    EXPECT_TRUE(std::accumulate(test_array.begin(), test_array.end(), 0) ==
-                std::accumulate(test_array.rbegin(), test_array.rend(), 0));
+    EXPECT_EQ(std::accumulate(test_array.begin(), test_array.end(), 0),
+              std::accumulate(test_array.rbegin(), test_array.rend(), 0));
     for (std::size_t i = 0; i < m_reference_vector.size(); ++i) {
-        EXPECT_TRUE(test_array.at(i) == m_reference_vector.at(i));
-        EXPECT_TRUE(test_array[i] == m_reference_vector[i]);
+        EXPECT_EQ(test_array.at(i), m_reference_vector.at(i));
+        EXPECT_EQ(test_array[i], m_reference_vector[i]);
     }
 }
 

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -59,5 +59,5 @@ TEST_F(core_contiguous_memory_resource_test, allocations) {
     EXPECT_EQ(static_cast<void*>(&*(vec5.begin())),
               static_cast<void*>(&*(vec4.end())));
 
-#endif // MSVC debug build...
+#endif  // MSVC debug build...
 }

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -30,6 +30,12 @@ protected:
 /// Test the dumb allocation of a bunch of vectors
 TEST_F(core_contiguous_memory_resource_test, allocations) {
 
+// Skip this test with MSVC, in debug builds. As MSVC pads vectors in a way
+// that makes this test fail.
+#if defined(_MSC_VER) && defined(_DEBUG)
+    GTEST_SKIP();
+#else
+
     /// Fixed size for the test vectors
     static constexpr std::size_t VECTOR_SIZE = 100;
 
@@ -38,18 +44,20 @@ TEST_F(core_contiguous_memory_resource_test, allocations) {
     vecmem::vector<int> vec1(VECTOR_SIZE, &m_resource);
 
     vecmem::vector<char> vec2(VECTOR_SIZE, &m_resource);
-    EXPECT_TRUE(static_cast<void*>(&*(vec2.begin())) ==
-                static_cast<void*>(&*(vec1.end())));
+    EXPECT_EQ(static_cast<void*>(&*(vec2.begin())),
+              static_cast<void*>(&*(vec1.end())));
 
     vecmem::vector<double> vec3(VECTOR_SIZE, &m_resource);
-    EXPECT_TRUE(static_cast<void*>(&*(vec3.begin())) ==
-                static_cast<void*>(&*(vec2.end())));
+    EXPECT_EQ(static_cast<void*>(&*(vec3.begin())),
+              static_cast<void*>(&*(vec2.end())));
 
     vecmem::vector<float> vec4(VECTOR_SIZE, &m_resource);
-    EXPECT_TRUE(static_cast<void*>(&*(vec4.begin())) ==
-                static_cast<void*>(&*(vec3.end())));
+    EXPECT_EQ(static_cast<void*>(&*(vec4.begin())),
+              static_cast<void*>(&*(vec3.end())));
 
     vecmem::vector<int> vec5(VECTOR_SIZE, &m_resource);
-    EXPECT_TRUE(static_cast<void*>(&*(vec5.begin())) ==
-                static_cast<void*>(&*(vec4.end())));
+    EXPECT_EQ(static_cast<void*>(&*(vec5.begin())),
+              static_cast<void*>(&*(vec4.end())));
+
+#endif // MSVC debug build...
 }

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -128,10 +128,16 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
     // Create an input vector in regular host memory.
     std::vector<int> host_vector{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
+    // Helper local type definitions.
+    typedef
+        typename vecmem::data::vector_buffer<int>::size_type buffer_size_type;
+    typedef typename vecmem::device_vector<int>::size_type vector_size_type;
+
     // Create a resizable buffer from that data.
-    static constexpr std::size_t BUFFER_SIZE = 100;
+    static constexpr buffer_size_type BUFFER_SIZE = 100;
     vecmem::data::vector_buffer<int> resizable_buffer(
-        BUFFER_SIZE, host_vector.size(), m_resource);
+        BUFFER_SIZE, static_cast<buffer_size_type>(host_vector.size()),
+        m_resource);
     m_copy.setup(resizable_buffer);
     EXPECT_EQ(resizable_buffer.capacity(), BUFFER_SIZE);
     m_copy(vecmem::get_data(host_vector), resizable_buffer);
@@ -151,45 +157,45 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
     // Modify the device vector in different ways, and check that it would work
     // as expected.
     device_vector.clear();
-    EXPECT_EQ(device_vector.size(), 0);
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(0));
 
     device_vector.push_back(10);
-    EXPECT_EQ(device_vector.size(), 1);
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(1));
     EXPECT_EQ(device_vector.at(0), 10);
 
     device_vector.emplace_back(15);
-    EXPECT_EQ(device_vector.size(), 2);
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(2));
     EXPECT_EQ(device_vector.back(), 15);
 
     device_vector.assign(20, 123);
-    EXPECT_EQ(device_vector.size(), 20);
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(20));
     for (int value : device_vector) {
         EXPECT_EQ(value, 123);
     }
 
     device_vector.resize(40, 234);
-    EXPECT_EQ(device_vector.size(), 40);
-    for (std::size_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(40));
+    for (vector_size_type i = 0; i < 20; ++i) {
         EXPECT_EQ(device_vector[i], 123);
     }
-    for (std::size_t i = 20; i < 40; ++i) {
+    for (vector_size_type i = 20; i < 40; ++i) {
         EXPECT_EQ(device_vector[i], 234);
     }
     device_vector.resize(25);
-    EXPECT_EQ(device_vector.size(), 25);
-    for (std::size_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(25));
+    for (vector_size_type i = 0; i < 20; ++i) {
         EXPECT_EQ(device_vector[i], 123);
     }
-    for (std::size_t i = 20; i < 25; ++i) {
+    for (vector_size_type i = 20; i < 25; ++i) {
         EXPECT_EQ(device_vector[i], 234);
     }
 
     device_vector.pop_back();
-    EXPECT_EQ(device_vector.size(), 24);
-    for (std::size_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(device_vector.size(), static_cast<vector_size_type>(24));
+    for (vector_size_type i = 0; i < 20; ++i) {
         EXPECT_EQ(device_vector[i], 123);
     }
-    for (std::size_t i = 20; i < 24; ++i) {
+    for (vector_size_type i = 20; i < 24; ++i) {
         EXPECT_EQ(device_vector[i], 234);
     }
 

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -43,13 +43,16 @@ TEST_F(core_jagged_vector_view_test, top_level_size) {
     EXPECT_EQ(m_jag.size(), 6);
 }
 
+/// Helper macro
+#define SIZE_VAR(X) static_cast<vecmem::device_vector<int>::size_type>(X)
+
 TEST_F(core_jagged_vector_view_test, row_size) {
-    EXPECT_EQ(m_jag.at(0).size(), 4);
-    EXPECT_EQ(m_jag.at(1).size(), 2);
-    EXPECT_EQ(m_jag.at(2).size(), 4);
-    EXPECT_EQ(m_jag.at(3).size(), 1);
-    EXPECT_EQ(m_jag.at(4).size(), 0);
-    EXPECT_EQ(m_jag.at(5).size(), 5);
+    EXPECT_EQ(m_jag.at(0).size(), SIZE_VAR(4));
+    EXPECT_EQ(m_jag.at(1).size(), SIZE_VAR(2));
+    EXPECT_EQ(m_jag.at(2).size(), SIZE_VAR(4));
+    EXPECT_EQ(m_jag.at(3).size(), SIZE_VAR(1));
+    EXPECT_EQ(m_jag.at(4).size(), SIZE_VAR(0));
+    EXPECT_EQ(m_jag.at(5).size(), SIZE_VAR(5));
 }
 
 TEST_F(core_jagged_vector_view_test, two_d_access) {

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -78,8 +78,9 @@ protected:
 
         // Remove a couple of elements from the vectors.
         for (int i : {26, 38, 25}) {
-            std::remove(reference_vector.begin(), reference_vector.end(), i);
-            std::remove(test_vector.begin(), test_vector.end(), i);
+            (void)std::remove(reference_vector.begin(), reference_vector.end(),
+                              i);
+            (void)std::remove(test_vector.begin(), test_vector.end(), i);
         }
         // Make sure that they are still the same.
         EXPECT_EQ(reference_vector.size(), test_vector.size());

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -159,12 +159,12 @@ TYPED_TEST(core_static_vector_test, element_access) {
 
     // Modify its elements.
     for (std::size_t i = 0; i < v.size(); ++i) {
-        v.at(i) = TypeParam(i);
+        v.at(i) = TypeParam(static_cast<int>(i));
     }
 
     // Check that the settings "took".
     for (std::size_t i = 0; i < v.size(); ++i) {
-        EXPECT_EQ(v[i], TypeParam(i));
+        EXPECT_EQ(v[i], TypeParam(static_cast<int>(i)));
     }
 
     // Test the front() and back() functions.
@@ -187,8 +187,8 @@ TYPED_TEST(core_static_vector_test, modifications) {
     vecmem::static_vector<TypeParam, 100> test(50);
     EXPECT_EQ_VEC(ref, test);
     for (std::size_t i = 0; i < ref.size(); ++i) {
-        ref[i] = TypeParam(i);
-        test[i] = TypeParam(i);
+        ref[i] = TypeParam(static_cast<int>(i));
+        test[i] = TypeParam(static_cast<int>(i));
     }
     EXPECT_EQ_VEC(ref, test);
 
@@ -198,8 +198,8 @@ TYPED_TEST(core_static_vector_test, modifications) {
     EXPECT_EQ_VEC(ref, test);
 
     // Do the same, just in a slightly different colour.
-    ref.emplace_back(70);
-    test.emplace_back(70);
+    ref.emplace_back(TypeParam(70));
+    test.emplace_back(TypeParam(70));
     EXPECT_EQ_VEC(ref, test);
 
     // Insert a single element in the middle of them.
@@ -208,8 +208,8 @@ TYPED_TEST(core_static_vector_test, modifications) {
     EXPECT_EQ_VEC(ref, test);
 
     // Emplace a single element in the middle of them.
-    ref.emplace(ref.begin() + 15, 55);
-    test.emplace(test.begin() + 15, 55);
+    ref.emplace(ref.begin() + 15, TypeParam(55));
+    test.emplace(test.begin() + 15, TypeParam(55));
     EXPECT_EQ_VEC(ref, test);
 
     // Remove one element from them.

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -70,8 +70,10 @@ TEST_F(cuda_containers_test, explicit_memory) {
 
     // Allocate a device memory block for the output container.
     auto outputvechost = vecmem::get_data(outputvec);
-    vecmem::data::vector_buffer<int> outputvecdevice(outputvec.size(),
-                                                     device_resource);
+    vecmem::data::vector_buffer<int> outputvecdevice(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(
+            outputvec.size()),
+        device_resource);
 
     // Create the array that is used in the linear transformation.
     vecmem::array<int, 2> constants(host_resource);
@@ -107,7 +109,7 @@ TEST_F(cuda_containers_test, atomic_memory) {
     auto vec_on_device = m_copy.to(vecmem::get_data(vec), device_resource);
 
     // Give it to the test function.
-    static constexpr int ITERATIONS = 100;
+    static constexpr unsigned int ITERATIONS = 100;
     atomicTransform(ITERATIONS, vec_on_device);
 
     // Copy it back to the host.
@@ -115,7 +117,7 @@ TEST_F(cuda_containers_test, atomic_memory) {
 
     // Check the output.
     for (int value : vec) {
-        EXPECT_EQ(value, 2 * ITERATIONS);
+        EXPECT_EQ(static_cast<unsigned int>(value), 2 * ITERATIONS);
     }
 }
 
@@ -134,8 +136,9 @@ TEST_F(cuda_containers_test, extendable_memory) {
     }
 
     // Create a buffer that will hold the filtered elements of the input vector.
-    vecmem::data::vector_buffer<int> output_buffer(input.size(), 0,
-                                                   device_resource);
+    vecmem::data::vector_buffer<int> output_buffer(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
+        0, device_resource);
     m_copy.setup(output_buffer);
 
     // Run the filtering kernel.

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -74,7 +74,7 @@ __global__ void atomicTransformKernel(std::size_t iterations,
     return;
 }
 
-void atomicTransform(std::size_t iterations,
+void atomicTransform(unsigned int iterations,
                      vecmem::data::vector_view<int> vec) {
 
     // Launch the kernel.
@@ -145,12 +145,12 @@ __global__ void filterTransformKernel(
 }
 
 void filterTransform(vecmem::data::jagged_vector_view<const int> input,
-                     std::size_t max_vec_size,
+                     unsigned int max_vec_size,
                      vecmem::data::jagged_vector_view<int> output) {
 
     // Launch the kernel.
-    filterTransformKernel<<<1, dim3(input.m_size, max_vec_size)>>>(input,
-                                                                   output);
+    dim3 dimensions(static_cast<unsigned int>(input.m_size), max_vec_size);
+    filterTransformKernel<<<1, dimensions>>>(input, output);
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -20,7 +20,7 @@ void linearTransform(vecmem::data::vector_view<const int> constants,
                      vecmem::data::vector_view<int> output);
 
 /// Function incrementing the elements of the received vector using atomics
-void atomicTransform(std::size_t iterations,
+void atomicTransform(unsigned int iterations,
                      vecmem::data::vector_view<int> vec);
 
 /// Function filtering elements of an input vector into an output vector
@@ -29,5 +29,5 @@ void filterTransform(vecmem::data::vector_view<const int> input,
 
 /// Function filtering elements of an input vector into an output vector
 void filterTransform(vecmem::data::jagged_vector_view<const int> input,
-                     std::size_t max_vec_size,
+                     unsigned int max_vec_size,
                      vecmem::data::jagged_vector_view<int> output);

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -64,7 +64,8 @@ void linearTransform(const vecmem::data::vector_view<int>& constants,
     assert(input.m_size == output.m_size);
 
     // Launch the kernel.
-    linearTransformKernel<<<1, input.m_size>>>(constants, input, output);
+    linearTransformKernel<<<1, static_cast<unsigned int>(input.m_size)>>>(
+        constants, input, output);
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());

--- a/tests/cuda/test_cuda_memory_resources.cpp
+++ b/tests/cuda/test_cuda_memory_resources.cpp
@@ -109,8 +109,9 @@ protected:
 
         // Remove a couple of elements from the vectors.
         for (int i : {26, 38, 25}) {
-            std::remove(reference_vector.begin(), reference_vector.end(), i);
-            std::remove(test_vector.begin(), test_vector.end(), i);
+            (void)std::remove(reference_vector.begin(), reference_vector.end(),
+                              i);
+            (void)std::remove(test_vector.begin(), test_vector.end(), i);
         }
         // Make sure that they are still the same.
         EXPECT_EQ(reference_vector.size(), test_vector.size());


### PR DESCRIPTION
As @stephenswat could see it ahead of time, #100 set some things in motion... (I'll be setting up a CI for Windows next. :stuck_out_tongue:)

Here I enabled roughly the same level of warnings for MSVC that we use with GCC and Clang as well. I **did not** use `/Wall` as the warning level, as that seemed a bit ridiculous. Even the Microsoft documentation recommends against using that. (With that enabled, even the test code from https://github.com/acts-project/vecmem/blob/main/core/CMakeLists.txt#L79-L84 would not compile. So at that point I have up on that warning level.)

Then I set out to fix all of the warnings that MSVC would print. Which are mostly integer type issues. MSVC really doesn't like it when you implicitly convert between different integer types... Since, as is discussed in #96, we use `std::size_t` as the size type in some places, and `unsigned int` in others, I had to make the code very explicit about type conversions in a good number of places. I'm not super happy about this either, but at the same time it did make the code a lot more explicit about what it expects the compiler to do...

I was pondering about https://github.com/acts-project/vecmem/blob/main/tests/core/test_core_contiguous_memory_resource.cpp for a bit. Since this test fails with MSVC in Debug builds. For multiple reasons actually. First off, in a Debug build it's a runtime error to de-reference `std::vector<T>::end()`. But even if I don't do that in the code, the test still fails. As in Debug mode MSVC pads all STL containers by some amount. To make it easier to detect out-of-range accesses in the code.

I was wondering about replacing `std::vector` with simple allocation/de-allocation calls in the tests, but in the end rather decided to just disable it for Debug builds with MSVC. But I'm not completely happy with this setup either...

I still maintain that listening to warnings from yet another compiler is a good thing! So I still very much want to go forward with this, even with all the necessary changes. (Note that the library code itself had to be changed very little. It was mostly the tests that needed adjustments.)