### PR TITLE
Fix duplicate allocation bug in binary page allocator

### DIFF
--- a/core/src/memory/binary_page_memory_resource.cpp
+++ b/core/src/memory/binary_page_memory_resource.cpp
@@ -123,7 +123,7 @@ void binary_page_memory_resource::do_deallocate(void *p, std::size_t,
         page *c = rem.top();
         rem.pop();
 
-        if (c->addr == p) {
+        if (c->addr == p && c->state != page_state::SPLIT) {
             /*
              * If we have found the target node, we're done.
              */


### PR DESCRIPTION
As @krasznaa and @konradkusiak97 found out the painful way, there is a duplicate allocation bug in the binary page allocator. The reason for this bug is that deallocation does not always correctly select the right page. As an example, consider the following example, in which we have a free page of size 16:

```
─ Page 1, size 16, free, 0x100
```

Now imagine an allocation of size 4:

```
─┬ Page 1, size 16, split, 0x100
 ├┬ Page 2, size 8, split, 0x100
 │├─ Page 3, size 4, occupied, 0x100
 │└─ Page 4, size 4, free, 0x104
 └─ Page 5, size 8, free, 0x108
```

Then, free the allocated memory at address 0x100. You would want the allocator to select page 3, and mark it as free.

```
─┬ Page 1, size 16, split, 0x100
 ├┬ Page 2, size 8, split, 0x100
 │├─ Page 3, size 4, free, 0x100
 │└─ Page 4, size 4, free, 0x104
 └─ Page 5, size 8, free, 0x108
```

However, what the current algorithm was doing was selecting the page with address 0x100 too eagerly. In other words, it was selecting page 1 because it has the correct address. That means that the allocator was freeing the root node (page 1), resulting in the following structure:

```
─┬ Page 1, size 16, free, 0x100
 ├┬ Page 2, size 8, free, 0x100
 │├─ Page 3, size 4, free, 0x100
 │└─ Page 4, size 4, free, 0x104
 └─ Page 5, size 8, free, 0x108
```

This has incorrectly freed too many pages.

The solution to this problem is simple: the deallocation function should not just select _a_ page with the given address, it should select the _smallest_ such page. This corresponds to finding a non-split page with that address.