### PR TITLE
oneAPI Support Update, main branch (2021.10.24.)

### DIFF
--- a/cmake/vecmem-check-sycl-code-compiles.cmake
+++ b/cmake/vecmem-check-sycl-code-compiles.cmake
@@ -1,0 +1,46 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2021 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Helper function for checking if some SYCL files can be built into an
+# executable.
+function( vecmem_check_sycl_code_compiles _variable )
+
+   # Enable the SYCL language.
+   enable_language( SYCL )
+
+   # Return early, if the result variable already has a value.
+   if( DEFINED ${_variable} )
+      return()
+   endif()
+
+   # Print a greeting message.
+   if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+      message( STATUS "Performing Test ${_variable}" )
+   else()
+      message( CHECK_START "Performing Test ${_variable}" )
+   endif()
+
+   # Perform the build attempt.
+   try_compile( ${_variable}
+      "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_variable}"
+      SOURCES ${ARGN} )
+
+   # Print a result message.
+   if( ${_variable} )
+      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+         message( STATUS "Performing Test ${_variable} - Success" )
+      else()
+         message( CHECK_PASS "Success" )
+      endif()
+   else()
+      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
+         message( STATUS "Performing Test ${_variable} - Failed" )
+      else()
+         message( CHECK_FAIL "Failed" )
+      endif()
+   endif()
+
+endfunction( vecmem_check_sycl_code_compiles )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 # Project include(s).
 include( vecmem-compiler-options-cpp )
+include( vecmem-check-sycl-code-compiles )
 
 # Set up the build of the VecMem core library.
 vecmem_add_library( vecmem_core core
@@ -152,4 +153,28 @@ check_cxx_source_compiles( "
 
 if(NOT VECMEM_HAVE_DEFAULT_RESOURCE)
    target_sources(vecmem_core PRIVATE src/memory/default_resource_polyfill.cpp)
+endif()
+
+# Figure out how to produce SYCL debug printouts.
+if( VECMEM_BUILD_SYCL_LIBRARY )
+
+   # Test which printf function(s) is/are available.
+   vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/ext_oneapi_printf_test.sycl" )
+   vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_ONEAPI_PRINTF
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/oneapi_printf_test.sycl" )
+
+   # Set up the appropriate flag with its help.
+   if( VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF )
+      target_compile_definitions( vecmem_core PUBLIC
+         VECMEM_SYCL_PRINTF_FUNCTION=cl::sycl::ext::oneapi::experimental::printf )
+   elseif( VECMEM_HAVE_SYCL_ONEAPI_PRINTF )
+      target_compile_definitions( vecmem_core PUBLIC
+         VECMEM_SYCL_PRINTF_FUNCTION=cl::sycl::ONEAPI::experimental::printf )
+   else()
+      message( WARNING "No valid printf function found for SYCL."
+         " Enabling debug messages will likely not work." )
+      target_compile_definitions( vecmem_core PUBLIC
+         VECMEM_ONEAPI_PRINTF_FUNCTION=printf )
+   endif()
 endif()

--- a/core/cmake/ext_oneapi_printf_test.sycl
+++ b/core/cmake/ext_oneapi_printf_test.sycl
@@ -1,0 +1,25 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+/// Helper macro, needed for using the printf function.
+#ifdef __SYCL_DEVICE_ONLY__
+#define VECMEM_MSG_ATTRIBUTES __attribute__((opencl_constant))
+#else
+#define VECMEM_MSG_ATTRIBUTES
+#endif
+
+int main() {
+
+    // Print a simple message using
+    // @c cl::sycl::ext::oneapi::experimental::printf.
+    const VECMEM_MSG_ATTRIBUTES char __msg[] = "Test message %i";
+    cl::sycl::ext::oneapi::experimental::printf(__msg, 20);
+    return 0;
+}

--- a/core/cmake/oneapi_printf_test.sycl
+++ b/core/cmake/oneapi_printf_test.sycl
@@ -1,0 +1,24 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+/// Helper macro, needed for using the printf function.
+#ifdef __SYCL_DEVICE_ONLY__
+#define VECMEM_MSG_ATTRIBUTES __attribute__((opencl_constant))
+#else
+#define VECMEM_MSG_ATTRIBUTES
+#endif
+
+int main() {
+
+    // Print a simple message using @c cl::sycl::ONEAPI::experimental::printf.
+    const VECMEM_MSG_ATTRIBUTES char __msg[] = "Test message %i";
+    cl::sycl::ONEAPI::experimental::printf(__msg, 20);
+    return 0;
+}

--- a/core/include/vecmem/memory/impl/atomic.ipp
+++ b/core/include/vecmem/memory/impl/atomic.ipp
@@ -35,7 +35,8 @@ VECMEM_HOST_AND_DEVICE atomic<T>::atomic(pointer ptr) : m_ptr(ptr) {}
 template <typename T>
 VECMEM_HOST_AND_DEVICE void atomic<T>::store(value_type data) {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     volatile pointer addr = m_ptr;
     __threadfence();
     *addr = data;
@@ -49,7 +50,8 @@ VECMEM_HOST_AND_DEVICE void atomic<T>::store(value_type data) {
 template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::load() const -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     volatile pointer addr = m_ptr;
     __threadfence();
     const value_type value = *addr;
@@ -65,7 +67,8 @@ VECMEM_HOST_AND_DEVICE auto atomic<T>::load() const -> value_type {
 template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::exchange(value_type data) -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicExch(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(exchange, m_ptr, data);
@@ -80,7 +83,8 @@ template <typename T>
 VECMEM_HOST_AND_DEVICE bool atomic<T>::compare_exchange_strong(
     reference expected, value_type desired) {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicCAS(m_ptr, expected, desired);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL2(compare_exchange_strong, m_ptr, expected,
@@ -100,7 +104,8 @@ template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_add(value_type data)
     -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicAdd(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(fetch_add, m_ptr, data);
@@ -115,7 +120,8 @@ template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_sub(value_type data)
     -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicSub(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(fetch_sub, m_ptr, data);
@@ -130,7 +136,8 @@ template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_and(value_type data)
     -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicAnd(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(fetch_and, m_ptr, data);
@@ -144,7 +151,8 @@ VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_and(value_type data)
 template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_or(value_type data) -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicOr(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(fetch_or, m_ptr, data);
@@ -159,7 +167,8 @@ template <typename T>
 VECMEM_HOST_AND_DEVICE auto atomic<T>::fetch_xor(value_type data)
     -> value_type {
 
-#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)
+#if (defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__)) && \
+    (!defined(SYCL_LANGUAGE_VERSION))
     return atomicXor(m_ptr, data);
 #elif defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
     return __VECMEM_SYCL_ATOMIC_CALL1(fetch_xor, m_ptr, data);

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -9,7 +9,7 @@
 /// Function name to use for printout operations
 #ifndef VECMEM_PRINTF
 #if defined(SYCL_LANGUAGE_VERSION) || defined(CL_SYCL_LANGUAGE_VERSION)
-#define VECMEM_PRINTF cl::sycl::ONEAPI::experimental::printf
+#define VECMEM_PRINTF VECMEM_SYCL_PRINTF_FUNCTION
 #else
 #define VECMEM_PRINTF printf
 #endif

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_language( SYCL )
 # Project include(s).
 include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
+include( vecmem-check-sycl-code-compiles )
 
 # Set up the build of the VecMem SYCL library.
 vecmem_add_library( vecmem_sycl sycl
@@ -39,45 +40,16 @@ set_target_properties( vecmem_sycl PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden"
    SYCL_VISIBILITY_PRESET "hidden" )
 
-# Helper function for checking if some SYCL files can be built into an
-# executable.
-function( check_sycl_code_compiles _variable )
-   if( DEFINED ${_variable} )
-      return()
-   endif()
-   if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
-      message( STATUS "Performing Test ${_variable}" )
-   else()
-      message( CHECK_START "Performing Test ${_variable}" )
-   endif()
-   try_compile( ${_variable}
-      "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_variable}"
-      SOURCES ${ARGN} )
-   if( ${_variable} )
-      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
-         message( STATUS "Performing Test ${_variable} - Success" )
-      else()
-         message( CHECK_PASS "Success" )
-      endif()
-   else()
-      if( ${CMAKE_VERSION} VERSION_LESS 3.17 )
-         message( STATUS "Performing Test ${_variable} - Failed" )
-      else()
-         message( CHECK_FAIL "Failed" )
-      endif()
-   endif()
-endfunction( check_sycl_code_compiles )
-
 # Check if assertions work out of the box in the build.
-check_sycl_code_compiles( VECMEM_SYCL_HAVE_ASSERT
+vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_ASSERT
    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl" )
 
 # If not, check if it can be solved as described in:
 #   https://github.com/intel/llvm/issues/3385
-if( NOT VECMEM_SYCL_HAVE_ASSERT )
+if( NOT VECMEM_HAVE_SYCL_ASSERT )
 
    # Check if the "CUDA polyfill" can make the test work.
-   check_sycl_code_compiles( VECMEM_SYCL_HAVE_ASSERT_POLYFILL
+   vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_CUDA_ASSERT_POLYFILL
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl"
       "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/sycl/cuda_assert_polyfill.sycl" )
 
@@ -86,7 +58,7 @@ if( NOT VECMEM_SYCL_HAVE_ASSERT )
    # Device code just does not work across binary boundaries. So we can't just
    # put the code into vecmem::sycl. Instead let's add a separate STATIC
    # library, which vecmem::sycl would depend on.
-   if( VECMEM_SYCL_HAVE_ASSERT_POLYFILL )
+   if( VECMEM_HAVE_SYCL_CUDA_ASSERT_POLYFILL )
 
       # Set up the vecmem::sycl_polyfill library.
       vecmem_add_library( vecmem_sycl_polyfill sycl_polyfill TYPE STATIC
@@ -96,6 +68,6 @@ if( NOT VECMEM_SYCL_HAVE_ASSERT )
    else()
       # If not even this worked, then warn the user, and see what happens...
       message( WARNING "Assertions are not available for SYCL device code."
-         "The build will likely fail." )
+         " Debug builds will likely fail." )
    endif()
 endif()


### PR DESCRIPTION
This is to make the code compatible with the very latest version of [intel/llvm](https://github.com/intel/llvm).
  - Made the previous `check_sycl_code_compiles(...)` function into `vecmem_check_sycl_code_compiles(...)`, which could be used in any part of the project.
    * This was necessary for figuring out which SYCL `printf` function to use, at configuration time.
  - Taught the `vecmem::atomic` code that SYCL and HIP flags may be defined at the same time, in which case SYCL code should be used.

The goal with all of this was to be able to build the project with the experimental support for AMD hardware. Which, with this version of the code, can be done like the following:

```
[bash][Legolas]:build > source ~/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/setup.sh 
Configured CUDA from: /home/krasznaa/software/cuda/11.4.2/x86_64-ubuntu2004
Configured Clang from: /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt
[bash][Legolas]:build > source ~/software/cmake/3.21.3/x86_64-ubuntu2004-gcc9-opt/setup.sh 
Configured CMake from: /home/krasznaa/software/cmake/3.21.3/x86_64-ubuntu2004-gcc9-opt
[bash][Legolas]:build > export SYCLCXX="clang++ -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx803"
[bash][Legolas]:build > cmake -DCMAKE_BUILD_TYPE=Release -DVECMEM_DEBUG_MSG_LVL=2 ../vecmem/
-- The CXX compiler identification is Clang 14.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for a CUDA compiler
-- Looking for a CUDA compiler - /home/krasznaa/software/cuda/11.4.2/x86_64-ubuntu2004/bin/nvcc
-- Looking for a HIP compiler
-- Looking for a HIP compiler - /usr/bin/hipcc
-- Looking for a SYCL compiler
-- Looking for a SYCL compiler - /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/bin/clang++
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE
-- Performing Test VECMEM_HAVE_PMR_MEMORY_RESOURCE - Success
-- Using memory resource types from the std::pmr namespace
-- Performing Test VECMEM_HAVE_DEFAULT_RESOURCE
-- Performing Test VECMEM_HAVE_DEFAULT_RESOURCE - Success
-- Check for working SYCL compiler: /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/bin/clang++
-- Check for working SYCL compiler: /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/bin/clang++ - works
-- Performing Test VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF
-- Performing Test VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF - Success
-- Performing Test VECMEM_HAVE_SYCL_ONEAPI_PRINTF
-- Performing Test VECMEM_HAVE_SYCL_ONEAPI_PRINTF - Failed
-- The CUDA compiler identification is NVIDIA 11.4.120
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Check for working CUDA compiler: /home/krasznaa/software/cuda/11.4.2/x86_64-ubuntu2004/bin/nvcc - skipped
-- Detecting CUDA compile features
-- Detecting CUDA compile features - done
-- Found CUDAToolkit: /home/krasznaa/software/cuda/11.4.2/x86_64-ubuntu2004/include (found version "11.4.120") 
-- Looking for C++ include pthread.h
-- Looking for C++ include pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Check for working HIP compiler: /usr/bin/hipcc
-- Check for working HIP compiler: /usr/bin/hipcc - works
-- Found HIPToolkit: /opt/rocm/include (found version "4.3.21331") 
-- Performing Test VECMEM_HAVE_SYCL_ASSERT
-- Performing Test VECMEM_HAVE_SYCL_ASSERT - Failed
-- Performing Test VECMEM_HAVE_SYCL_CUDA_ASSERT_POLYFILL
-- Performing Test VECMEM_HAVE_SYCL_CUDA_ASSERT_POLYFILL - Failed
CMake Warning at sycl/CMakeLists.txt:70 (message):
  Assertions are not available for SYCL device code.Debug builds will likely
  fail.


-- Building GoogleTest as part of the VecMem project
-- The C compiler identification is Clang 14.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/krasznaa/software/intel/clang/nightly-20211023/x86_64-ubuntu2004-gcc9-opt/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Found Python: /usr/bin/python3.8 (found version "3.8.10") found components: Interpreter 
-- Configuring done
-- Generating done
-- Build files have been written to: /data/ssd-1tb/projects/vecmem/build
[bash][Legolas]:build >
```

A couple of comments with this:
  - The very latest version of the Intel code is finally compatible with CUDA 11. So we may be able to drop the C\+\+14 support from our device code at one point. Though for now I wouldn't be too hasty.
  - Assertions do not work in the AMD code at the moment. :frowning: But the silver lining is that I very much hope that we will be able to produce a "polyfill" for this platform as well later on. But for now we need to stick to "Release" builds on this platform.

The Intel implementation is quite experimental for the moment, the tests do not all succeed on my AMD card.

```
[bash][Legolas]:build > SYCL_DEVICE_FILTER=hip ./bin/vecmem_test_sycl    
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
Running main() from /data/ssd-1tb/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 18 tests from 4 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from sycl_containers_test
[ RUN      ] sycl_containers_test.shared_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[       OK ] sycl_containers_test.shared_memory (2 ms)
[ RUN      ] sycl_containers_test.device_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:52 Created a vector buffer of type "i" with capacity 2
[vecmem] core/include/vecmem/utils/impl/copy.ipp:52 Created a vector buffer of type "i" with capacity 10
[       OK ] sycl_containers_test.device_memory (5 ms)
[ RUN      ] sycl_containers_test.atomic_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[       OK ] sycl_containers_test.atomic_memory (0 ms)
[ RUN      ] sycl_containers_test.extendable_memory
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:34 Prepared a device vector buffer of capacity 100 for use on a device (ptr: 0x210160f000)
[       OK ] sycl_containers_test.extendable_memory (1 ms)
[----------] 4 tests from sycl_containers_test (10 ms total)

[----------] 5 tests from sycl_jagged_containers_test
[ RUN      ] sycl_jagged_containers_test.mutate_in_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[       OK ] sycl_jagged_containers_test.mutate_in_kernel (1 ms)
[ RUN      ] sycl_jagged_containers_test.set_in_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 5 copy operation(s)
[       OK ] sycl_jagged_containers_test.set_in_kernel (2 ms)
[ RUN      ] sycl_jagged_containers_test.set_in_contiguous_kernel
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/src/memory/contiguous_memory_resource.cpp:28 Allocated 16384 bytes at 0x10e8000 from the upstream memory resource
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 1 copy operation(s)
[vecmem] core/src/memory/contiguous_memory_resource.cpp:38 De-allocated 16384 bytes at 0x10e8000 using the upstream memory resource
[       OK ] sycl_jagged_containers_test.set_in_contiguous_kernel (2 ms)
[ RUN      ] sycl_jagged_containers_test.filter
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 2 copy operation(s)
/data/ssd-1tb/projects/vecmem/vecmem/tests/sycl/test_sycl_jagged_containers.sycl:415: Failure
Expected equality of these values:
  std::set<int>(output[0].begin(), output[0].end())
    Which is: {}
  std::set<int>({1, 3})
    Which is: { 1, 3 }
/data/ssd-1tb/projects/vecmem/vecmem/tests/sycl/test_sycl_jagged_containers.sycl:417: Failure
Expected equality of these values:
  std::set<int>(output[1].begin(), output[1].end())
    Which is: {}
  std::set<int>({5})
    Which is: { 5 }
/data/ssd-1tb/projects/vecmem/vecmem/tests/sycl/test_sycl_jagged_containers.sycl:419: Failure
Expected equality of these values:
  std::set<int>(output[2].begin(), output[2].end())
    Which is: {}
  std::set<int>({7, 9})
    Which is: { 7, 9 }
[  FAILED  ] sycl_jagged_containers_test.filter (3 ms)
[ RUN      ] sycl_jagged_containers_test.zero_capacity
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:32 Created an "owning wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:43 Created a "view wrapper" around a queue on device: Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 5 copy operation(s)
[vecmem] core/include/vecmem/utils/impl/copy.ipp:163 Prepared a jagged device vector buffer of size 6 for use on a device
[vecmem] core/include/vecmem/utils/impl/copy.ipp:430 Copied the payload of a jagged vector of type "i" with 5 copy operation(s)
[       OK ] sycl_jagged_containers_test.zero_capacity (4 ms)
[----------] 5 tests from sycl_jagged_containers_test (14 ms total)

[----------] 3 tests from sycl_memory_resource_tests/sycl_memory_resource_test
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/device_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/device_resource (0 ms)
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/host_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/host_resource (7 ms)
[ RUN      ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/shared_resource
[       OK ] sycl_memory_resource_tests/sycl_memory_resource_test.allocations/shared_resource (7 ms)
[----------] 3 tests from sycl_memory_resource_tests/sycl_memory_resource_test (15 ms total)

[----------] 6 tests from sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.int_value/shared_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.double_value/shared_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/host_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/host_resource (0 ms)
[ RUN      ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/shared_resource
[       OK ] sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test.custom_value/shared_resource (0 ms)
[----------] 6 tests from sycl_host_accessible_memory_resource_tests/sycl_host_accessible_memory_resource_test (0 ms total)

[----------] Global test environment tear-down
[==========] 18 tests from 4 test suites ran. (40 ms total)
[  PASSED  ] 17 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] sycl_jagged_containers_test.filter

 1 FAILED TEST
[bash][Legolas]:build >
```

They do acknowledge that at the moment there are still some problems with atomics on this platform.

https://intel.github.io/llvm-docs/GetStartedGuide.html#hip-back-end-limitations

So I guess this is as good as it gets for now.