### PR TITLE
Copy Improvements, main branch (2021.09.24.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -16,6 +16,7 @@
 
 // System include(s).
 #include <cstddef>
+#include <type_traits>
 #include <vector>
 
 namespace vecmem {
@@ -66,14 +67,14 @@ public:
 
     /// Copy a 1-dimensional vector to the specified memory resource
     template <typename TYPE>
-    data::vector_buffer<TYPE> to(const data::vector_view<TYPE>& data,
-                                 memory_resource& resource,
-                                 type::copy_type cptype = type::unknown);
+    data::vector_buffer<std::remove_cv_t<TYPE>> to(
+        const data::vector_view<TYPE>& data, memory_resource& resource,
+        type::copy_type cptype = type::unknown);
 
     /// Copy a 1-dimensional vector's data between two existing memory blocks
-    template <typename TYPE>
-    void operator()(const data::vector_view<TYPE>& from,
-                    data::vector_view<TYPE>& to,
+    template <typename TYPE1, typename TYPE2>
+    void operator()(const data::vector_view<TYPE1>& from,
+                    data::vector_view<TYPE2>& to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a 1-dimensional vector's data into a vector object
@@ -98,40 +99,40 @@ public:
 
     /// Copy a jagged vector to the specified memory resource
     template <typename TYPE>
-    data::jagged_vector_buffer<TYPE> to(
+    data::jagged_vector_buffer<std::remove_cv_t<TYPE>> to(
         const data::jagged_vector_view<TYPE>& data, memory_resource& resource,
         memory_resource* host_access_resource = nullptr,
         type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector to the specified memory resource
     template <typename TYPE>
-    data::jagged_vector_buffer<TYPE> to(
+    data::jagged_vector_buffer<std::remove_cv_t<TYPE>> to(
         const data::jagged_vector_buffer<TYPE>& data, memory_resource& resource,
         memory_resource* host_access_resource = nullptr,
         type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE>
-    void operator()(const data::jagged_vector_view<TYPE>& from,
-                    data::jagged_vector_view<TYPE>& to,
+    template <typename TYPE1, typename TYPE2>
+    void operator()(const data::jagged_vector_view<TYPE1>& from,
+                    data::jagged_vector_view<TYPE2>& to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE>
-    void operator()(const data::jagged_vector_view<TYPE>& from,
-                    data::jagged_vector_buffer<TYPE>& to,
+    template <typename TYPE1, typename TYPE2>
+    void operator()(const data::jagged_vector_view<TYPE1>& from,
+                    data::jagged_vector_buffer<TYPE2>& to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE>
-    void operator()(const data::jagged_vector_buffer<TYPE>& from,
-                    data::jagged_vector_view<TYPE>& to,
+    template <typename TYPE1, typename TYPE2>
+    void operator()(const data::jagged_vector_buffer<TYPE1>& from,
+                    data::jagged_vector_view<TYPE2>& to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE>
-    void operator()(const data::jagged_vector_buffer<TYPE>& from,
-                    data::jagged_vector_buffer<TYPE>& to,
+    template <typename TYPE1, typename TYPE2>
+    void operator()(const data::jagged_vector_buffer<TYPE1>& from,
+                    data::jagged_vector_buffer<TYPE2>& to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data into a vector object
@@ -167,9 +168,9 @@ protected:
 
 private:
     /// Helper function performing the copy of a jagged array/vector
-    template <typename TYPE>
-    void copy_views(std::size_t size, const data::vector_view<TYPE>* from,
-                    data::vector_view<TYPE>* to, type::copy_type cptype);
+    template <typename TYPE1, typename TYPE2>
+    void copy_views(std::size_t size, const data::vector_view<TYPE1>* from,
+                    data::vector_view<TYPE2>* to, type::copy_type cptype);
     /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -14,7 +14,6 @@
 
 // System include(s).
 #include <cassert>
-#include <type_traits>
 
 namespace vecmem {
 
@@ -36,16 +35,17 @@ void copy::setup(data::vector_view<TYPE>& data) {
 }
 
 template <typename TYPE>
-data::vector_buffer<TYPE> copy::to(const vecmem::data::vector_view<TYPE>& data,
-                                   memory_resource& resource,
-                                   type::copy_type cptype) {
+data::vector_buffer<std::remove_cv_t<TYPE>> copy::to(
+    const vecmem::data::vector_view<TYPE>& data, memory_resource& resource,
+    type::copy_type cptype) {
 
     // Set up the result buffer.
-    data::vector_buffer<TYPE> result(data.capacity(), get_size(data), resource);
+    data::vector_buffer<std::remove_cv_t<TYPE>> result(
+        data.capacity(), get_size(data), resource);
     setup(result);
 
     // Copy the payload of the vector.
-    this->operator()<TYPE>(data, result, cptype);
+    this->operator()(data, result, cptype);
     VECMEM_DEBUG_MSG(2,
                      "Created a vector buffer of type \"%s\" with "
                      "capacity %u",
@@ -53,26 +53,32 @@ data::vector_buffer<TYPE> copy::to(const vecmem::data::vector_view<TYPE>& data,
     return result;
 }
 
-template <typename TYPE>
-void copy::operator()(const data::vector_view<TYPE>& from_view,
-                      data::vector_view<TYPE>& to_view,
+template <typename TYPE1, typename TYPE2>
+void copy::operator()(const data::vector_view<TYPE1>& from_view,
+                      data::vector_view<TYPE2>& to_view,
                       type::copy_type cptype) {
 
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
+
     // Get the size of the source view.
-    const typename data::vector_view<TYPE>::size_type size =
+    const typename data::vector_view<TYPE1>::size_type size =
         get_size(from_view);
 
     // Make sure that if the target view is resizable, that it would be set up
     // for the correct size.
     if (to_view.size_ptr() != 0) {
         assert(to_view.capacity() >= size);
-        do_copy(sizeof(typename data::vector_view<TYPE>::size_type), &size,
+        do_copy(sizeof(typename data::vector_view<TYPE2>::size_type), &size,
                 to_view.size_ptr(), cptype);
     }
 
     // Copy the payload.
     assert(size == get_size(to_view));
-    do_copy(size * sizeof(TYPE), from_view.ptr(), to_view.ptr(), cptype);
+    do_copy(size * sizeof(TYPE1), from_view.ptr(), to_view.ptr(), cptype);
 }
 
 template <typename TYPE1, typename TYPE2, typename ALLOC>
@@ -83,8 +89,7 @@ void copy::operator()(const data::vector_view<TYPE1>& from_view,
     // The input and output types are allowed to be different, but only by
     // const-ness.
     static_assert(std::is_same<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE2, TYPE1>::value,
+                      details::is_same_nc<TYPE1, TYPE2>::value,
                   "Can only use compatible types in the copy");
 
     // Figure out the size of the buffer.
@@ -159,13 +164,13 @@ void copy::setup(data::jagged_vector_buffer<TYPE>& data) {
 }
 
 template <typename TYPE>
-data::jagged_vector_buffer<TYPE> copy::to(
+data::jagged_vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     const data::jagged_vector_view<TYPE>& data, memory_resource& resource,
     memory_resource* host_access_resource, type::copy_type cptype) {
 
     // Create the result buffer object.
-    data::jagged_vector_buffer<TYPE> result(data, resource,
-                                            host_access_resource);
+    data::jagged_vector_buffer<std::remove_cv_t<TYPE>> result(
+        data, resource, host_access_resource);
     assert(result.m_size == data.m_size);
 
     // Copy the description of the "inner vectors" if necessary.
@@ -179,13 +184,13 @@ data::jagged_vector_buffer<TYPE> copy::to(
 }
 
 template <typename TYPE>
-data::jagged_vector_buffer<TYPE> copy::to(
+data::jagged_vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     const data::jagged_vector_buffer<TYPE>& data, memory_resource& resource,
     memory_resource* host_access_resource, type::copy_type cptype) {
 
     // Create the result buffer object.
-    data::jagged_vector_buffer<TYPE> result(data, resource,
-                                            host_access_resource);
+    data::jagged_vector_buffer<std::remove_cv_t<TYPE>> result(
+        data, resource, host_access_resource);
     assert(result.m_size == data.m_size);
 
     // Copy the description of the "inner vectors" if necessary.
@@ -198,10 +203,16 @@ data::jagged_vector_buffer<TYPE> copy::to(
     return result;
 }
 
-template <typename TYPE>
-void copy::operator()(const data::jagged_vector_view<TYPE>& from_view,
-                      data::jagged_vector_view<TYPE>& to_view,
+template <typename TYPE1, typename TYPE2>
+void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
+                      data::jagged_vector_view<TYPE2>& to_view,
                       type::copy_type cptype) {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
 
     // A sanity check.
     assert(from_view.m_size == to_view.m_size);
@@ -210,10 +221,16 @@ void copy::operator()(const data::jagged_vector_view<TYPE>& from_view,
     copy_views(from_view.m_size, from_view.m_ptr, to_view.m_ptr, cptype);
 }
 
-template <typename TYPE>
-void copy::operator()(const data::jagged_vector_view<TYPE>& from_view,
-                      data::jagged_vector_buffer<TYPE>& to_buffer,
+template <typename TYPE1, typename TYPE2>
+void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
+                      data::jagged_vector_buffer<TYPE2>& to_buffer,
                       type::copy_type cptype) {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
 
     // A sanity check.
     assert(from_view.m_size == to_buffer.m_size);
@@ -222,10 +239,16 @@ void copy::operator()(const data::jagged_vector_view<TYPE>& from_view,
     copy_views(from_view.m_size, from_view.m_ptr, to_buffer.host_ptr(), cptype);
 }
 
-template <typename TYPE>
-void copy::operator()(const data::jagged_vector_buffer<TYPE>& from_buffer,
-                      data::jagged_vector_view<TYPE>& to_view,
+template <typename TYPE1, typename TYPE2>
+void copy::operator()(const data::jagged_vector_buffer<TYPE1>& from_buffer,
+                      data::jagged_vector_view<TYPE2>& to_view,
                       type::copy_type cptype) {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
 
     // A sanity check.
     assert(from_buffer.m_size == to_view.m_size);
@@ -235,10 +258,16 @@ void copy::operator()(const data::jagged_vector_buffer<TYPE>& from_buffer,
                cptype);
 }
 
-template <typename TYPE>
-void copy::operator()(const data::jagged_vector_buffer<TYPE>& from_buffer,
-                      data::jagged_vector_buffer<TYPE>& to_buffer,
+template <typename TYPE1, typename TYPE2>
+void copy::operator()(const data::jagged_vector_buffer<TYPE1>& from_buffer,
+                      data::jagged_vector_buffer<TYPE2>& to_buffer,
                       type::copy_type cptype) {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
 
     // A sanity check.
     assert(from_buffer.m_size == to_buffer.m_size);
@@ -256,8 +285,7 @@ void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
     // The input and output types are allowed to be different, but only by
     // const-ness.
     static_assert(std::is_same<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE2, TYPE1>::value,
+                      details::is_same_nc<TYPE1, TYPE2>::value,
                   "Can only use compatible types in the copy");
 
     // Resize the output object to the correct size.
@@ -281,8 +309,7 @@ void copy::operator()(const data::jagged_vector_buffer<TYPE1>& from_buffer,
     // The input and output types are allowed to be different, but only by
     // const-ness.
     static_assert(std::is_same<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE1, TYPE2>::value ||
-                      details::is_same_nc<TYPE2, TYPE1>::value,
+                      details::is_same_nc<TYPE1, TYPE2>::value,
                   "Can only use compatible types in the copy");
 
     // Resize the output object to the correct size.
@@ -314,15 +341,21 @@ std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes(
     return get_sizes(data.host_ptr(), data.m_size);
 }
 
-template <typename TYPE>
+template <typename TYPE1, typename TYPE2>
 void copy::copy_views(std::size_t size,
-                      const data::vector_view<TYPE>* from_view,
-                      data::vector_view<TYPE>* to_view,
+                      const data::vector_view<TYPE1>* from_view,
+                      data::vector_view<TYPE2>* to_view,
                       type::copy_type cptype) {
 
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(std::is_same<TYPE1, TYPE2>::value ||
+                      details::is_same_nc<TYPE1, TYPE2>::value,
+                  "Can only use compatible types in the copy");
+
     // Helper variables used in the copy.
-    const TYPE* from_ptr = nullptr;
-    TYPE* to_ptr = nullptr;
+    const std::remove_cv_t<TYPE1>* from_ptr = nullptr;
+    TYPE2* to_ptr = nullptr;
     std::size_t copy_size = 0;
     [[maybe_unused]] std::size_t copy_ops = 0;
 
@@ -332,24 +365,21 @@ void copy::copy_views(std::size_t size,
 
     // Helper lambda for figuring out if the next vector element is
     // connected to the currently processed one or not.
-    auto next_is_connected =
-        [size](const data::vector_view<TYPE>* array,
-               const std::vector<typename data::vector_view<TYPE>::size_type>&
-                   sizes,
-               std::size_t i) {
-            // Check if the next non-empty vector element is connected to the
-            // current one.
-            std::size_t j = i + 1;
-            while (j < size) {
-                if (sizes[j] == 0) {
-                    ++j;
-                    continue;
-                }
-                return ((array[i].ptr() + sizes[i]) == array[j].ptr());
+    auto next_is_connected = [size](const auto* array, const auto& sizes,
+                                    std::size_t index) {
+        // Check if the next non-empty vector element is connected to the
+        // current one.
+        std::size_t j = index + 1;
+        while (j < size) {
+            if (sizes[j] == 0) {
+                ++j;
+                continue;
             }
-            // If we got here, then the answer is no...
-            return false;
-        };
+            return ((array[index].ptr() + sizes[index]) == array[j].ptr());
+        }
+        // If we got here, then the answer is no...
+        return false;
+    };
 
     // Perform the copy in multiple steps.
     for (std::size_t i = 0; i < size; ++i) {
@@ -369,12 +399,12 @@ void copy::copy_views(std::size_t size,
         if ((from_ptr == nullptr) && (to_ptr == nullptr) && (copy_size == 0)) {
             from_ptr = from_view[i].ptr();
             to_ptr = to_view[i].ptr();
-            copy_size = from_sizes[i] * sizeof(TYPE);
+            copy_size = from_sizes[i] * sizeof(TYPE1);
         } else {
             assert(from_ptr != nullptr);
             assert(to_ptr != nullptr);
             assert(copy_size != 0);
-            copy_size += from_sizes[i] * sizeof(TYPE);
+            copy_size += from_sizes[i] * sizeof(TYPE1);
         }
 
         // Check if the next vector element connects to this one. If not,
@@ -397,7 +427,7 @@ void copy::copy_views(std::size_t size,
     VECMEM_DEBUG_MSG(2,
                      "Copied the payload of a jagged vector of type "
                      "\"%s\" with %lu copy operation(s)",
-                     typeid(TYPE).name(), copy_ops);
+                     typeid(TYPE2).name(), copy_ops);
 }
 
 template <typename TYPE>

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -54,6 +54,32 @@ TEST_F(core_copy_test, vector) {
     }
 }
 
+/// Tests for copying 1-dimensional constant vectors
+TEST_F(core_copy_test, const_vector) {
+
+    // Create a reference vector.
+    const vecmem::vector<int> reference = {{1, 5, 6, 74, 234, 43, 22},
+                                           &m_resource};
+
+    // Create a view of its data.
+    auto reference_data = vecmem::get_data(reference);
+
+    // Make a copy of this reference.
+    auto copy_data = m_copy.to(reference_data, m_resource);
+
+    // Create device vectors over the two, and compare them.
+    vecmem::device_vector<const int> reference_vector(reference_data);
+    vecmem::device_vector<int> copy_vector(copy_data);
+    EXPECT_EQ(reference_vector.size(), copy_vector.size());
+    auto reference_itr = reference_vector.begin();
+    auto copy_itr = copy_vector.begin();
+    for (; (reference_itr != reference_vector.end()) &&
+           (copy_itr != copy_vector.end());
+         ++reference_itr, ++copy_itr) {
+        EXPECT_EQ(*reference_itr, *copy_itr);
+    }
+}
+
 /// Tests for copying jagged vectors
 TEST_F(core_copy_test, jagged_vector) {
 
@@ -75,6 +101,45 @@ TEST_F(core_copy_test, jagged_vector) {
 
     // Create device vectors over the two, and compare them.
     vecmem::jagged_device_vector<int> reference_vector(reference_data);
+    vecmem::jagged_device_vector<int> copy_vector(copy_data);
+    EXPECT_EQ(reference_vector.size(), copy_vector.size());
+    auto reference_itr = reference_vector.begin();
+    auto copy_itr = copy_vector.begin();
+    for (; (reference_itr != reference_vector.end()) &&
+           (copy_itr != copy_vector.end());
+         ++reference_itr, ++copy_itr) {
+        EXPECT_EQ(reference_itr->size(), copy_itr->size());
+        auto reference_itr2 = reference_itr->begin();
+        auto copy_itr2 = copy_itr->begin();
+        for (; (reference_itr2 != reference_itr->end()) &&
+               (copy_itr2 != copy_itr->end());
+             ++reference_itr2, ++copy_itr2) {
+            EXPECT_EQ(*reference_itr2, *copy_itr2);
+        }
+    }
+}
+
+/// Tests for copying constant jagged vectors
+TEST_F(core_copy_test, const_jagged_vector) {
+
+    // Create a reference vector.
+    const vecmem::jagged_vector<int> reference = {
+        {{{1, 2, 3, 4, 5}, &m_resource},
+         {{6, 7}, &m_resource},
+         {{8, 9, 10, 11}, &m_resource},
+         {{12, 13, 14, 15, 16, 17, 18}, &m_resource},
+         {{19}, &m_resource},
+         {{20}, &m_resource}},
+        &m_resource};
+
+    // Create a view of its data.
+    auto reference_data = vecmem::get_data(reference);
+
+    // Make a copy of this reference.
+    auto copy_data = m_copy.to(reference_data, m_resource);
+
+    // Create device vectors over the two, and compare them.
+    vecmem::jagged_device_vector<const int> reference_vector(reference_data);
     vecmem::jagged_device_vector<int> copy_vector(copy_data);
     EXPECT_EQ(reference_vector.size(), copy_vector.size());
     auto reference_itr = reference_vector.begin();


### PR DESCRIPTION
We bumped into this issue with @konradkusiak97 in https://github.com/acts-project/acts/pull/998. The current implementation of `vecmem::copy` is not able to copy from a constant vector into a non-constant one.

Initially I thought that I may be able to get away with writing this type of code:

```c++
    template <typename TYPE>
    void operator()(data::vector_view<const TYPE> from,
                    data::vector_view<TYPE> to,
                    type::copy_type cptype = type::unknown);
```

Since a view of a non-const vector can be translated into a view of a constant one. But switching to passing the vector views by value in these copy functions would've made their usage **very** inconvenient as it turns out. :frowning: As for instance `vecmem::data::vector_buffer` objects would not be auto-converted into `vecmem::data::vector_view` objects.

So I went with the brute-force method, making the functions use two template types, and only making sure with a `static_cast` that these types would be compatible with each other. Not the absolute best, but that's life.

I also made sure that the `vecmem::copy::to(...)` functions could be conveniently called with constant vectors. Which was also not the case previously...