### PR TITLE
CI Update, main branch (2021.10.08.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -30,7 +30,7 @@ jobs:
           - OS: "macos-latest"
             GENERATOR: "Xcode"
           - OS: "windows-latest"
-            GENERATOR: "NMake Makefiles"
+            GENERATOR: "Visual Studio 16 2019"
 
     # The system to run on.
     runs-on: ${{ matrix.PLATFORM.OS }}
@@ -39,8 +39,6 @@ jobs:
     steps:
     # Use a standard checkout of the code.
     - uses: actions/checkout@v2
-    # Set up the build environment.
-    - uses: ilammy/msvc-dev-cmd@v1.9.0
     # Run the CMake configuration.
     - name: Configure
       run: cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD.TYPE }}


### PR DESCRIPTION
With #118 now in, the Windows CI build can be simplified a bit. We don't need to use [NMAKE](https://docs.microsoft.com/en-us/cpp/build/reference/nmake-reference) anymore when building the core and CUDA libraries.

We still need it for building the SYCL library, but we won't be doing that on Windows in the CI...

This way we can test the "native build systems" on all 3 "native platforms". :wink: (And we don't need to rely on a 3rd party action anymore...)