### PR TITLE
Memory Monitor, main branch (2021.10.11.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -75,6 +75,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/utils/impl/copy.ipp"
    "src/utils/copy.cpp"
    "include/vecmem/utils/debug.hpp"
+   "src/utils/memory_monitor.cpp"
+   "include/vecmem/utils/memory_monitor.hpp"
    "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )
 

--- a/core/include/vecmem/memory/instrumenting_memory_resource.hpp
+++ b/core/include/vecmem/memory/instrumenting_memory_resource.hpp
@@ -73,11 +73,6 @@ public:
     instrumenting_memory_resource(memory_resource& upstream);
 
     /**
-     * @brief Get the total size of outstanding requests.
-     */
-    std::size_t get_outstanding(void) const;
-
-    /**
      * @brief Return a list of memory allocation and deallocation events in
      * chronological order.
      */
@@ -131,11 +126,6 @@ private:
      * deallocation will be forwarded.
      */
     memory_resource& m_upstream;
-
-    /*
-     * This variable tracks the total size of outstanding allocations.
-     */
-    std::size_t m_outstanding = 0;
 
     /*
      * This list stores a chronological set of requests that were passed to

--- a/core/include/vecmem/utils/memory_monitor.hpp
+++ b/core/include/vecmem/utils/memory_monitor.hpp
@@ -1,0 +1,66 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/instrumenting_memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem {
+
+/// Class collecting some basic set of memory allocation statistics
+///
+/// Objects of this class can be used together with
+/// @c vecmem::instrumenting_memory_resource to easily access a common set of
+/// useful performance metrics about an application.
+///
+/// Note that the lifetime of this object must be at least as long as the
+/// lifetime of the connected memory resource!
+///
+class VECMEM_CORE_EXPORT memory_monitor {
+
+public:
+    /// Constructor with a memory resource reference
+    memory_monitor(instrumenting_memory_resource& resource);
+
+    /// Get the total amount of allocations
+    std::size_t total_allocation() const;
+    /// Get the outstanding allocation left after all operations
+    std::size_t outstanding_allocation() const;
+    /// Get the average allocation size
+    std::size_t average_allocation() const;
+    /// Get the maximal concurrent allocation
+    std::size_t maximal_allocation() const;
+
+private:
+    /// @name Function(s) implementing the "monitor interface"
+    /// @{
+
+    /// Function called after successful memory allocations
+    void post_allocate(std::size_t size, std::size_t align, void* ptr);
+    /// Function called before memory de-allocations
+    void pre_deallocate(void* ptr, std::size_t size, std::size_t align);
+
+    /// @}
+
+    /// The number of allocations
+    std::size_t m_n_alloc = 0;
+    /// Total allocation
+    std::size_t m_total_alloc = 0;
+    /// Outstanding allocation
+    std::size_t m_outstanding_alloc = 0;
+    /// Maximum allocation
+    std::size_t m_maximum_alloc = 0;
+
+};  // class memory_monitor
+
+}  // namespace vecmem

--- a/core/src/memory/instrumenting_memory_resource.cpp
+++ b/core/src/memory/instrumenting_memory_resource.cpp
@@ -16,10 +16,6 @@ instrumenting_memory_resource::instrumenting_memory_resource(
     memory_resource &upstream)
     : m_upstream(upstream) {}
 
-std::size_t instrumenting_memory_resource::get_outstanding(void) const {
-    return m_outstanding;
-}
-
 const std::vector<instrumenting_memory_resource::memory_event>
     &instrumenting_memory_resource::get_events(void) const {
     return m_events;
@@ -103,12 +99,6 @@ void *instrumenting_memory_resource::do_allocate(std::size_t size,
      */
     if (ptr == nullptr) {
         throw std::bad_alloc();
-    } else {
-        /*
-         * If the allocation was a success, add the size to the total
-         * outstanding memory pool.
-         */
-        m_outstanding += size;
     }
 
     return ptr;
@@ -123,14 +113,6 @@ void instrumenting_memory_resource::do_deallocate(void *ptr, std::size_t size,
          m_pre_deallocate_hooks) {
         f(ptr, size, align);
     }
-
-    /*
-     * Now, remove the requested amount of memory from the outstanding pool. We
-     * don't really have a notion of deallocation failing, so we always assume
-     * that it succeeds. Calling deallocate on memory that was not succesfully
-     * allocated is UB anyway.
-     */
-    m_outstanding -= size;
 
     /*
      * As with allocation, we calculate the time taken to process this

--- a/core/src/utils/memory_monitor.cpp
+++ b/core/src/utils/memory_monitor.cpp
@@ -1,0 +1,71 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/utils/memory_monitor.hpp"
+
+// System include(s).
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+namespace vecmem {
+
+memory_monitor::memory_monitor(instrumenting_memory_resource& resource) {
+
+    resource.add_post_allocate_hook(
+        [this](std::size_t size, std::size_t align, void* ptr) {
+            this->post_allocate(size, align, ptr);
+        });
+    resource.add_pre_deallocate_hook(
+        [this](void* ptr, std::size_t size, std::size_t align) {
+            this->pre_deallocate(ptr, size, align);
+        });
+}
+
+std::size_t memory_monitor::total_allocation() const {
+
+    return m_total_alloc;
+}
+
+std::size_t memory_monitor::outstanding_allocation() const {
+
+    return m_outstanding_alloc;
+}
+
+std::size_t memory_monitor::average_allocation() const {
+
+    return static_cast<std::size_t>(std::round(
+        static_cast<double>(m_total_alloc) / static_cast<double>(m_n_alloc)));
+}
+
+std::size_t memory_monitor::maximal_allocation() const {
+
+    return m_maximum_alloc;
+}
+
+void memory_monitor::post_allocate(std::size_t size, std::size_t, void* ptr) {
+
+    // Don't do anything on failed allocations.
+    if (ptr == nullptr) {
+        return;
+    }
+
+    ++m_n_alloc;
+    m_total_alloc += size;
+    m_outstanding_alloc += size;
+    m_maximum_alloc = std::max(m_outstanding_alloc, m_maximum_alloc);
+}
+
+void memory_monitor::pre_deallocate(void*, std::size_t size, std::size_t) {
+
+    assert(m_outstanding_alloc >= size);
+    m_outstanding_alloc -= size;
+}
+
+}  // namespace vecmem


### PR DESCRIPTION
With @konradkusiak97 making performance measurements using the [Acts](https://github.com/acts-project/acts) code at the moment, I was wondering how to make the best use of the recently introduced `vecmem::instrumenting_memory_resource` class.

I considered multiple things.
  - Extending `vecmem::instrumenting_memory_resource` to collect some other information beside "current outstanding memory";
  - Adding a couple of helper functions that would take an `std::vector<vecmem::instrumenting_memory_resource::memory_event>` argument, and calculate some useful metrics out of those event objects.

But after some pondering, I rather came up with this... That I would write a class that could listen to events from `vecmem::instrumenting_memory_resource`, and collect some useful metrics with that information. The reason I liked @stephenswat's `vecmem::instrumenting_memory_resource` design was exactly that it made it possible for users to write such classes in their own code. But I thought it could still be useful to provide a basic implementation as part of this project as well.

At the same time, the `vecmem::instrumenting_memory_resource::m_outstanding` variable has bugged me ever since #125. Since it just stands on its own in that class, sort of out of place. So with this update I removed that variable, as `vecmem::memory_monitor` is meant to take over its functionality. This way the `vecmem::instrumenting_memory_resource` and `vecmem::memory_monitor` classes each have their well defined purpose in my mind...

We may still want to add some helper functions that would "analyse" sets of `vecmem::instrumenting_memory_resource::memory_event` objects for some common metrics, but I didn't want to bloat this PR with something like that as well.

What do you think @stephenswat?