### PR TITLE
Add builds on macOS to CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,16 +14,17 @@ on: [ push, pull_request ]
 jobs:
 
   # Native build job on an Ubuntu system.
-  ubuntu-native:
-
-    # The system to run on.
-    runs-on: ubuntu-latest
+  native:
 
     # The different build modes to test.
     strategy:
       matrix:
         BUILD_TYPE: [ "Release", "Debug" ]
         DEBUG_MSG_LVL: [ 0, 5 ]
+        OS: ["ubuntu-latest", "macos-10.15"]
+
+    # The system to run on.
+    runs-on: ${{ matrix.OS }}
 
     # The build/test steps to execute.
     steps:

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -13,7 +13,7 @@ on: [ push, pull_request ]
 # All the different build/test jobs.
 jobs:
 
-  # Native build job on an Ubuntu system.
+  # Native build job
   native:
 
     # The different build modes to test.


### PR DESCRIPTION
Related to #105 it's probably not a bad idea to build on macOS with clang+libc++ as well.

This extends the build matrix of the "native" jobs, but we could reduce this to run on macOS with fewer combinations.