### PR TITLE
Memory Resource Updates, main branch (2021.10.04.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -49,6 +49,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/memory/deallocator.hpp"
    "src/memory/deallocator.cpp"
    # Memory management.
+   "include/vecmem/memory/details/memory_resource_base.hpp"
+   "src/memory/details/memory_resource_base.cpp"
    "include/vecmem/memory/atomic.hpp"
    "include/vecmem/memory/impl/atomic.ipp"
    "include/vecmem/memory/polymorphic_allocator.hpp"

--- a/core/include/vecmem/memory/binary_page_memory_resource.hpp
+++ b/core/include/vecmem/memory/binary_page_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_core_export.hpp"
 
 // System include(s).
@@ -30,7 +30,8 @@ namespace vecmem {
  * creates a binary tree of pages which can be either vacant, occupied, or
  * split.
  */
-class VECMEM_CORE_EXPORT binary_page_memory_resource : public memory_resource {
+class VECMEM_CORE_EXPORT binary_page_memory_resource
+    : public details::memory_resource_base {
 public:
     /**
      * @brief Initialize a binary page memory manager depending on an
@@ -119,8 +120,6 @@ private:
     virtual void *do_allocate(std::size_t, std::size_t) override;
 
     virtual void do_deallocate(void *p, std::size_t, std::size_t) override;
-
-    virtual bool do_is_equal(const memory_resource &) const noexcept override;
 
     /**
      * @brief Find the smallest free page that could fit the requested size.

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_core_export.hpp"
 
 // System include(s).
@@ -32,7 +32,9 @@ namespace vecmem {
  * amount of memory that can be allocated from the contiguous memory
  * resource.
  */
-class VECMEM_CORE_EXPORT contiguous_memory_resource : public memory_resource {
+class VECMEM_CORE_EXPORT contiguous_memory_resource
+    : public details::memory_resource_base {
+
 public:
     /**
      * @brief Constructs the contiguous memory resource.
@@ -50,15 +52,23 @@ public:
     ~contiguous_memory_resource();
 
 private:
-    virtual void* do_allocate(std::size_t, std::size_t) override;
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
 
+    /// Allocate memory "just after" the previous allocation
+    virtual void* do_allocate(std::size_t, std::size_t) override;
+    /// De-allocate a block of previously allocated memory
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
 
-    virtual bool do_is_equal(const memory_resource&) const noexcept override;
+    /// @}
 
+    /// Upstream memory resource to allocate the one memory blob with
     memory_resource& m_upstream;
+    /// Size of memory to allocate upstream
     const std::size_t m_size;
+    /// Pointer to the memory blob allocated from upstream
     void* const m_begin;
+    /// Pointer to the next free memory block to give out
     void* m_next;
 
 };  // class contiguous_memory_resource

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -32,7 +32,7 @@ namespace vecmem {
  * amount of memory that can be allocated from the contiguous memory
  * resource.
  */
-class VECMEM_CORE_EXPORT contiguous_memory_resource
+class VECMEM_CORE_EXPORT contiguous_memory_resource final
     : public details::memory_resource_base {
 
 public:

--- a/core/include/vecmem/memory/details/memory_resource_base.hpp
+++ b/core/include/vecmem/memory/details/memory_resource_base.hpp
@@ -1,0 +1,41 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+namespace vecmem::details {
+
+/// Base class for implementations of the @c vecmem::memory_resource interface
+///
+/// This helper class is mainly meant to help with mitigating compiler warnings
+/// about exporting types that inherit from standard library types. But at the
+/// very least it also provides a default/conservative implementation for the
+/// @c vecmem::memory_resource::do_is_equal(...) function.
+///
+class VECMEM_CORE_EXPORT memory_resource_base : public memory_resource {
+
+public:
+    /// Inherit the base class's constructor(s)
+    using vecmem::memory_resource::memory_resource;
+
+protected:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
+    /// Compares @c *this for equality with @c other
+    virtual bool do_is_equal(
+        const memory_resource &other) const noexcept override;
+
+    /// @}
+
+};  // class memory_resource_base
+
+}  // namespace vecmem::details

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_core_export.hpp"
 
 namespace vecmem {
@@ -21,14 +21,22 @@ namespace vecmem {
  * is a terminal resource which does nothing but wrap malloc and free. It
  * is state-free (on the relevant levels of abstraction).
  */
-class VECMEM_CORE_EXPORT host_memory_resource : public vecmem::memory_resource {
+class VECMEM_CORE_EXPORT host_memory_resource
+    : public details::memory_resource_base {
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
+    /// Allocate standard host memory
     virtual void* do_allocate(std::size_t, std::size_t) override;
-
+    /// De-allocate a block of previously allocated memory
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+    /// Compares @c *this for equality with @c other
+    virtual bool do_is_equal(
+        const memory_resource& other) const noexcept override;
 
-    virtual bool do_is_equal(const memory_resource&) const noexcept override;
+    /// @}
 
 };  // class host_memory_resource
 

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -21,7 +21,7 @@ namespace vecmem {
  * is a terminal resource which does nothing but wrap malloc and free. It
  * is state-free (on the relevant levels of abstraction).
  */
-class VECMEM_CORE_EXPORT host_memory_resource
+class VECMEM_CORE_EXPORT host_memory_resource final
     : public details::memory_resource_base {
 
 private:

--- a/core/src/memory/binary_page_memory_resource.cpp
+++ b/core/src/memory/binary_page_memory_resource.cpp
@@ -156,15 +156,6 @@ void binary_page_memory_resource::do_deallocate(void *p, std::size_t,
     }
 }
 
-bool binary_page_memory_resource::do_is_equal(
-    const memory_resource &other) const noexcept {
-    /*
-     * These memory resources are only equal if they are actually the same
-     * object.
-     */
-    return this == &other;
-}
-
 binary_page_memory_resource::page *binary_page_memory_resource::find_free_page(
     std::size_t size) {
     page *cand = nullptr;

--- a/core/src/memory/contiguous_memory_resource.cpp
+++ b/core/src/memory/contiguous_memory_resource.cpp
@@ -6,27 +6,36 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "vecmem/memory/contiguous_memory_resource.hpp"
 
-#include <cstddef>
-#include <memory>
+#include "vecmem/utils/debug.hpp"
+
+// System include(s).
 #include <stdexcept>
 
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem {
+
 contiguous_memory_resource::contiguous_memory_resource(
     memory_resource &upstream, std::size_t size)
     : m_upstream(upstream),
       m_size(size),
       m_begin(m_upstream.allocate(m_size)),
-      m_next(m_begin) {}
+      m_next(m_begin) {
+
+    VECMEM_DEBUG_MSG(
+        2, "Allocated %lu bytes at %p from the upstream memory resource",
+        m_size, m_begin);
+}
 
 contiguous_memory_resource::~contiguous_memory_resource() {
     /*
      * Deallocate our memory arena upstream.
      */
     m_upstream.deallocate(m_begin, m_size);
+    VECMEM_DEBUG_MSG(
+        2, "De-allocated %lu bytes at %p using the upstream memory resource",
+        m_size, m_begin);
 }
 
 void *contiguous_memory_resource::do_allocate(std::size_t size, std::size_t) {
@@ -54,6 +63,7 @@ void *contiguous_memory_resource::do_allocate(std::size_t size, std::size_t) {
      */
     m_next = next;
 
+    VECMEM_DEBUG_MSG(4, "Allocated %lu bytes at %p", size, curr);
     return curr;
 }
 
@@ -63,15 +73,6 @@ void contiguous_memory_resource::do_deallocate(void *, std::size_t,
      * Deallocation is a no-op for this memory resource, so we do nothing.
      */
     return;
-}
-
-bool contiguous_memory_resource::do_is_equal(
-    const memory_resource &other) const noexcept {
-    /*
-     * These memory resources are equal if and only if they are the same
-     * object.
-     */
-    return this == &other;
 }
 
 }  // namespace vecmem

--- a/core/src/memory/details/memory_resource_base.cpp
+++ b/core/src/memory/details/memory_resource_base.cpp
@@ -1,0 +1,21 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/memory/details/memory_resource_base.hpp"
+
+namespace vecmem::details {
+
+bool memory_resource_base::do_is_equal(
+    const memory_resource &other) const noexcept {
+
+    // Perform a single pointer comparison. Assuming that only the very same
+    // memory resource objects can be considered equal.
+    return (this == &other);
+}
+
+}  // namespace vecmem::details

--- a/core/src/memory/host_memory_resource.cpp
+++ b/core/src/memory/host_memory_resource.cpp
@@ -6,19 +6,27 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "vecmem/memory/host_memory_resource.hpp"
 
-#include <memory>
+#include "vecmem/utils/debug.hpp"
 
-#include "vecmem/memory/memory_resource.hpp"
+// System include(s).
+#include <cstdlib>
 
 namespace vecmem {
+
 void *host_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
-    return malloc(bytes);
+
+    void *ptr = std::malloc(bytes);
+    VECMEM_DEBUG_MSG(4, "Allocated %lu bytes at %p", bytes, ptr);
+    return ptr;
 }
 
 void host_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
-    free(p);
+
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", p);
+    std::free(p);
 }
 
 bool host_memory_resource::do_is_equal(
@@ -34,4 +42,5 @@ bool host_memory_resource::do_is_equal(
 
     return c != nullptr;
 }
+
 }  // namespace vecmem

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -21,7 +21,7 @@ namespace vecmem::cuda {
  * allocates, it does not try to manage memory in a smart way) that works
  * for CUDA device memory. Each instance is bound to a specific device.
  */
-class VECMEM_CUDA_EXPORT device_memory_resource
+class VECMEM_CUDA_EXPORT device_memory_resource final
     : public vecmem::details::memory_resource_base {
 
 public:

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
@@ -21,7 +21,9 @@ namespace vecmem::cuda {
  * allocates, it does not try to manage memory in a smart way) that works
  * for CUDA device memory. Each instance is bound to a specific device.
  */
-class VECMEM_CUDA_EXPORT device_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT device_memory_resource
+    : public vecmem::details::memory_resource_base {
+
 public:
     /**
      * @brief Construct a CUDA device resource for a specific device.
@@ -33,16 +35,26 @@ public:
      *
      * @note The default device is resolved at resource construction time,
      * not at allocation time.
+     *
+     * @param[in] device CUDA identifier for the device to use
      */
     device_memory_resource(int device = -1);
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
+    /// Allocate memory on the selected device
     virtual void* do_allocate(std::size_t, std::size_t) override;
-
+    /// De-allocate a previously allocated memory block on the selected device
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+    /// Compares @c *this for equality with @c other
+    virtual bool do_is_equal(
+        const memory_resource& other) const noexcept override;
 
-    virtual bool do_is_equal(const memory_resource&) const noexcept override;
+    /// @}
 
+    /// CUDA device identifier to use for the (de-)allocations
     const int m_device;
 
 };  // class device_memory_resource

--- a/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
@@ -21,13 +21,22 @@ namespace vecmem::cuda {
  * memory, which is page-locked by default to allow faster transfer to the
  * CUDA devices.
  */
-class VECMEM_CUDA_EXPORT host_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT host_memory_resource
+    : public vecmem::details::memory_resource_base {
+
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
+    /// Allocate page-locked host memory
     virtual void* do_allocate(std::size_t, std::size_t) override;
-
+    /// De-allocate a previously allocated page-locked memory block
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+    /// Compares @c *this for equality with @c other
+    virtual bool do_is_equal(
+        const memory_resource& other) const noexcept override;
 
-    virtual bool do_is_equal(const memory_resource&) const noexcept override;
+    /// @}
 
 };  // class host_memory_resource
 

--- a/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/host_memory_resource.hpp
@@ -21,7 +21,7 @@ namespace vecmem::cuda {
  * memory, which is page-locked by default to allow faster transfer to the
  * CUDA devices.
  */
-class VECMEM_CUDA_EXPORT host_memory_resource
+class VECMEM_CUDA_EXPORT host_memory_resource final
     : public vecmem::details::memory_resource_base {
 
 private:

--- a/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
@@ -20,7 +20,7 @@ namespace vecmem::cuda {
  * This is an allocator-type memory resource that allocates managed CUDA
  * memory, which is accessible directly to devices as well as to the host.
  */
-class VECMEM_CUDA_EXPORT managed_memory_resource
+class VECMEM_CUDA_EXPORT managed_memory_resource final
     : public vecmem::details::memory_resource_base {
 
 private:

--- a/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/managed_memory_resource.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_cuda_export.hpp"
 
 namespace vecmem::cuda {
@@ -20,13 +20,22 @@ namespace vecmem::cuda {
  * This is an allocator-type memory resource that allocates managed CUDA
  * memory, which is accessible directly to devices as well as to the host.
  */
-class VECMEM_CUDA_EXPORT managed_memory_resource : public memory_resource {
+class VECMEM_CUDA_EXPORT managed_memory_resource
+    : public vecmem::details::memory_resource_base {
+
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
+    /// Allocate CUDA managed memory
     virtual void* do_allocate(std::size_t, std::size_t) override;
-
+    /// De-allocate a previously allocated managed memory block
     virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+    /// Compares @c *this for equality with @c other
+    virtual bool do_is_equal(
+        const memory_resource& other) const noexcept override;
 
-    virtual bool do_is_equal(const memory_resource&) const noexcept override;
+    /// @}
 
 };  // class managed_memory_resource
 

--- a/cuda/src/memory/cuda/device_memory_resource.cpp
+++ b/cuda/src/memory/cuda/device_memory_resource.cpp
@@ -6,30 +6,42 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "vecmem/memory/cuda/device_memory_resource.hpp"
-
-#include <cuda_runtime_api.h>
 
 #include "../../utils/cuda_error_handling.hpp"
 #include "../../utils/cuda_wrappers.hpp"
 #include "../../utils/select_device.hpp"
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/utils/debug.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
 
 namespace vecmem::cuda {
+
 device_memory_resource::device_memory_resource(int device)
     : m_device(device >= 0 ? device : details::get_device()) {}
 
 void *device_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
+
+    // Make sure that we would use the appropriate device.
     details::select_device dev(m_device);
 
-    void *res;
+    // Allocate the memory.
+    void *res = nullptr;
     VECMEM_CUDA_ERROR_CHECK(cudaMalloc(&res, bytes));
+    VECMEM_DEBUG_MSG(4, "Allocated %ld bytes at %p on device %i", bytes, res,
+                     m_device);
     return res;
 }
 
 void device_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+
+    // Make sure that we would use the appropriate device.
     details::select_device dev(m_device);
 
+    // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p on device %i", p, m_device);
     VECMEM_CUDA_ERROR_CHECK(cudaFree(p));
 }
 
@@ -45,4 +57,5 @@ bool device_memory_resource::do_is_equal(
      */
     return c != nullptr && c->m_device == m_device;
 }
+
 }  // namespace vecmem::cuda

--- a/cuda/src/memory/cuda/host_memory_resource.cpp
+++ b/cuda/src/memory/cuda/host_memory_resource.cpp
@@ -6,21 +6,30 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "vecmem/memory/cuda/host_memory_resource.hpp"
 
+#include "../../utils/cuda_error_handling.hpp"
+#include "vecmem/utils/debug.hpp"
+
+// CUDA include(s).
 #include <cuda_runtime_api.h>
 
-#include "../../utils/cuda_error_handling.hpp"
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem::cuda {
+
 void *host_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
-    void *res;
+
+    // Allocate the memory.
+    void *res = nullptr;
     VECMEM_CUDA_ERROR_CHECK(cudaMallocHost(&res, bytes));
+    VECMEM_DEBUG_MSG(4, "Allocated %ld bytes at %p", bytes, res);
     return res;
 }
 
 void host_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+
+    // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", p);
     VECMEM_CUDA_ERROR_CHECK(cudaFreeHost(p));
 }
 
@@ -31,4 +40,5 @@ bool host_memory_resource::do_is_equal(
 
     return c != nullptr;
 }
+
 }  // namespace vecmem::cuda

--- a/cuda/src/memory/cuda/managed_memory_resource.cpp
+++ b/cuda/src/memory/cuda/managed_memory_resource.cpp
@@ -6,21 +6,30 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
 #include "vecmem/memory/cuda/managed_memory_resource.hpp"
 
+#include "../../utils/cuda_error_handling.hpp"
+#include "vecmem/utils/debug.hpp"
+
+// CUDA include(s).
 #include <cuda_runtime_api.h>
 
-#include "../../utils/cuda_error_handling.hpp"
-#include "vecmem/memory/memory_resource.hpp"
-
 namespace vecmem::cuda {
+
 void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
-    void *res;
+
+    // Allocate the memory.
+    void *res = nullptr;
     VECMEM_CUDA_ERROR_CHECK(cudaMallocManaged(&res, bytes));
+    VECMEM_DEBUG_MSG(4, "Allocated %ld bytes at %p", bytes, res);
     return res;
 }
 
 void managed_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+
+    // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", p);
     VECMEM_CUDA_ERROR_CHECK(cudaFree(p));
 }
 
@@ -31,4 +40,5 @@ bool managed_memory_resource::do_is_equal(
 
     return c != nullptr;
 }
+
 }  // namespace vecmem::cuda

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -7,13 +7,14 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_hip_export.hpp"
 
 namespace vecmem::hip {
 
 /// Memory resource for a specific HIP device
-class VECMEM_HIP_EXPORT device_memory_resource final : public memory_resource {
+class VECMEM_HIP_EXPORT device_memory_resource final
+    : public vecmem::details::memory_resource_base {
 
 public:
     /// Invalid/default device identifier
@@ -23,6 +24,9 @@ public:
     device_memory_resource(int device = INVALID_DEVICE);
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 
@@ -34,8 +38,10 @@ private:
     bool do_is_equal(
         const memory_resource& other) const noexcept override final;
 
+    /// @}
+
     /// The HIP device used by this resource
-    int m_device;
+    const int m_device;
 
 };  // class device_memory_resource
 

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -7,15 +7,19 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_hip_export.hpp"
 
 namespace vecmem::hip {
 
 /// Memory resource for HIP shared host/device memory
-class VECMEM_HIP_EXPORT host_memory_resource final : public memory_resource {
+class VECMEM_HIP_EXPORT host_memory_resource final
+    : public vecmem::details::memory_resource_base {
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
 
@@ -26,6 +30,8 @@ private:
     /// Function comparing two memory resource instances
     bool do_is_equal(
         const memory_resource& other) const noexcept override final;
+
+    /// @}
 
 };  // class host_memory_resource
 

--- a/hip/src/memory/hip/device_memory_resource.cpp
+++ b/hip/src/memory/hip/device_memory_resource.cpp
@@ -11,31 +11,34 @@
 #include "../../utils/get_device.hpp"
 #include "../../utils/hip_error_handling.hpp"
 #include "../../utils/run_on_device.hpp"
+#include "vecmem/utils/debug.hpp"
 
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
 
 namespace vecmem::hip {
 
-device_memory_resource::device_memory_resource(int device) : m_device(device) {
-
-    if (m_device == INVALID_DEVICE) {
-        m_device = details::get_device();
-    }
-}
+device_memory_resource::device_memory_resource(int device)
+    : m_device(device == INVALID_DEVICE ? details::get_device() : device) {}
 
 void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 
+    // Allocate the memory.
     void* result = nullptr;
     (details::run_on_device(m_device))([&result, nbytes]() {
         VECMEM_HIP_ERROR_CHECK(hipMalloc(&result, nbytes));
     });
+    VECMEM_DEBUG_MSG(4, "Allocated %ld bytes at %p on device %i", nbytes,
+                     result, m_device);
     return result;
 }
 
 void device_memory_resource::do_deallocate(void* ptr, std::size_t,
                                            std::size_t) {
 
+    // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p on device %i", ptr,
+                     m_device);
     (details::run_on_device(m_device))(
         [ptr]() { VECMEM_HIP_ERROR_CHECK(hipFree(ptr)); });
 }

--- a/hip/src/memory/hip/host_memory_resource.cpp
+++ b/hip/src/memory/hip/host_memory_resource.cpp
@@ -9,6 +9,7 @@
 #include "vecmem/memory/hip/host_memory_resource.hpp"
 
 #include "../../utils/hip_error_handling.hpp"
+#include "vecmem/utils/debug.hpp"
 
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
@@ -17,13 +18,17 @@ namespace vecmem::hip {
 
 void* host_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 
+    // Allocate the memory.
     void* result = nullptr;
     VECMEM_HIP_ERROR_CHECK(hipHostMalloc(&result, nbytes));
+    VECMEM_DEBUG_MSG(4, "Allocated %ld bytes at %p", nbytes, result);
     return result;
 }
 
 void host_memory_resource::do_deallocate(void* ptr, std::size_t, std::size_t) {
 
+    // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", ptr);
     VECMEM_HIP_ERROR_CHECK(hipHostFree(ptr));
 }
 

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 // Local include(s).
-#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
@@ -18,7 +18,8 @@ namespace vecmem::sycl::details {
 /// This class is used as base by all of the oneAPI/SYCL memory resource
 /// classes. It holds functionality that those classes all need.
 ///
-class VECMEM_SYCL_EXPORT memory_resource_base : public memory_resource {
+class VECMEM_SYCL_EXPORT memory_resource_base
+    : public vecmem::details::memory_resource_base {
 
 public:
     /// Constructor on top of a user-provided queue
@@ -29,6 +30,9 @@ protected:
     queue_wrapper m_queue;
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory de-allocation
     void do_deallocate(void* ptr, std::size_t nbytes,
                        std::size_t alignment) override final;
@@ -36,6 +40,8 @@ private:
     /// Function comparing two memory resource instances
     bool do_is_equal(
         const memory_resource& other) const noexcept override final;
+
+    /// @}
 
 };  // memory_resource_base
 

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -21,8 +21,13 @@ public:
     using details::memory_resource_base::memory_resource_base;
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+
+    /// @}
 
 };  // device_memory_resource
 

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -21,8 +21,13 @@ public:
     using details::memory_resource_base::memory_resource_base;
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+
+    /// @}
 
 };  // host_memory_resource
 

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -21,8 +21,13 @@ public:
     using details::memory_resource_base::memory_resource_base;
 
 private:
+    /// @name Function(s) implemented from @c vecmem::memory_resource
+    /// @{
+
     /// Function performing the memory allocation
     void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+
+    /// @}
 
 };  // class shared_memory_resource
 

--- a/sycl/src/memory/sycl/details/memory_resource_base.sycl
+++ b/sycl/src/memory/sycl/details/memory_resource_base.sycl
@@ -13,9 +13,6 @@
 // SYCL include(s).
 #include <CL/sycl.hpp>
 
-// System include(s).
-#include <cassert>
-
 namespace vecmem::sycl::details {
 
 memory_resource_base::memory_resource_base(const queue_wrapper& queue)
@@ -24,10 +21,8 @@ memory_resource_base::memory_resource_base(const queue_wrapper& queue)
 void memory_resource_base::do_deallocate(void* ptr, std::size_t, std::size_t) {
 
     // Free the memory.
+    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", ptr);
     cl::sycl::free(ptr, get_queue(m_queue));
-
-    // Let the user know what happened.
-    VECMEM_DEBUG_MSG(5, "Freed the memory block at %p", ptr);
 }
 
 bool memory_resource_base::do_is_equal(

--- a/sycl/src/memory/sycl/device_memory_resource.sycl
+++ b/sycl/src/memory/sycl/device_memory_resource.sycl
@@ -21,9 +21,7 @@ void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
     void* result = cl::sycl::malloc_device(nbytes, details::get_queue(m_queue));
 
     // Let the user know what's happening.
-    VECMEM_DEBUG_MSG(5,
-                     "Allocated %ld bytes of device memory on \"%s\" "
-                     "at %p",
+    VECMEM_DEBUG_MSG(5, "Allocated %ld bytes of device memory on \"%s\" at %p",
                      nbytes,
                      details::get_queue(m_queue)
                          .get_device()

--- a/sycl/src/memory/sycl/shared_memory_resource.sycl
+++ b/sycl/src/memory/sycl/shared_memory_resource.sycl
@@ -21,9 +21,7 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
     void* result = cl::sycl::malloc_shared(nbytes, details::get_queue(m_queue));
 
     // Let the user know what's happening.
-    VECMEM_DEBUG_MSG(5,
-                     "Allocated %ld bytes of shared memory on \"%s\" "
-                     "at %p",
+    VECMEM_DEBUG_MSG(5, "Allocated %ld bytes of shared memory on \"%s\" at %p",
                      nbytes,
                      details::get_queue(m_queue)
                          .get_device()


### PR DESCRIPTION
This one was inspired by the work I've done in #118. As I explained in that PR, `vecmem::memory_resource` can not be replaced by our own class that would inherit from `std::pmr::memory_resource`. But it **is** possible to introduce a class called `vecmem::details::memory_resource_base` (similar to `vecmem::sycl::details::memory_resource_base`) that all memory resources should inherit from. In which we could centralise some of the "inconvenient code" needed to be able to build DLLs on Windows.

While at it, I also tried to harmonise the implementation of all the different memory resources a little better. So that they would all print consistent debug messages about what they're doing, and would provide more-or-less the same type of Doxygen documentation.

If accepted, this one should go in before #118, and that PR will have to be re-designed (simplified...) on top of these changes.

P.S. `clang-format` and I really don't agree on what a reasonable include order should look like in the source files. :frowning: