### PR TITLE
Memory Resource Stress Test, main branch (2021.09.27.)

### DIFF
--- a/core/src/memory/binary_page_memory_resource.cpp
+++ b/core/src/memory/binary_page_memory_resource.cpp
@@ -13,6 +13,7 @@
 #include <stack>
 
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/utils/debug.hpp"
 
 namespace {
 /**
@@ -46,11 +47,13 @@ binary_page_memory_resource::~binary_page_memory_resource() {
 }
 
 void *binary_page_memory_resource::do_allocate(std::size_t size, std::size_t) {
+    VECMEM_DEBUG_MSG(5, "Request received for %ld bytes", size);
     /*
      * First, we round our allocation request up to a power of two, since
      * that is what the sizes of all our pages are.
      */
     std::size_t goal = round_up(size);
+    VECMEM_DEBUG_MSG(5, "Will be allocating %ld bytes instead", goal);
 
     /*
      * Attempt to find a free page that can fit our allocation goal.
@@ -97,11 +100,16 @@ void *binary_page_memory_resource::do_allocate(std::size_t size, std::size_t) {
      */
     cand->state = page_state::OCCUPIED;
 
+    VECMEM_DEBUG_MSG(2, "Allocated %ld (%ld) bytes at %p", size, goal,
+                     cand->addr);
     return cand->addr;
 }
 
 void binary_page_memory_resource::do_deallocate(void *p, std::size_t,
                                                 std::size_t) {
+
+    VECMEM_DEBUG_MSG(2, "De-allocating memory at %p", p);
+
     page *cand = nullptr;
 
     /*


### PR DESCRIPTION
Added a stress test for the core memory resources. One that `vecmem::binary_page_memory_resource` is failing at the moment. :frowning:

@stephenswat, this is just meant as a simple demonstrator for the problem that I wrote you about earlier. Hopefully this will allow you/us to understand what is the bug in that memory resource...

There are a few things to point out:
  - If I add an explicit `vecmem::vector<int>::reserve(...)` statement before the filling of the inner vectors (thereby eliminating all the re-allocations in the inner loop), the test succeeds.
  - If the outermost loop is only executed once, even if the inner loops do a lot of (re-)allocations, the test succeeds.
    * So something seems to be going wrong when all memory is de-allocated, and then we start asking for memory again. Just how we observe it in @konradkusiak97's code as well.