### PR TITLE
Implement an instrumenting memory resource

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -68,6 +68,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/memory/binary_page_memory_resource.hpp"
    "src/memory/contiguous_memory_resource.cpp"
    "include/vecmem/memory/contiguous_memory_resource.hpp"
+   "src/memory/instrumenting_memory_resource.cpp"
+   "include/vecmem/memory/instrumenting_memory_resource.hpp"
    # Utilities.
    "include/vecmem/utils/copy.hpp"
    "include/vecmem/utils/impl/copy.ipp"

--- a/core/include/vecmem/memory/instrumenting_memory_resource.hpp
+++ b/core/include/vecmem/memory/instrumenting_memory_resource.hpp
@@ -1,0 +1,168 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <vector>
+
+#include "vecmem/memory/details/memory_resource_base.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
+namespace vecmem {
+/**
+ * @brief This memory resource forwards allocation and deallocation requests to
+ * the upstream resource while recording useful statistics and information
+ * about these events.
+ *
+ * This allocator is here to allow us to debug, to profile, to test, but also
+ * to instrument user code.
+ */
+class VECMEM_CORE_EXPORT instrumenting_memory_resource final
+    : public details::memory_resource_base {
+public:
+    /**
+     * @brief Structure describing a memory resource event.
+     */
+    struct VECMEM_CORE_EXPORT memory_event {
+        /**
+         * @brief Classify an event as an alloction or a deallocation.
+         */
+        enum class type { ALLOCATION, DEALLOCATION };
+
+        /**
+         * @brief Construct an allocation/deallocation event.
+         *
+         * @param[in] t The type of event (allocation or deallocation).
+         * @param[in] s The size of the request.
+         * @param[in] a The alignment of the request.
+         * @param[in] p The pointer that was returned or deallocated.
+         * @param[in] ns The time taken to perform the request in nanoseconds.
+         */
+        memory_event(type t, std::size_t s, std::size_t a, void* p,
+                     std::size_t ns)
+            : m_type(t), m_size(s), m_align(a), m_ptr(p), m_time(ns) {}
+
+        type m_type;
+
+        std::size_t m_size;
+        std::size_t m_align;
+
+        void* m_ptr;
+
+        std::size_t m_time;
+    };
+
+    /**
+     * @brief Constructs the instrumenting memory resource.
+     *
+     * @param[in] upstream The upstream memory resource to use.
+     */
+    instrumenting_memory_resource(memory_resource& upstream);
+
+    /**
+     * @brief Get the total size of outstanding requests.
+     */
+    std::size_t get_outstanding(void) const;
+
+    /**
+     * @brief Return a list of memory allocation and deallocation events in
+     * chronological order.
+     */
+    const std::vector<memory_event>& get_events(void) const;
+
+    /**
+     * @brief Add a pre-allocation hook.
+     *
+     * Whenever memory is allocated, all pre-allocation hooks are exectuted.
+     * This happens before we know whether the allocation was a success or not.
+     *
+     * The function passed to this function should accept the size of the
+     * request as the first argument, and the alignment as the second.
+     */
+    void add_pre_allocate_hook(std::function<void(std::size_t, std::size_t)> f);
+
+    /**
+     * @brief Add a post-allocation hook.
+     *
+     * Whenever memory is allocated, all post-allocation hooks are exectuted.
+     * This happens after we know whether the allocation was a success or not,
+     * and the pointer that was returned.
+     *
+     * The function passed to this function should accept the size of the
+     * request as the first argument, the alignment as the second, and the
+     * pointer to the allocated memory as the third argument.
+     */
+    void add_post_allocate_hook(
+        std::function<void(std::size_t, std::size_t, void*)> f);
+
+    /**
+     * @brief Add a pre-deallocation hook.
+     *
+     * Whenever memory is deallocated, all pre-deallocation hooks are
+     * exectuted.]
+     *
+     * The function passed to this function should accept the pointer to
+     * allocate as its first argument, the size of the request as the second
+     * argument, and the alignment as the third.
+     */
+    void add_pre_deallocate_hook(
+        std::function<void(void*, std::size_t, std::size_t)> f);
+
+private:
+    virtual void* do_allocate(std::size_t, std::size_t) override;
+
+    virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+
+    /*
+     * The upstream memory resource to which requests for allocation and
+     * deallocation will be forwarded.
+     */
+    memory_resource& m_upstream;
+
+    /*
+     * This variable tracks the total size of outstanding allocations.
+     */
+    std::size_t m_outstanding = 0;
+
+    /*
+     * This list stores a chronological set of requests that were passed to
+     * this memory resource.
+     */
+    std::vector<memory_event> m_events;
+
+    /*
+     * The list of all pre-allocation hooks.
+     */
+    std::vector<std::function<void(std::size_t, std::size_t)>>
+        m_pre_allocate_hooks;
+
+    /*
+     * The list of all post-allocation hooks.
+     */
+    std::vector<std::function<void(std::size_t, std::size_t, void*)>>
+        m_post_allocate_hooks;
+
+    /*
+     * The list of all pre-deallocation hooks.
+     */
+    std::vector<std::function<void(void*, std::size_t, std::size_t)>>
+        m_pre_deallocate_hooks;
+};
+}  // namespace vecmem
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/core/src/memory/instrumenting_memory_resource.cpp
+++ b/core/src/memory/instrumenting_memory_resource.cpp
@@ -1,0 +1,162 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include "vecmem/memory/instrumenting_memory_resource.hpp"
+
+#include <chrono>
+#include <functional>
+
+namespace vecmem {
+instrumenting_memory_resource::instrumenting_memory_resource(
+    memory_resource &upstream)
+    : m_upstream(upstream) {}
+
+std::size_t instrumenting_memory_resource::get_outstanding(void) const {
+    return m_outstanding;
+}
+
+const std::vector<instrumenting_memory_resource::memory_event>
+    &instrumenting_memory_resource::get_events(void) const {
+    return m_events;
+}
+
+void instrumenting_memory_resource::add_pre_allocate_hook(
+    std::function<void(std::size_t, std::size_t)> f) {
+    m_pre_allocate_hooks.push_back(f);
+}
+
+void instrumenting_memory_resource::add_post_allocate_hook(
+    std::function<void(std::size_t, std::size_t, void *)> f) {
+    m_post_allocate_hooks.push_back(f);
+}
+
+void instrumenting_memory_resource::add_pre_deallocate_hook(
+    std::function<void(void *, std::size_t, std::size_t)> f) {
+    m_pre_deallocate_hooks.push_back(f);
+}
+
+void *instrumenting_memory_resource::do_allocate(std::size_t size,
+                                                 std::size_t align) {
+    /*
+     * First, we will execute all pre-allocation hooks.
+     */
+    for (const std::function<void(std::size_t, std::size_t)> &f :
+         m_pre_allocate_hooks) {
+        f(size, align);
+    }
+
+    /*
+     * We record the time before the request, so we can compute the total
+     * execution time afterwards.
+     */
+    std::chrono::high_resolution_clock::time_point t1 =
+        std::chrono::high_resolution_clock::now();
+
+    void *ptr;
+
+    /*
+     * If an allocation fails, a std::bad_alloc exception is thrown. Normally
+     * we can just forward those to the user, but in this case we want to do
+     * some extra administration. Therefore, if this happens, we set the
+     * pointer to null for now.
+     */
+    try {
+        ptr = m_upstream.allocate(size, align);
+    } catch (std::bad_alloc &) {
+        ptr = nullptr;
+    }
+
+    /*
+     * Record the time after the allocation, and compute the difference in
+     * nanoseconds from the start of the allocation.
+     */
+    std::chrono::high_resolution_clock::time_point t2 =
+        std::chrono::high_resolution_clock::now();
+
+    std::size_t time =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+
+    /*
+     * Add a new allocation event with the size, alignment, pointer, and time
+     * of what has just happened.
+     */
+    m_events.emplace_back(memory_event::type::ALLOCATION, size, align, ptr,
+                          time);
+
+    /*
+     * Now, we can run the post-allocation hooks. For failed allocations, the
+     * pointer will be null.
+     */
+    for (const std::function<void(std::size_t, std::size_t, void *)> &f :
+         m_post_allocate_hooks) {
+        f(size, align, ptr);
+    }
+
+    /*
+     * Now we check whether our allocation failed. If that is the case, we just
+     * throw another bad allocation exception.
+     */
+    if (ptr == nullptr) {
+        throw std::bad_alloc();
+    } else {
+        /*
+         * If the allocation was a success, add the size to the total
+         * outstanding memory pool.
+         */
+        m_outstanding += size;
+    }
+
+    return ptr;
+}
+
+void instrumenting_memory_resource::do_deallocate(void *ptr, std::size_t size,
+                                                  std::size_t align) {
+    /*
+     * First, we will run all of our pre-deallocation hooks.
+     */
+    for (const std::function<void(void *, std::size_t, std::size_t)> &f :
+         m_pre_deallocate_hooks) {
+        f(ptr, size, align);
+    }
+
+    /*
+     * Now, remove the requested amount of memory from the outstanding pool. We
+     * don't really have a notion of deallocation failing, so we always assume
+     * that it succeeds. Calling deallocate on memory that was not succesfully
+     * allocated is UB anyway.
+     */
+    m_outstanding -= size;
+
+    /*
+     * As with allocation, we calculate the time taken to process this
+     * deallocation.
+     */
+    std::chrono::high_resolution_clock::time_point t1 =
+        std::chrono::high_resolution_clock::now();
+
+    /*
+     * The deallocation, like allocation, is a forwarding method.
+     */
+    m_upstream.deallocate(ptr, size, align);
+
+    /*
+     * Compute the total elapsed time during the deallocation request.
+     */
+    std::chrono::high_resolution_clock::time_point t2 =
+        std::chrono::high_resolution_clock::now();
+
+    std::size_t time =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+
+    /*
+     * Register a deallocation event.
+     */
+    m_events.emplace_back(memory_event::type::DEALLOCATION, size, align, ptr,
+                          time);
+}
+}  // namespace vecmem

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -14,4 +14,5 @@ vecmem_add_test( core
    "test_core_device_containers.cpp" "test_core_memory_resources.cpp"
    "test_core_static_vector.cpp" "test_core_vector.cpp"
    "test_core_jagged_vector_view.cpp" "test_core_static_array.cpp" "test_core_default_resource.cpp"
+   "test_core_instrumenting_memory_resource.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_instrumenting_memory_resource.cpp
+++ b/tests/core/test_core_instrumenting_memory_resource.cpp
@@ -1,0 +1,221 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <functional>
+
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/memory/instrumenting_memory_resource.hpp"
+
+class core_instrumenting_memory_resource_test : public testing::Test {
+protected:
+    vecmem::host_memory_resource m_upstream;
+};
+
+TEST_F(core_instrumenting_memory_resource_test, equality) {
+    vecmem::instrumenting_memory_resource res1(m_upstream);
+    vecmem::instrumenting_memory_resource res2(m_upstream);
+
+    EXPECT_FALSE(res1.is_equal(res2));
+    EXPECT_TRUE(res1.is_equal(res1));
+    EXPECT_TRUE(res2.is_equal(res2));
+}
+
+TEST_F(core_instrumenting_memory_resource_test, pre_allocate_hook) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    std::size_t total_size = 0;
+
+    res.add_pre_allocate_hook(
+        [&total_size](std::size_t size, std::size_t) { total_size += size; });
+
+    void* ptr1 = res.allocate(100);
+    void* ptr2 = res.allocate(50);
+    void* ptr3 = res.allocate(2);
+
+    EXPECT_EQ(total_size, 152);
+
+    res.deallocate(ptr1, 100);
+    res.deallocate(ptr2, 50);
+    res.deallocate(ptr3, 2);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, post_allocate_hook) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    std::size_t total_size = 0;
+
+    res.add_post_allocate_hook([&total_size](std::size_t size, std::size_t,
+                                             void*) { total_size += size; });
+
+    void* ptr1 = res.allocate(100);
+    void* ptr2 = res.allocate(50);
+    void* ptr3 = res.allocate(2);
+
+    EXPECT_EQ(total_size, 152);
+
+    res.deallocate(ptr1, 100);
+    res.deallocate(ptr2, 50);
+    res.deallocate(ptr3, 2);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, post_allocate_hook_eq) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    void* last;
+
+    res.add_post_allocate_hook(
+        [&last](std::size_t, std::size_t, void* ptr) { last = ptr; });
+
+    void* ptr1 = res.allocate(100);
+
+    EXPECT_EQ(ptr1, last);
+
+    void* ptr2 = res.allocate(50);
+
+    EXPECT_EQ(ptr2, last);
+
+    void* ptr3 = res.allocate(2);
+
+    EXPECT_EQ(ptr3, last);
+
+    res.deallocate(ptr1, 100);
+    res.deallocate(ptr2, 50);
+    res.deallocate(ptr3, 2);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, pre_post_allocate_hook) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    std::size_t total_size = 0;
+
+    res.add_pre_allocate_hook(
+        [&total_size](std::size_t size, std::size_t) { total_size += size; });
+
+    res.add_post_allocate_hook([&total_size](std::size_t size, std::size_t,
+                                             void*) { total_size += size; });
+
+    void* ptr1 = res.allocate(100);
+    void* ptr2 = res.allocate(50);
+    void* ptr3 = res.allocate(2);
+
+    EXPECT_EQ(total_size, 304);
+
+    res.deallocate(ptr1, 100);
+    res.deallocate(ptr2, 50);
+    res.deallocate(ptr3, 2);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, pre_deallocate_hook) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    std::size_t total_size = 0;
+
+    res.add_pre_deallocate_hook(
+        [&total_size](void*, std::size_t size, std::size_t) {
+            total_size += size;
+        });
+
+    void* ptr1 = res.allocate(100);
+    void* ptr2 = res.allocate(50);
+    void* ptr3 = res.allocate(2);
+
+    res.deallocate(ptr1, 100);
+    res.deallocate(ptr2, 50);
+
+    EXPECT_EQ(total_size, 150);
+
+    res.deallocate(ptr3, 2);
+
+    EXPECT_EQ(total_size, 152);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, outstanding) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    EXPECT_EQ(res.get_outstanding(), 0);
+
+    void* ptr1 = res.allocate(100);
+
+    EXPECT_EQ(res.get_outstanding(), 100);
+
+    void* ptr2 = res.allocate(50);
+
+    EXPECT_EQ(res.get_outstanding(), 150);
+
+    void* ptr3 = res.allocate(2);
+
+    EXPECT_EQ(res.get_outstanding(), 152);
+
+    res.deallocate(ptr2, 50);
+
+    EXPECT_EQ(res.get_outstanding(), 102);
+
+    res.deallocate(ptr3, 2);
+
+    EXPECT_EQ(res.get_outstanding(), 100);
+
+    void* ptr4 = res.allocate(32);
+
+    EXPECT_EQ(res.get_outstanding(), 132);
+
+    res.deallocate(ptr1, 100);
+
+    EXPECT_EQ(res.get_outstanding(), 32);
+
+    res.deallocate(ptr4, 32);
+
+    EXPECT_EQ(res.get_outstanding(), 0);
+}
+
+TEST_F(core_instrumenting_memory_resource_test, events) {
+    vecmem::instrumenting_memory_resource res(m_upstream);
+
+    void* ptr1 = res.allocate(100);
+    void* ptr2 = res.allocate(50);
+    res.deallocate(ptr2, 50);
+    void* ptr3 = res.allocate(2, 8);
+    res.deallocate(ptr1, 100);
+
+    const std::vector<vecmem::instrumenting_memory_resource::memory_event>
+        events = res.get_events();
+
+    ASSERT_EQ(events.size(), 5);
+
+    EXPECT_EQ(
+        events[0].m_type,
+        vecmem::instrumenting_memory_resource::memory_event::type::ALLOCATION);
+    EXPECT_EQ(events[0].m_size, 100);
+    EXPECT_EQ(events[0].m_ptr, ptr1);
+
+    EXPECT_EQ(
+        events[1].m_type,
+        vecmem::instrumenting_memory_resource::memory_event::type::ALLOCATION);
+    EXPECT_EQ(events[1].m_size, 50);
+    EXPECT_EQ(events[1].m_ptr, ptr2);
+
+    EXPECT_EQ(events[2].m_type, vecmem::instrumenting_memory_resource::
+                                    memory_event::type::DEALLOCATION);
+    EXPECT_EQ(events[2].m_size, 50);
+    EXPECT_EQ(events[2].m_ptr, ptr2);
+
+    EXPECT_EQ(
+        events[3].m_type,
+        vecmem::instrumenting_memory_resource::memory_event::type::ALLOCATION);
+    EXPECT_EQ(events[3].m_size, 2);
+    EXPECT_EQ(events[3].m_align, 8);
+    EXPECT_EQ(events[3].m_ptr, ptr3);
+
+    EXPECT_EQ(events[4].m_type, vecmem::instrumenting_memory_resource::
+                                    memory_event::type::DEALLOCATION);
+    EXPECT_EQ(events[4].m_size, 100);
+    EXPECT_EQ(events[4].m_ptr, ptr1);
+
+    res.deallocate(ptr3, 2, 8);
+}

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -12,6 +12,7 @@
 #include "vecmem/memory/binary_page_memory_resource.hpp"
 #include "vecmem/memory/contiguous_memory_resource.hpp"
 #include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/memory/instrumenting_memory_resource.hpp"
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
@@ -156,22 +157,27 @@ static vecmem::contiguous_memory_resource contiguous_resource(host_resource,
                                                               20000);
 static vecmem::arena_memory_resource arena_resource(host_resource, 20000,
                                                     10000000);
+static vecmem::instrumenting_memory_resource instrumenting_resource(
+    host_resource);
 
 // Instantiate the test suite(s).
-INSTANTIATE_TEST_SUITE_P(core_memory_resource_tests, core_memory_resource_test,
-                         testing::Values(&host_resource, &binary_resource,
-                                         &contiguous_resource, &arena_resource),
-                         vecmem::testing::memory_resource_name_gen(
-                             {{&host_resource, "host_resource"},
-                              {&binary_resource, "binary_resource"},
-                              {&contiguous_resource, "contiguous_resource"},
-                              {&arena_resource, "arena_resource"}}));
+INSTANTIATE_TEST_SUITE_P(
+    core_memory_resource_tests, core_memory_resource_test,
+    testing::Values(&host_resource, &binary_resource, &contiguous_resource,
+                    &arena_resource, &instrumenting_resource),
+    vecmem::testing::memory_resource_name_gen(
+        {{&host_resource, "host_resource"},
+         {&binary_resource, "binary_resource"},
+         {&contiguous_resource, "contiguous_resource"},
+         {&arena_resource, "arena_resource"},
+         {&instrumenting_resource, "instrumenting_resource"}}));
 
-INSTANTIATE_TEST_SUITE_P(core_memory_resource_stress_tests,
-                         core_memory_resource_stress_test,
-                         testing::Values(&host_resource, &binary_resource,
-                                         &arena_resource),
-                         vecmem::testing::memory_resource_name_gen(
-                             {{&host_resource, "host_resource"},
-                              {&binary_resource, "binary_resource"},
-                              {&arena_resource, "arena_resource"}}));
+INSTANTIATE_TEST_SUITE_P(
+    core_memory_resource_stress_tests, core_memory_resource_stress_test,
+    testing::Values(&host_resource, &binary_resource, &arena_resource,
+                    &instrumenting_resource),
+    vecmem::testing::memory_resource_name_gen(
+        {{&host_resource, "host_resource"},
+         {&binary_resource, "binary_resource"},
+         {&arena_resource, "arena_resource"},
+         {&instrumenting_resource, "instrumenting_resource"}}));


### PR DESCRIPTION
This memory resource is a little different from the others, in the sense that its purpose is not to control how memory is allocated, but rather to monitor and instrument that process. This memory resource is mainly designed for debugging, profiling, and testing other resources, both in our code and in user code.

The instrumenting memory resource provides support for arbitrary user-provided pre-allocation, post-allocation, and pre-deallocation hooks. It keeps track of a chronological series of allocation and deallocation requests, and it knows about the side of its own outstanding allocation pool.