### PR TITLE
Constexpr Capability For vecmem::static_array, main branch (2021.09.26.)

### DIFF
--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -15,13 +15,10 @@
 #include "vecmem/utils/types.hpp"
 
 namespace vecmem {
+
 template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE static_array<T, N>::static_array(void) {
-    /*
-     * This function does quite literally nothing, and leaves the array's
-     * contents uninitialized.
-     */
-}
+VECMEM_HOST_AND_DEVICE constexpr static_array<T, N>::static_array(void)
+    : m_array() {}
 
 template <typename T, std::size_t N>
 VECMEM_HOST constexpr auto static_array<T, N>::at(size_type i) -> reference {
@@ -236,9 +233,8 @@ VECMEM_HOST_AND_DEVICE void static_array<T, N>::fill(const_reference value) {
 
 template <typename T, std::size_t N>
 template <typename Tp1, typename... Tp>
-VECMEM_HOST_AND_DEVICE void static_array<T, N>::static_array_impl(size_type i,
-                                                                  Tp1&& a1,
-                                                                  Tp&&... a) {
+VECMEM_HOST_AND_DEVICE constexpr void static_array<T, N>::static_array_impl(
+    size_type i, Tp1&& a1, Tp&&... a) {
 
     m_array[i] = a1;
     static_array_impl(i + 1, std::forward<Tp>(a)...);
@@ -246,8 +242,8 @@ VECMEM_HOST_AND_DEVICE void static_array<T, N>::static_array_impl(size_type i,
 
 template <typename T, std::size_t N>
 template <typename Tp1>
-VECMEM_HOST_AND_DEVICE void static_array<T, N>::static_array_impl(size_type i,
-                                                                  Tp1&& a1) {
+VECMEM_HOST_AND_DEVICE constexpr void static_array<T, N>::static_array_impl(
+    size_type i, Tp1&& a1) {
 
     m_array[i] = a1;
 }

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -73,7 +73,7 @@ public:
      * uninitialized.
      */
     VECMEM_HOST_AND_DEVICE
-    static_array(void);
+    constexpr static_array(void);
 
     /**
      * @brief Construct an array from a parameter pack of arbitrary size.
@@ -95,7 +95,7 @@ public:
     template <typename... Tp, typename = std::enable_if_t<sizeof...(Tp) == N>,
               typename = std::enable_if_t<
                   details::conjunction_v<std::is_convertible<Tp, T>...> > >
-    VECMEM_HOST_AND_DEVICE static_array(Tp &&... a) {
+    VECMEM_HOST_AND_DEVICE constexpr static_array(Tp &&... a) : m_array() {
 
         static_array_impl(0, std::forward<Tp>(a)...);
     }
@@ -283,13 +283,15 @@ private:
      * @brief Private helper-constructor for the parameter pack constructor.
      */
     template <typename Tp1, typename... Tp>
-    VECMEM_HOST_AND_DEVICE void static_array_impl(size_type i, Tp1 &&a1,
-                                                  Tp &&... a);
+    VECMEM_HOST_AND_DEVICE constexpr void static_array_impl(size_type i,
+                                                            Tp1 &&a1,
+                                                            Tp &&... a);
     /**
      * @brief Private helper-constructor for the parameter pack constructor.
      */
     template <typename Tp1>
-    VECMEM_HOST_AND_DEVICE void static_array_impl(size_type i, Tp1 &&a1);
+    VECMEM_HOST_AND_DEVICE constexpr void static_array_impl(size_type i,
+                                                            Tp1 &&a1);
 
     /// Array holding the container's data
     typename details::array_type<T, N>::type m_array;

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -156,4 +156,21 @@ TEST_F(core_container_test, static_array) {
     EXPECT_EQ(test_array4.size(), 0);
     EXPECT_EQ(test_array4.max_size(), 0);
     EXPECT_TRUE(test_array4.empty());
+
+    constexpr vecmem::static_array<int, 0> test_array5;
+    constexpr auto test_array5_size = test_array5.size();
+    EXPECT_EQ(test_array5_size, 0);
+    constexpr auto test_array5_max_size = test_array5.max_size();
+    EXPECT_EQ(test_array5_max_size, 0);
+    constexpr bool test_array5_empty = test_array5.empty();
+    EXPECT_TRUE(test_array5_empty);
+
+    constexpr vecmem::static_array<int, ARRAY_SIZE> test_array6 = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    constexpr auto test_array6_size = test_array6.size();
+    EXPECT_EQ(test_array6_size, ARRAY_SIZE);
+    constexpr auto test_array6_max_size = test_array6.max_size();
+    EXPECT_EQ(test_array6_max_size, ARRAY_SIZE);
+    constexpr bool test_array6_empty = test_array6.empty();
+    EXPECT_FALSE(test_array6_empty);
 }


### PR DESCRIPTION
Made it possible to create `constexpr` static_array objects, by declaring the existing constructors as `constexpr`. The only tricky part was that GCC needed the `m_array` member to be explicitly initialised in this case. Luckily an empty initialisation was enough, as it's not possible to meaningfully initialise that variable in the constructor itself.

I think it's interesting to note (just because I myself didn't even think about it beforehand) that declaring any `constexpr` functions on a class is really only meaningful if it has `constexpr` constructors. Otherwise those function can never be used as `constexpr` anyway...

At the same time added some basic tests for this functionality as well. Though we'll probably want to re-organise the tests a bit at one point, as at the moment they are a bit too all over the place...

Of course this is all to address the issue brought up by @beomki-yeo in #107.