### PR TITLE
macOS Warning Fix, main branch (2021.09.18.)

### DIFF
--- a/cmake/vecmem-googletest.cmake
+++ b/cmake/vecmem-googletest.cmake
@@ -35,6 +35,9 @@ if( WIN32 )
       "Use shared (DLL) run-time library, even with static libraries" )
 endif()
 
+# Silence some warnings with modern versions of CMake on macOS.
+set( CMAKE_MACOSX_RPATH TRUE )
+
 # Get it into the current directory.
 FetchContent_Populate( GoogleTest )
 add_subdirectory( "${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"


### PR DESCRIPTION
Set `CMAKE_MACOSX_RPATH` for the GoogleTest configuration explicitly.

Since GoogleTest requires a very old version of CMake as a minimum, one needs to explicitly set this variable to avoid seeing the following warning on macOS about CMake not being sure how to set up the RPATH for the GTest libraries.

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   gtest
   gtest_main

This warning is for project developers.  Use -Wno-dev to suppress it.
```

I was actually trying to see if I could get the SYCL library working on macOS. But had to realise that the macOS version of oneAPI does not actually come with the DPC++ compiler. 😦  Still, with this at least the core library compiles and runs without any warnings on the platform...