### PR TITLE
SYCL Debug Support on NVidia Backend, main branch (2021.10.09.)

### DIFF
--- a/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
@@ -26,6 +26,10 @@ endif()
 set( CMAKE_SYCL_COMPILE_OBJECT
    "<CMAKE_SYCL_COMPILER> -x c++ <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>" )
 
+# Set an archive (static library) creation command explicitly for this platform.
+set( CMAKE_SYCL_CREATE_STATIC_LIBRARY
+   "<CMAKE_AR> qc <TARGET> <LINK_FLAGS> <OBJECTS>" )
+
 # Set the flags controlling the C++ standard used by the SYCL compiler.
 set( CMAKE_SYCL17_STANDARD_COMPILE_OPTION "-std=c++17" )
 set( CMAKE_SYCL17_EXTENSION_COMPILE_OPTION "-std=c++17" )

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -38,3 +38,64 @@ target_link_libraries( vecmem_sycl PUBLIC vecmem::core )
 set_target_properties( vecmem_sycl PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden"
    SYCL_VISIBILITY_PRESET "hidden" )
+
+# Helper function for checking if some SYCL files can be built into an
+# executable.
+function( check_sycl_code_compiles _variable )
+   if( DEFINED ${_variable} )
+      return()
+   endif()
+   if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+      message( STATUS "Performing Test ${_variable}" )
+   else()
+      message( CHECK_START "Performing Test ${_variable}" )
+   endif()
+   try_compile( ${_variable}
+      "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_variable}"
+      SOURCES ${ARGN} )
+   if( ${_variable} )
+      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+         message( STATUS "Performing Test ${_variable} - Success" )
+      else()
+         message( CHECK_PASS "Success" )
+      endif()
+   else()
+      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+         message( STATUS "Performing Test ${_variable} - Failed" )
+      else()
+         message( CHECK_FAIL "Failed" )
+      endif()
+   endif()
+endfunction( check_sycl_code_compiles )
+
+# Check if assertions work out of the box in the build.
+check_sycl_code_compiles( VECMEM_SYCL_HAVE_ASSERT
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl" )
+
+# If not, check if it can be solved as described in:
+#   https://github.com/intel/llvm/issues/3385
+if( NOT VECMEM_SYCL_HAVE_ASSERT )
+
+   # Check if the "CUDA polyfill" can make the test work.
+   check_sycl_code_compiles( VECMEM_SYCL_HAVE_ASSERT_POLYFILL
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl"
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/sycl/cuda_assert_polyfill.sycl" )
+
+   # If yes, we have to do something a bit elaborate. The "polyfill" code only
+   # works correctly when linked into the binary that needs to use assertions.
+   # Device code just does not work across binary boundaries. So we can't just
+   # put the code into vecmem::sycl. Instead let's add a separate STATIC
+   # library, which vecmem::sycl would depend on.
+   if( VECMEM_SYCL_HAVE_ASSERT_POLYFILL )
+
+      # Set up the vecmem::sycl_polyfill library.
+      vecmem_add_library( vecmem_sycl_polyfill sycl_polyfill TYPE STATIC
+         "src/utils/sycl/cuda_assert_polyfill.sycl" )
+      target_link_libraries( vecmem_sycl INTERFACE vecmem::sycl_polyfill )
+
+   else()
+      # If not even this worked, then warn the user, and see what happens...
+      message( WARNING "Assertions are not available for SYCL device code."
+         "The build will likely fail." )
+   endif()
+endif()

--- a/sycl/cmake/assert_test.sycl
+++ b/sycl/cmake/assert_test.sycl
@@ -1,0 +1,27 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// System include(s).
+#include <cassert>
+
+int main() {
+
+    // Run a useless little kernel that requires assert(...) to be available.
+    cl::sycl::queue queue;
+    int i = 20;
+    (void)i;
+    queue.submit([&](cl::sycl::handler& h) {
+        h.parallel_for<class test_kernel>(
+            cl::sycl::range<1>(100), [=](cl::sycl::id<1>) { assert(i == 20); });
+    });
+
+    // Return gracefully.
+    return 0;
+}

--- a/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
+++ b/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
@@ -1,0 +1,36 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// I can't figure out how to make the __assert_fail(...) function noreturn. :-(
+// So for now let's just silence this warning from the compiler.
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Winvalid-noreturn"
+#endif  // GCC
+
+// I stole this implementation for __assert_fail and __assertfail from:
+//   https://github.com/intel/llvm/issues/3385
+
+extern "C" {
+extern SYCL_EXTERNAL void __assertfail(const char *__assertion,
+                                       const char *__file, unsigned int __line,
+                                       const char *__function, size_t)
+#ifndef __SYCL_DEVICE_ONLY__
+{
+    fprintf(stderr, "Assertion %s in file %s @ %ud, func %s\n", __assertion,
+            __file, __line, __function);
+}
+#endif
+;
+}
+
+void __assert_fail(const char *expr, const char *file, unsigned int line,
+                   const char *func) {
+    __assertfail(expr, file, line, func, 1);
+}


### PR DESCRIPTION
This is something that has been haunting me for a while. :frowning: All the assertions that we have in the (device) code have prevented building "Debug" binaries for the NVidia backend of oneAPI/SYCL since forever. The reason for this is arguably a bug in the Intel compiler, as discussed in https://github.com/intel/llvm/issues/3385.

Following on from how @paulgessinger introduced a "polyfill" for shortcomings in [libc++](https://libcxx.llvm.org/), I thought the same type of fix could be provided for this problem as well.

First off, I had to write a bit of code that would be able to detect when the issue is afoot. As it happens, the [try_compile(...)](https://cmake.org/cmake/help/latest/command/try_compile.html) statements actually build the code without any optimisations, regarless of the value of `CMAKE_BUILD_TYPE`. So even in "Release" mode, if one is trying to set the compiler as

```sh
export SYCLCXX="clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice"
```

, the test will come out as:

```
[bash][Legolas]:build > export SYCLCXX="clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda-sycldevice"
[bash][Legolas]:build > cmake -DCMAKE_BUILD_TYPE=Release ../vecmem/
-- The CXX compiler identification is Clang 13.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/krasznaa/software/intel/clang/2021-07/x86_64-ubuntu2004-gcc9-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - /home/krasznaa/software/cuda/10.2.89/x86_64-ubuntu2004/bin/nvcc
-- Looking for a HIP compiler
-- Looking for a HIP compiler - NOTFOUND
-- Looking for a SYCL compiler
-- Looking for a SYCL compiler - /home/krasznaa/software/intel/clang/2021-07/x86_64-ubuntu2004-gcc9-opt/bin/clang++
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE - Success
-- Using memory resource types from the std::pmr namespace
-- Performing Test VECMEM_HAVE_DEFAULT_RESOURCE
-- Performing Test VECMEM_HAVE_DEFAULT_RESOURCE - Success
-- The CUDA compiler identification is NVIDIA 10.2.89
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /home/krasznaa/software/cuda/10.2.89/x86_64-ubuntu2004/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /home/krasznaa/software/cuda/10.2.89/x86_64-ubuntu2004/include (found version "10.2.89") 
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Check for working SYCL compiler: /home/krasznaa/software/intel/clang/2021-07/x86_64-ubuntu2004-gcc9-opt/bin/clang++
-- Check for working SYCL compiler: /home/krasznaa/software/intel/clang/2021-07/x86_64-ubuntu2004-gcc9-opt/bin/clang++ - works
-- Performing Test VECMEM_SYCL_HAVE_ASSERT
-- Performing Test VECMEM_SYCL_HAVE_ASSERT - Failed
-- Performing Test VECMEM_SYCL_HAVE_ASSERT_POLYFILL
-- Performing Test VECMEM_SYCL_HAVE_ASSERT_POLYFILL - Success
-- Building GoogleTest as part of the VecMem project
-- The C compiler identification is Clang 13.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/krasznaa/software/intel/clang/2021-07/x86_64-ubuntu2004-gcc9-opt/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python: /usr/bin/python3.8 (found version "3.8.10") found components: Interpreter 
-- Configuring done
-- Generating done
-- Build files have been written to: /data/ssd-1tb/projects/vecmem/build
[bash][Legolas]:build >
```

I.e. the "polyfill" will be turned on. Which I actually think is a good thing. Since even if VecMem is built in "Release" mode, clients may still build their own code in Debug mode, at which point all the assertions in the (template) device classes would trigger this issue. We will need to be careful with how this polyfill would interact with SYCL code in [traccc](https://github.com/acts-project/traccc), but we'll cross that bridge when we get to it.

Note that this code can not be hidden into the `vecmem::sycl` library unfortunately. At least not as long as it is being built as a shared library. (As device code like this can not be called across binary boundaries.) So I created a new library, called `vecmem::sycl_polyfill`. Which `vecmem::sycl` "links against" in `INTERFACE` mode. I.e. only the clients of `vecmem::sycl` link against it.

With this in place, the linking succeeds, and the test jobs can run in Debug mode as well. :partying_face:

```
[bash][Legolas]:build > SYCL_DEVICE_FILTER=cuda ./bin/vecmem_test_sycl 
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: NVIDIA GeForce RTX 3080
Running main() from /data/ssd-1tb/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 17 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from sycl_containers_test
[ RUN      ] sycl_containers_test.shared_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[       OK ] sycl_containers_test.shared_memory (232 ms)
[ RUN      ] sycl_containers_test.device_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/include/vecmem/utils/impl/copy.ipp:52 Created a vector buffer of type "i" with capacity 2
[vecmem] core/include/vecmem/utils/impl/copy.ipp:52 Created a vector buffer of type "i" with capacity 10
[       OK ] sycl_containers_test.device_memory (70 ms)
[ RUN      ] sycl_containers_test.atomic_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[       OK ] sycl_containers_test.atomic_memory (60 ms)
[ RUN      ] sycl_containers_test.extendable_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/include/vecmem/utils/impl/copy.ipp:34 Prepared a device vector buffer of capacity 100 for use on a device (ptr: 0x7fed86800000)
[       OK ] sycl_containers_test.extendable_memory (65 ms)
[----------] 4 tests from sycl_containers_test (428 ms total)

[----------] 4 tests from sycl_jagged_containers_test
[ RUN      ] sycl_jagged_containers_test.mutate_in_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[       OK ] sycl_jagged_containers_test.mutate_in_kernel (62 ms)
[ RUN      ] sycl_jagged_containers_test.set_in_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 5 copy operation(s)
[       OK ] sycl_jagged_containers_test.set_in_kernel (115 ms)
[ RUN      ] sycl_jagged_containers_test.set_in_contiguous_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/src/memory/contiguous_memory_resource.cpp:28 Allocated 16384 bytes at 0x7fed86800000 from the upstream memory resource
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 1 copy operation(s)
[vecmem] core/src/memory/contiguous_memory_resource.cpp:38 De-allocated 16384 bytes at 0x7fed86800000 using the upstream memory resource
[       OK ] sycl_jagged_containers_test.set_in_contiguous_kernel (116 ms)
[ RUN      ] sycl_jagged_containers_test.filter
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: NVIDIA GeForce RTX 3080
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 5 copy operation(s)
[       OK ] sycl_jagged_containers_test.filter (63 ms)
[----------] 4 tests from sycl_jagged_containers_test (357 ms total)

[----------] 3 tests from sycl_memory_resource_tests/sycl_memory_resource_test
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/device_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/device_resource (10 ms)
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/host_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/host_resource (62 ms)
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/shared_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/shared_resource (1 ms)
[----------] 3 tests from sycl_memory_resource_tests/sycl_memory_resource_test (74 ms total)

[----------] 6 tests from sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/shared_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/shared_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/shared_resource (0 ms)
[----------] 6 tests from sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test (2 ms total)

[----------] Global test environment tear-down
[==========] 17 tests from 4 test suites ran. (861 ms total)
[  PASSED  ] 17 tests.
[bash][Legolas]:build >
```

Builds for the Intel backend (as executed in the CI as well) should not be affected by this update. This of course once again brings up the idea that we might want to create a Docker image for the CI that would hold a "CUDA capable" version of Intel's compiler. But that's for a future update as well.