### PR TITLE
CMake 3.21+ Compatibility, main branch (2021.09.19.)

### DIFF
--- a/cmake/sycl/CMakeSYCLInformation.cmake
+++ b/cmake/sycl/CMakeSYCLInformation.cmake
@@ -6,8 +6,13 @@
 
 # Tweak the linker flags on Windows, to make them compatible with DPC++.
 if( WIN32 )
-   set( CMAKE_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
-   set( CMAKE_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
+   if( ${CMAKE_VERSION} VERSION_LESS 3.21 )
+      set( CMAKE_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
+      set( CMAKE_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
+   else()
+      set( CMAKE_SYCL_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
+      set( CMAKE_SYCL_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
+   endif()
    foreach( _type EXE SHARED MODULE )
       string( REGEX REPLACE "(/machine:[a-zA-Z0-9]+)" "-Xlinker \\1"
          CMAKE_${_type}_LINKER_FLAGS "${CMAKE_${_type}_LINKER_FLAGS}" )


### PR DESCRIPTION
As it turns out, the names of some of the internal variables that the SYCL code interacts with, have changed. Now the code should work correctly with CMake 3.21+ as well.

At the same time I also had to realise that the Visual Studio pre-processor is not able to deal with the `VECMEM_DEBUG_MSG` macros. 😦 I currently blame the compiler, and not our code over this, but this will need some further checks later on...