### PR TITLE
Allocator Test Fixes, main branch (2021.10.06.)

### DIFF
--- a/tests/core/test_core_allocator.cpp
+++ b/tests/core/test_core_allocator.cpp
@@ -31,75 +31,78 @@ public:
 class core_allocator_test : public testing::Test {
 protected:
     vecmem::host_memory_resource m_upstream;
-    vecmem::allocator* m_alloc;
-
-    void SetUp() override { m_alloc = new vecmem::allocator(m_upstream); }
+    vecmem::allocator m_alloc{m_upstream};
 };
 
 TEST_F(core_allocator_test, basic) {
-    void* p = m_alloc->allocate_bytes(1024);
+    void* p = m_alloc.allocate_bytes(1024);
 
-    EXPECT_TRUE(p != nullptr);
+    EXPECT_NE(p, nullptr);
 
-    m_alloc->deallocate_bytes(p, 1024);
+    m_alloc.deallocate_bytes(p, 1024);
 }
 
 TEST_F(core_allocator_test, primitive) {
-    int* p = m_alloc->allocate_object<int>();
+    int* p = m_alloc.allocate_object<int>();
 
-    ASSERT_TRUE(p != nullptr);
+    EXPECT_NE(p, nullptr);
 
     *p = 5;
 
-    EXPECT_TRUE(*p == 5);
+    EXPECT_EQ(*p, 5);
 
-    m_alloc->deallocate_object<int>(p);
+    m_alloc.deallocate_object<int>(p);
 }
 
 TEST_F(core_allocator_test, array) {
-    int* p = m_alloc->allocate_object<int>(10);
+    int* p = m_alloc.allocate_object<int>(10);
 
-    ASSERT_TRUE(p != nullptr);
+    EXPECT_NE(p, nullptr);
 
     for (int i = 0; i < 10; ++i) {
         p[i] = i;
     }
 
     for (int i = 0; i < 10; ++i) {
-        EXPECT_TRUE(p[i] == i);
+        EXPECT_EQ(p[i], i);
     }
 
-    m_alloc->deallocate_object<int>(p, 10);
+    m_alloc.deallocate_object<int>(p, 10);
 }
 
 TEST_F(core_allocator_test, constructor) {
-    test_class* p1 = m_alloc->new_object<test_class>();
-    test_class* p2 = m_alloc->new_object<test_class>(12);
-    test_class* p3 = m_alloc->new_object<test_class>(21, 611);
-    test_class* p4 = m_alloc->new_object<test_class>(21, 15);
+    test_class* p1 = m_alloc.new_object<test_class>();
+    test_class* p2 = m_alloc.new_object<test_class>(12);
+    test_class* p3 = m_alloc.new_object<test_class>(21, 611);
+    test_class* p4 = m_alloc.new_object<test_class>(21, 15);
 
-    ASSERT_TRUE(p1 != nullptr);
-    ASSERT_TRUE(p2 != nullptr);
-    ASSERT_TRUE(p3 != nullptr);
-    ASSERT_TRUE(p4 != nullptr);
+    EXPECT_NE(p1, nullptr);
+    EXPECT_NE(p2, nullptr);
+    EXPECT_NE(p3, nullptr);
+    EXPECT_NE(p4, nullptr);
 
-    EXPECT_TRUE(p1->m_int_1 == 5);
-    EXPECT_TRUE(p1->m_int_2 == 11);
-    EXPECT_TRUE(p1->m_bool_1 == false);
-    EXPECT_TRUE(p1->m_bool_2 == true);
+    EXPECT_EQ(p1->m_int_1, 5);
+    EXPECT_EQ(p1->m_int_2, 11);
+    EXPECT_EQ(p1->m_bool_1, false);
+    EXPECT_EQ(p1->m_bool_2, true);
 
-    EXPECT_TRUE(p2->m_int_1 == 5);
-    EXPECT_TRUE(p2->m_int_2 == 12);
-    EXPECT_TRUE(p2->m_bool_1 == false);
-    EXPECT_TRUE(p2->m_bool_2 == false);
+    EXPECT_EQ(p2->m_int_1, 5);
+    EXPECT_EQ(p2->m_int_2, 12);
+    EXPECT_EQ(p2->m_bool_1, false);
+    EXPECT_EQ(p2->m_bool_2, false);
 
-    EXPECT_TRUE(p3->m_int_1 == 5);
-    EXPECT_TRUE(p3->m_int_2 == 21);
-    EXPECT_TRUE(p3->m_bool_1 == false);
-    EXPECT_TRUE(p3->m_bool_2 == true);
+    EXPECT_EQ(p3->m_int_1, 5);
+    EXPECT_EQ(p3->m_int_2, 21);
+    EXPECT_EQ(p3->m_bool_1, false);
+    EXPECT_EQ(p3->m_bool_2, true);
 
-    EXPECT_TRUE(p4->m_int_1 == 5);
-    EXPECT_TRUE(p4->m_int_2 == 21);
-    EXPECT_TRUE(p4->m_bool_1 == false);
-    EXPECT_TRUE(p4->m_bool_2 == false);
+    EXPECT_EQ(p4->m_int_1, 5);
+    EXPECT_EQ(p4->m_int_2, 21);
+    EXPECT_EQ(p4->m_bool_1, false);
+    EXPECT_EQ(p4->m_bool_2, false);
+
+    m_alloc.delete_object(p1);
+    m_alloc.delete_object(p2);
+    m_alloc.delete_object(p3);
+    m_alloc.delete_object(p4);
 }


### PR DESCRIPTION
While looking at the issues in #99 with [valgrind](https://www.valgrind.org/), I had to realise that our existing core tests were leaking memory. :frowning: This is meant to fix that.

At the same time I updated the tests in `test_core_allocator.cpp`  to use GTest's (non-)equality checking macros, instead of `EXPECT_TRUE(...)` / `ASSERT_TRUE(...)`. (Just because those give a nicer output upon failure.)