### PR TITLE
Explicit Symbol Export, main branch (2021.09.30.)

### DIFF
--- a/cmake/sycl/CMakeSYCLCompiler.cmake.in
+++ b/cmake/sycl/CMakeSYCLCompiler.cmake.in
@@ -27,5 +27,9 @@ set( CMAKE_SYCL_FLAGS_RELEASE_INIT "@CMAKE_SYCL_FLAGS_RELEASE_INIT@" )
 set( CMAKE_SYCL_FLAGS_RELWITHDEBINFO_INIT
    "@CMAKE_SYCL_FLAGS_RELWITHDEBINFO_INIT@" )
 
+# Save the C++ compiler version. This is needed for Platform/Windows-MSVC to
+# work correctly. (As that one knows nothing about SYCL.)
+set( CMAKE_CXX_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@" )
+
 # Mark the SYCL compiler as "loaded".
 set( CMAKE_SYCL_COMPILER_LOADED TRUE )

--- a/cmake/sycl/CMakeSYCLInformation.cmake
+++ b/cmake/sycl/CMakeSYCLInformation.cmake
@@ -22,6 +22,9 @@ endif()
 # Common CMake include(s).
 include( CMakeCommonLanguageInclude )
 
+# Set up platform specific flags.
+include( Platform/${CMAKE_EFFECTIVE_SYSTEM_NAME}-IntelLLVM-SYCL OPTIONAL )
+
 # Set up how SYCL object file compilation should go.
 set( CMAKE_SYCL_COMPILE_OBJECT
    "<CMAKE_SYCL_COMPILER> -x c++ <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>" )

--- a/cmake/sycl/CMakeSYCLInformation.cmake
+++ b/cmake/sycl/CMakeSYCLInformation.cmake
@@ -4,21 +4,6 @@
 #
 # Mozilla Public License Version 2.0
 
-# Tweak the linker flags on Windows, to make them compatible with DPC++.
-if( WIN32 )
-   if( ${CMAKE_VERSION} VERSION_LESS 3.21 )
-      set( CMAKE_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
-      set( CMAKE_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
-   else()
-      set( CMAKE_SYCL_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
-      set( CMAKE_SYCL_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
-   endif()
-   foreach( _type EXE SHARED MODULE )
-      string( REGEX REPLACE "(/machine:[a-zA-Z0-9]+)" "-Xlinker \\1"
-         CMAKE_${_type}_LINKER_FLAGS "${CMAKE_${_type}_LINKER_FLAGS}" )
-   endforeach()
-endif()
-
 # Common CMake include(s).
 include( CMakeCommonLanguageInclude )
 

--- a/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
@@ -1,0 +1,11 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+include( Platform/Linux-IntelLLVM )
+
+# Set up the variables specifying the command line arguments of the compiler.
+__linux_compiler_intel_llvm( SYCL )

--- a/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
@@ -9,3 +9,16 @@ include( Platform/Windows-IntelLLVM )
 
 # Set up the variables specifying the command line arguments of the compiler.
 __windows_compiler_intel( SYCL )
+
+# Tweak the MSVC linker flags, to make them compatible with DPC++.
+if( ${CMAKE_VERSION} VERSION_LESS 3.21 )
+   set( CMAKE_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
+   set( CMAKE_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
+else()
+   set( CMAKE_SYCL_CREATE_WIN32_EXE "-Xlinker /subsystem:windows" )
+   set( CMAKE_SYCL_CREATE_CONSOLE_EXE "-Xlinker /subsystem:console" )
+endif()
+foreach( _type EXE SHARED MODULE )
+   string( REGEX REPLACE "(/machine:[a-zA-Z0-9]+)" "-Xlinker \\1"
+      CMAKE_${_type}_LINKER_FLAGS "${CMAKE_${_type}_LINKER_FLAGS}" )
+endforeach()

--- a/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
@@ -1,0 +1,11 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+include( Platform/Windows-IntelLLVM )
+
+# Set up the variables specifying the command line arguments of the compiler.
+__windows_compiler_intel( SYCL )

--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -10,10 +10,6 @@ include( vecmem-functions )
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 
-# Do not export symbols by default.
-set( CMAKE_CXX_VISIBILITY_PRESET "hidden" CACHE STRING
-   "C++ symbol visibility setting" )
-
 # Turn on the correct setting for the __cplusplus macro with MSVC.
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )

--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -10,6 +10,10 @@ include( vecmem-functions )
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 
+# Do not export symbols by default.
+set( CMAKE_CXX_VISIBILITY_PRESET "hidden" CACHE STRING
+   "C++ symbol visibility setting" )
+
 # Turn on the correct setting for the __cplusplus macro with MSVC.
 if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -9,6 +9,7 @@ include_guard( GLOBAL )
 
 # CMake include(s).
 include( CMakeParseArguments )
+include( GenerateExportHeader )
 
 # Helper function for setting up the VecMem libraries.
 #
@@ -23,6 +24,16 @@ function( vecmem_add_library fullname basename )
 
    # Create the library.
    add_library( ${fullname} ${ARG_TYPE} ${ARG_UNPARSED_ARGUMENTS} )
+
+   # Set up symbol exports for the library.
+   set( export_header_filename
+      "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vecmem/${fullname}_export.hpp" )
+   generate_export_header( ${fullname}
+      EXPORT_FILE_NAME "${export_header_filename}" )
+   install( FILES "${export_header_filename}"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vecmem" )
+   target_include_directories( ${fullname} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}> )
 
    # Set up how clients should find its headers.
    target_include_directories( ${fullname} PUBLIC

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -67,6 +67,10 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )
 
+# Hide the library's symbols by default.
+set_target_properties( vecmem_core PROPERTIES
+   CXX_VISIBILITY_PRESET "hidden" )
+
 # Add definitions necessary for the correct functioning of VECMEM_DEBUG_MSG.
 string( LENGTH "${CMAKE_SOURCE_DIR}/" VECMEM_SOURCE_DIR_LENGTH )
 target_compile_definitions( vecmem_core PUBLIC

--- a/core/include/vecmem/memory/allocator.hpp
+++ b/core/include/vecmem/memory/allocator.hpp
@@ -8,11 +8,15 @@
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
 #include <cstddef>
 
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem {
+
 /**
  * @brief An allocator class that wraps a memory resource.
  *
@@ -30,7 +34,7 @@ namespace vecmem {
  * than the one doing the deallocation is not well-defined and should be
  * avoided.
  */
-class allocator {
+class VECMEM_CORE_EXPORT allocator {
 public:
     /**
      * @brief Construct an allocator.
@@ -129,7 +133,9 @@ public:
 
 private:
     memory_resource& m_mem;
-};
+
+};  // class allocator
+
 }  // namespace vecmem
 
 // Include the implementation.

--- a/core/include/vecmem/memory/binary_page_memory_resource.hpp
+++ b/core/include/vecmem/memory/binary_page_memory_resource.hpp
@@ -8,13 +8,17 @@
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
 #include <cstddef>
 #include <memory>
 #include <vector>
 
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem {
+
 /**
  * @brief A memory manager using power-of-two pages that can be split to
  * deal with allocation requests of various sizes.
@@ -26,7 +30,7 @@ namespace vecmem {
  * creates a binary tree of pages which can be either vacant, occupied, or
  * split.
  */
-class binary_page_memory_resource : public memory_resource {
+class VECMEM_CORE_EXPORT binary_page_memory_resource : public memory_resource {
 public:
     /**
      * @brief Initialize a binary page memory manager depending on an
@@ -139,5 +143,7 @@ private:
 
     memory_resource &m_upstream;
     std::vector<std::unique_ptr<page>> m_pages;
-};
+
+};  // class binary_page_memory_resource
+
 }  // namespace vecmem

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -8,11 +8,15 @@
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
 #include <cstddef>
 
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem {
+
 /**
  * @brief Downstream allocator that ensures that allocations are contiguous.
  *
@@ -28,7 +32,7 @@ namespace vecmem {
  * amount of memory that can be allocated from the contiguous memory
  * resource.
  */
-class contiguous_memory_resource : public memory_resource {
+class VECMEM_CORE_EXPORT contiguous_memory_resource : public memory_resource {
 public:
     /**
      * @brief Constructs the contiguous memory resource.
@@ -56,5 +60,7 @@ private:
     const std::size_t m_size;
     void* const m_begin;
     void* m_next;
-};
+
+};  // class contiguous_memory_resource
+
 }  // namespace vecmem

--- a/core/include/vecmem/memory/deallocator.hpp
+++ b/core/include/vecmem/memory/deallocator.hpp
@@ -8,6 +8,7 @@
 
 // Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -21,7 +22,7 @@ namespace vecmem::details {
 /// type. It *does not* call any custom destructors. It merely de-allocates
 /// a memory block.
 ///
-class deallocator {
+class VECMEM_CORE_EXPORT deallocator {
 
 public:
     /// Constructor

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -8,12 +8,12 @@
 
 #pragma once
 
-#include <cstddef>
-#include <memory>
-
+// Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
 
 namespace vecmem {
+
 /**
  * @brief Memory resource which wraps the malloc standard library call.
  *
@@ -21,12 +21,15 @@ namespace vecmem {
  * is a terminal resource which does nothing but wrap malloc and free. It
  * is state-free (on the relevant levels of abstraction).
  */
-class host_memory_resource : public vecmem::memory_resource {
+class VECMEM_CORE_EXPORT host_memory_resource : public vecmem::memory_resource {
+
 private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
 
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
-};
+
+};  // class host_memory_resource
+
 }  // namespace vecmem

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -13,6 +13,7 @@
 #include "vecmem/containers/data/vector_buffer.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -31,7 +32,7 @@ namespace vecmem {
 /// Language specific @c copy classes should only need to re-implement the
 /// @c do_copy function, everything else should be provided by this class.
 ///
-class copy {
+class VECMEM_CORE_EXPORT copy {
 
 public:
     /// Wrapper struct around the @c copy_type enumeration

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -86,7 +86,7 @@
 // the macro to receive 0 or more arguments just confuses MSVC. And the MSVC
 // variadic macro handling can deal with 0 or more arguments out of the box
 // anyway.
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (!defined(__clang__))
 
 /// Helper macro for printing debug messages from "any" code
 ///

--- a/core/src/memory/default_resource_polyfill.cpp
+++ b/core/src/memory/default_resource_polyfill.cpp
@@ -9,6 +9,7 @@
 
 #include "vecmem/memory/host_memory_resource.hpp"
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
 
 #if defined(VECMEM_HAVE_PMR_MEMORY_RESOURCE)
 namespace std::pmr {
@@ -27,18 +28,19 @@ std::atomic<memory_resource*>& default_resource() noexcept {
 
 }  // namespace
 
-memory_resource* new_delete_resource() noexcept {
+VECMEM_CORE_EXPORT memory_resource* new_delete_resource() noexcept {
     // vecmem::host_memory_resource is not singleton, and does not check
     // equality via pointer equality, but is close enough for our purposes.
     static vecmem::host_memory_resource res{};
     return &res;
 }
 
-memory_resource* get_default_resource() noexcept {
+VECMEM_CORE_EXPORT memory_resource* get_default_resource() noexcept {
     return default_resource();
 }
 
-memory_resource* set_default_resource(memory_resource* res) noexcept {
+VECMEM_CORE_EXPORT memory_resource* set_default_resource(
+    memory_resource* res) noexcept {
 
     memory_resource* new_res = res == nullptr ? new_delete_resource() : res;
 

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -38,3 +38,8 @@ vecmem_add_library( vecmem_cuda cuda
 target_link_libraries( vecmem_cuda
    PUBLIC vecmem::core
    PRIVATE CUDA::cudart )
+
+# Hide the library's symbols by default.
+set_target_properties( vecmem_cuda PROPERTIES
+   CXX_VISIBILITY_PRESET  "hidden"
+   CUDA_VISIBILITY_PRESET "hidden" )

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -8,9 +8,12 @@
 
 #pragma once
 
+// Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
+
 /**
  * @brief Memory resource that wraps direct allocations on a CUDA device.
  *
@@ -18,7 +21,7 @@ namespace vecmem::cuda {
  * allocates, it does not try to manage memory in a smart way) that works
  * for CUDA device memory. Each instance is bound to a specific device.
  */
-class device_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT device_memory_resource : public memory_resource {
 public:
     /**
      * @brief Construct a CUDA device resource for a specific device.
@@ -41,5 +44,7 @@ private:
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
 
     const int m_device;
-};
+
+}; // class device_memory_resource
+
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -45,6 +45,6 @@ private:
 
     const int m_device;
 
-}; // class device_memory_resource
+};  // class device_memory_resource
 
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
@@ -8,9 +8,12 @@
 
 #pragma once
 
+// Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
+
 /**
  * @brief Memory resource that wraps page-locked CUDA host allocation.
  *
@@ -18,12 +21,14 @@ namespace vecmem::cuda {
  * memory, which is page-locked by default to allow faster transfer to the
  * CUDA devices.
  */
-class host_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT host_memory_resource : public memory_resource {
 private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
 
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
-};
+
+}; // class host_memory_resource
+
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
@@ -29,6 +29,6 @@ private:
 
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
 
-}; // class host_memory_resource
+};  // class host_memory_resource
 
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
@@ -8,21 +8,26 @@
 
 #pragma once
 
+// Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
+
 /**
  * @brief Memory resource that wraps managed CUDA allocation.
  *
  * This is an allocator-type memory resource that allocates managed CUDA
  * memory, which is accessible directly to devices as well as to the host.
  */
-class managed_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT managed_memory_resource : public memory_resource {
 private:
     virtual void* do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
 
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
-};
+
+}; // class managed_memory_resource
+
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
@@ -28,6 +28,6 @@ private:
 
     virtual bool do_is_equal(const memory_resource&) const noexcept override;
 
-}; // class managed_memory_resource
+};  // class managed_memory_resource
 
 }  // namespace vecmem::cuda

--- a/cuda/include/vecmem/utils/cuda/copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/copy.hpp
@@ -9,11 +9,12 @@
 
 // VecMem include(s).
 #include "vecmem/utils/copy.hpp"
+#include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
 
 /// Specialisation of @c vecmem::copy for CUDA
-class copy : public vecmem::copy {
+class VECMEM_CUDA_EXPORT copy : public vecmem::copy {
 
 protected:
     /// Perform a memory copy using CUDA

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -34,3 +34,8 @@ vecmem_add_library( vecmem_hip hip
 target_link_libraries( vecmem_hip
    PUBLIC vecmem::core
    PRIVATE HIP::hiprt )
+
+# Hide the library's symbols by default.
+set_target_properties( vecmem_hip PROPERTIES
+   CXX_VISIBILITY_PRESET "hidden"
+   HIP_VISIBILITY_PRESET "hidden" )

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -8,11 +8,12 @@
 
 // Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_hip_export.hpp"
 
 namespace vecmem::hip {
 
 /// Memory resource for a specific HIP device
-class device_memory_resource final : public memory_resource {
+class VECMEM_HIP_EXPORT device_memory_resource final : public memory_resource {
 
 public:
     /// Invalid/default device identifier

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -8,11 +8,12 @@
 
 // Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_hip_export.hpp"
 
 namespace vecmem::hip {
 
 /// Memory resource for HIP shared host/device memory
-class host_memory_resource final : public memory_resource {
+class VECMEM_HIP_EXPORT host_memory_resource final : public memory_resource {
 
 private:
     /// Function performing the memory allocation

--- a/hip/include/vecmem/utils/hip/copy.hpp
+++ b/hip/include/vecmem/utils/hip/copy.hpp
@@ -9,11 +9,12 @@
 
 // VecMem include(s).
 #include "vecmem/utils/copy.hpp"
+#include "vecmem/vecmem_hip_export.hpp"
 
 namespace vecmem::hip {
 
 /// Specialisation of @c vecmem::copy for HIP
-class copy : public vecmem::copy {
+class VECMEM_HIP_EXPORT copy : public vecmem::copy {
 
 protected:
     /// Perform a memory copy using HIP

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -33,3 +33,8 @@ vecmem_add_library( vecmem_sycl sycl
    "src/utils/sycl/get_queue.sycl"
    "src/utils/sycl/opaque_queue.hpp" )
 target_link_libraries( vecmem_sycl PUBLIC vecmem::core )
+
+# Hide the library's symbols by default.
+set_target_properties( vecmem_sycl PROPERTIES
+   CXX_VISIBILITY_PRESET  "hidden"
+   SYCL_VISIBILITY_PRESET "hidden" )

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -9,6 +9,7 @@
 // Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
 
 namespace vecmem::sycl::details {
 
@@ -17,7 +18,7 @@ namespace vecmem::sycl::details {
 /// This class is used as base by all of the oneAPI/SYCL memory resource
 /// classes. It holds functionality that those classes all need.
 ///
-class memory_resource_base : public memory_resource {
+class VECMEM_SYCL_EXPORT memory_resource_base : public memory_resource {
 
 public:
     /// Constructor on top of a user-provided queue

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -8,11 +8,13 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/details/memory_resource_base.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
 
 namespace vecmem::sycl {
 
 /// Memory resource for a specific SYCL device
-class device_memory_resource final : public details::memory_resource_base {
+class VECMEM_SYCL_EXPORT device_memory_resource final
+    : public details::memory_resource_base {
 
 public:
     // Inherit the base class's constructor(s).

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -8,11 +8,13 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/details/memory_resource_base.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
 
 namespace vecmem::sycl {
 
 /// Host memory resource, connected to a specific SYCL device
-class host_memory_resource final : public details::memory_resource_base {
+class VECMEM_SYCL_EXPORT host_memory_resource final
+    : public details::memory_resource_base {
 
 public:
     // Inherit the base class's constructor(s).

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -8,11 +8,13 @@
 
 // Local include(s).
 #include "vecmem/memory/sycl/details/memory_resource_base.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
 
 namespace vecmem::sycl {
 
 /// Memory resource shared between the host and a specific SYCL device
-class shared_memory_resource final : public details::memory_resource_base {
+class VECMEM_SYCL_EXPORT shared_memory_resource final
+    : public details::memory_resource_base {
 
 public:
     // Inherit the base class's constructor(s).

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -10,6 +10,7 @@
 // VecMem include(s).
 #include "vecmem/utils/copy.hpp"
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
 
 namespace vecmem::sycl {
 
@@ -20,7 +21,7 @@ namespace vecmem::sycl {
 /// @c cl::sycl::queue object. So this object needs to point to a valid
 /// queue object itself.
 ///
-class copy : public vecmem::copy {
+class VECMEM_SYCL_EXPORT copy : public vecmem::copy {
 
 public:
     /// Constructor on top of a user-provided queue

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -6,6 +6,9 @@
  */
 #pragma once
 
+// Local include(s).
+#include "vecmem/vecmem_sycl_export.hpp"
+
 // System include(s).
 #include <memory>
 #include <string>
@@ -22,7 +25,7 @@ class opaque_queue;
 /// It is necessary for passing around SYCL queue objects in code that should
 /// not be directly exposed to the SYCL headers.
 ///
-class queue_wrapper {
+class VECMEM_SYCL_EXPORT queue_wrapper {
 
 public:
     /// Construct a queue for a device with a specific name

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -11,6 +11,9 @@ enable_language( CUDA )
 include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-cuda )
 
+# External dependency/dependencies.
+find_package( CUDAToolkit REQUIRED )
+
 # Test all of the CUDA library's features.
 vecmem_add_test( cuda
    "test_cuda_memory_resources.cpp"
@@ -19,5 +22,7 @@ vecmem_add_test( cuda
    "test_cuda_jagged_vector_view.cpp"
    "test_cuda_jagged_vector_view_kernels.cu"
    "test_cuda_jagged_vector_view_kernels.cuh"
-   LINK_LIBRARIES vecmem::core vecmem::cuda GTest::gtest_main
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
+   LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda GTest::gtest_main
                   vecmem_testing_common )

--- a/tests/hip/CMakeLists.txt
+++ b/tests/hip/CMakeLists.txt
@@ -11,12 +11,17 @@ enable_language( HIP )
 include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-hip )
 
+# External dependency/dependencies.
+find_package( HIPToolkit REQUIRED )
+
 # Test all of the HIP library's features.
 vecmem_add_test( hip
    "test_hip_memory_resources.cpp"
    "test_hip_containers.cpp" "test_hip_jagged_containers.cpp"
    "test_hip_containers_kernels.hpp" "test_hip_containers_kernels.hip"
-   LINK_LIBRARIES vecmem::core vecmem::hip GTest::gtest_main
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../hip/src/utils/hip_error_handling.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../hip/src/utils/hip_error_handling.cpp"
+   LINK_LIBRARIES HIP::hiprt vecmem::core vecmem::hip GTest::gtest_main
                   vecmem_testing_common )
 
 # The executable's source code needs to be built into position independent

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -15,5 +15,7 @@ include( vecmem-compiler-options-sycl )
 vecmem_add_test( sycl
    "test_sycl_memory_resources.cpp"
    "test_sycl_containers.sycl" "test_sycl_jagged_containers.sycl"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../sycl/src/utils/sycl/device_selector.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../sycl/src/utils/sycl/device_selector.sycl"
    LINK_LIBRARIES vecmem::core vecmem::sycl GTest::gtest_main
                   vecmem_testing_common )


### PR DESCRIPTION
As we discussed with @stephenswat on a few occasions, we were both interested in making the project's main libraries explicitly declare which symbols they want to export for the clients. From my side I'm a little interested in it for my continued play-sessions on Windows, but this can be a healthy thing on other platforms as well.

The PR first of all makes use of [GenerateExportHeader](https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html) to generate header files with the macros necessary to nicely declare which classes/functions provide the public interface of the libraries. Then I went ahead and set the `CXX_VISIBILITY_PRESET`, `CUDA_VISIBILITY_PRESET`, `HIP_VISIBILITY_PRESET` and `SYCL_VISIBILITY_PRESET` target properties to just the main libraries of the project. (Note that `CUDA_VISIBILITY_PRESET` and `HIP_VISIBILITY_PRESET` don't actually play any role, since `vecmem_cuda` and `vecmem_hip` don't contain any CUDA/HIP code at the moment. But should that change, the target property will already be there. :wink:) And finally I updated the code of the libraries to explicitly declare every class/function that is meant to provide the public interface of the libraries.

For SYCL I had to improve our CMake code yet a little further to make this work. For HIP I didn't bother, since at one point we'll completely retire the HIP CMake code from the repository anyway. (Now that CMake 3.21 comes with a first-class support for HIP itself. See #112.)

The updates did remind me about some of the shenanigans that we do in the unit tests. As the tests make use of some of the private headers of the libraries as well. Since using those private headers does make sense for the tests, but I didn't want to make the symbols in question visible on the libraries, I now added the appropriate source files to the test executables as well.