### PR TITLE
MSVC Fixes and CI, main branch (2021.09.24.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         BUILD_TYPE: [ "Release", "Debug" ]
         DEBUG_MSG_LVL: [ 0, 5 ]
-        OS: ["ubuntu-latest", "macos-10.15"]
+        OS: ["ubuntu-latest", "macos-10.15", "windows-latest"]
 
     # The system to run on.
     runs-on: ${{ matrix.OS }}
@@ -30,11 +30,20 @@ jobs:
     steps:
     # Use a standard checkout of the code.
     - uses: actions/checkout@v2
+    # Set up the build environment.
+    - uses: ilammy/msvc-dev-cmd@v1.9.0
     # Run the CMake configuration.
     - name: Configure
+      if: "!startsWith(matrix.os, 'windows')"
       run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
                  -DVECMEM_DEBUG_MSG_LVL=${{ matrix.DEBUG_MSG_LVL }}
-                 -S $GITHUB_WORKSPACE -B build
+                 -S ${{ github.workspace }} -B build
+    - name: Configure-Windows
+      if: "startsWith(matrix.os, 'windows')"
+      run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD_TYPE }}
+                 -DVECMEM_DEBUG_MSG_LVL=${{ matrix.DEBUG_MSG_LVL }}
+                 -S ${{ github.workspace }} -B build
+                 -G "NMake Makefiles"
     # Perform the build.
     - name: Build
       run: cmake --build build

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -116,7 +116,7 @@ check_cxx_source_compiles( "
    #include <${pmr_include}>
    int main() {
          ${pmr_ns}::set_default_resource(nullptr);
-         ${pmr_ns}::memory_resource* mr = ${pmr_ns}::get_default_resource();
+         (void)${pmr_ns}::get_default_resource();
          return 0;
    }
   " VECMEM_HAVE_DEFAULT_RESOURCE)

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -97,10 +97,10 @@
 ///            [1-5] range.
 /// @param MSG The text message to use, before the variadic arguments
 ///
-#define VECMEM_DEBUG_MSG(LVL, MSG, ...)                                   \
-    __VECMEM_PRINT_##LVL(                                                 \
-        "[vecmem] %s:%i " MSG "\n",                                       \
-        (static_cast<const char*>(__FILE__) + VECMEM_SOURCE_DIR_LENGTH ), \
+#define VECMEM_DEBUG_MSG(LVL, MSG, ...)                                  \
+    __VECMEM_PRINT_##LVL(                                                \
+        "[vecmem] %s:%i " MSG "\n",                                      \
+        (static_cast<const char*>(__FILE__) + VECMEM_SOURCE_DIR_LENGTH), \
         __LINE__, __VA_ARGS__)
 
 #else
@@ -123,4 +123,4 @@
 ///
 #define VECMEM_DEBUG_MSG(LVL, ...) __VECMEM_DEBUG_MSG(LVL, __VA_ARGS__, "")
 
-#endif // MSC
+#endif  // MSC

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -81,6 +81,30 @@
 #define __VECMEM_PRINT_5(MSG, ...)
 #endif
 
+// Implement the main macro(s) a little differently for MSVC and all other
+// compilers/preprocessors. Since the "trick" used for GCC/Clang to allow
+// the macro to receive 0 or more arguments just confuses MSVC. And the MSVC
+// variadic macro handling can deal with 0 or more arguments out of the box
+// anyway.
+#ifdef _MSC_VER
+
+/// Helper macro for printing debug messages from "any" code
+///
+/// Since CUDA, HIP and SYCL all provide "printf style" functions for this, the
+/// macro also provides an interface like @c printf canonically does.
+///
+/// @param LVL The integer message level to use. It must have a value in the
+///            [1-5] range.
+/// @param MSG The text message to use, before the variadic arguments
+///
+#define VECMEM_DEBUG_MSG(LVL, MSG, ...)                                   \
+    __VECMEM_PRINT_##LVL(                                                 \
+        "[vecmem] %s:%i " MSG "\n",                                       \
+        (static_cast<const char*>(__FILE__) + VECMEM_SOURCE_DIR_LENGTH ), \
+        __LINE__, __VA_ARGS__)
+
+#else
+
 /// Macro used for handling the case of printing a pure/simple character string
 #define __VECMEM_DEBUG_MSG(LVL, MSG, ...)                                \
     __VECMEM_PRINT_##LVL(                                                \
@@ -98,3 +122,5 @@
 /// @param ... The "printf style" arguments.
 ///
 #define VECMEM_DEBUG_MSG(LVL, ...) __VECMEM_DEBUG_MSG(LVL, __VA_ARGS__, "")
+
+#endif // MSC

--- a/tests/core/test_core_default_resource.cpp
+++ b/tests/core/test_core_default_resource.cpp
@@ -15,8 +15,8 @@
 
 TEST(core_default_resource_test, vector_default_resource) {
     vecmem::vector<float> v;
-    v.emplace_back(1);
-    v.emplace_back(3);
-    v.emplace_back(2);
-    EXPECT_EQ(v.back(), 2);
+    v.emplace_back(1.f);
+    v.emplace_back(3.f);
+    v.emplace_back(2.f);
+    EXPECT_EQ(v.back(), 2.f);
 }


### PR DESCRIPTION
With a lot of trial-and-error, but finally I managed to set up a CI for Windows with MSVC. Since #105 made the Windows build fail, it was quite timely to finally have this set up...

Let me go through the modifications:
  - The `VECMEM_HAVE_DEFAULT_RESOURCE` test kept failing on Windows. I was already suspicious previously of the unused variable in the test code possibly giving us problems down the line (I bumped into the same sort of issue in https://github.com/root-project/root/pull/4561 back in the day.), I just didn't realise that it would be with the Windows build. :stuck_out_tongue: After eliminating the unused variable warning/error, the test now works on all platforms.
  - The test introduced by #105 performed an implicit `int` -> `float` conversion. Which MSVC really doesn't like...
  - As discussed in #104, MSVC was not happy with the setup of the variadic macros in `debug.hpp`. I played around with different pre-processor behaviour setting flags, but those would only make things worse. :frowning: (At one point making the compiler issue warnings about system headers as well. :scream:) So I decided to bite the bullet, and provide a different implementation for MSVC. Which is the same implementation that I made initially btw. (Before turning on warnings from GCC about it not liking that implementation.)
  - I was trying my best to add the Windows CI build with the least amount of code lines. But unfortunately I couldn't avoid defining a different CMake configuration command than what we use for the other platforms. On Windows we just have to use the `"NMake Makefiles"` generator, as the SYCL configuration doesn't work with MSBuild. :frowning: (Since MSBuild doesn't do anything with `.sycl` files, the compilation test that we perform to check whether the C\+\+ compiler understands SYCL, is no-op. So with MSBuild the MSVC compiler is always accepted as a valid SYCL compiler... :facepalm:)
    - If you know how to define something like an environment variable differently for different platforms, then this part could be simplified a bit. For now I just defined two separate CMake configuration steps.
    - Note that I also replaced `$GITHUB_WORKSPACE` with `${{ github.workspace }}`. Even though in the end this was not necessary, once it became clear that I'd have to implement the CMake configuration command separately for the platforms. Still, using this formalism is a more platform independent way of referring to the workspace directory. :wink: