### PR TITLE
CMake 3.21+ & HIP 4.2+ Support, main branch (2021.09.26.)

### DIFF
--- a/cmake/vecmem-check-language.cmake
+++ b/cmake/vecmem-check-language.cmake
@@ -11,8 +11,10 @@ include_guard( GLOBAL )
 include( CheckLanguage )
 
 # Teach CMake about VecMem's custom language files.
-list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/hip"
-                               "${CMAKE_CURRENT_LIST_DIR}/sycl" )
+if( "${CMAKE_VERSION}" VERSION_LESS "3.21" )
+   list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/hip" )
+endif()
+list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/sycl" )
 
 # Code mimicking CMake's CheckLanguage.cmake module. But making sure that the
 # VecMem specific code is used while looking for the non-standard languages.
@@ -23,7 +25,9 @@ macro( vecmem_check_language lang )
    if( NOT DEFINED CMAKE_${lang}_COMPILER )
 
       # Handle the HIP and SYCL cases.
-      if( ( "${lang}" STREQUAL "HIP" ) OR ( "${lang}" STREQUAL "SYCL" ) )
+      if( ( ( "${CMAKE_VERSION}" VERSION_LESS "3.21" ) AND
+            ( "${lang}" STREQUAL "HIP" ) ) OR
+          ( "${lang}" STREQUAL "SYCL" ) )
 
          # Greet the user.
          set( _desc "Looking for a ${lang} compiler" )


### PR DESCRIPTION
CMake 3.21 introduced support for the "HIP language" in an extremely similar way to how this project has been operating from the start.

https://cmake.org/cmake/help/latest/release/3.21.html#languages

While I thought that it would be enough to disable our own test for the existence of the compiler, I actually had to hide all of our code from CMake to make the "new code" work. Even though I'm only "APPEND"-ing our modules, so the built-in CMake modules should've been preferred. But since the code just didn't work with our own HIP code available, I didn't look more carefully, I just removed it from `CMAKE_MODULE_PATH` with CMake >=3.21.

Note that while "our" code uses `hipcc` as the HIP compiler, the new CMake code instead uses HIP's `clang++` frontend directly. So you should not point `$HIPCXX` at the `hipcc` script, but rather at the appropriate `clang++` binary. Using [gitlab-registry.cern.ch/akraszna/atlas-gpu-devel-env:centos7-1-6-0](https://gitlab.cern.ch/akraszna/atlas-gpu-devel-env/container_registry) for instance, this means setting it like:

```
[bash][atlas]:vecmem-build > echo $HIPCXX
/opt/rocm-4.3.1/llvm/bin/clang++
[bash][atlas]:vecmem-build >
```

Also note that the CMake support for HIP is far from being perfect at the moment. :frowning: As a major pain, for the moment I could only build our code in "Release" mode with it, since our warning settings trigger a bunch of warnings from the HIP headers.

```
In file included from /data/ssd-1tb/projects/vecmem/vecmem/tests/hip/test_hip_containers_kernels.hip:10:
In file included from /opt/rocm-4.3.1/hip/include/hip/hip_runtime.h:62:
In file included from /opt/rocm-4.3.1/hip/include/hip/amd_detail/hip_runtime.h:63:
In file included from /opt/rocm-4.3.1/hip/include/hip/hip_runtime_api.h:410:
/opt/rocm-4.3.1/hip/include/hip/amd_detail/hip_runtime_api.h:4033:79: warning: unused parameter 'flags' [-Wunused-parameter]
    T f, size_t dynSharedMemPerBlk = 0, int blockSizeLimit = 0, unsigned int  flags = 0 ) {
                                                                              ^
In file included from /data/ssd-1tb/projects/vecmem/vecmem/tests/hip/test_hip_containers_kernels.hip:10:
In file included from /opt/rocm-4.3.1/hip/include/hip/hip_runtime.h:62:
In file included from /opt/rocm-4.3.1/hip/include/hip/amd_detail/hip_runtime.h:70:
In file included from /opt/rocm-4.3.1/hip/include/hip/amd_detail/hip_atomic.h:3:
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1001:23: warning: unused parameter 'a' [-Wunused-parameter]
void __named_sync(int a, int b) { __builtin_amdgcn_s_barrier(); }
                      ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1001:30: warning: unused parameter 'b' [-Wunused-parameter]
void __named_sync(int a, int b) { __builtin_amdgcn_s_barrier(); }
                             ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1141:31: warning: unused parameter 'assertion' [-Wunused-parameter]
void __assertfail(const char *assertion,
                              ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1142:31: warning: unused parameter 'file' [-Wunused-parameter]
                  const char *file,
                              ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1143:32: warning: unused parameter 'line' [-Wunused-parameter]
                  unsigned int line,
                               ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1144:31: warning: unused parameter 'function' [-Wunused-parameter]
                  const char *function,
                              ^
/opt/rocm-4.3.1/hip/include/hip/amd_detail/device_functions.h:1145:26: warning: unused parameter 'charsize' [-Wunused-parameter]
                  size_t charsize)
                         ^
...
```

The CMake code will have to learn to tell `clang++` to treat the HIP include directories as system include directories. Or, you know, AMD developers should fix the @#$% warnings...