### PR TITLE
GoogleTest Separation, main branch (2021.10.25.)

### DIFF
--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -7,9 +7,13 @@
 # Guard against multiple includes.
 include_guard( GLOBAL )
 
+# CMake version requirement.
+cmake_minimum_required( VERSION 3.10 )
+
 # CMake include(s).
 include( CMakeParseArguments )
 include( GenerateExportHeader )
+include( GoogleTest )
 
 # Helper function for setting up the VecMem libraries.
 #
@@ -79,8 +83,7 @@ function( vecmem_add_test name )
    endif()
 
    # Run the executable as the test.
-   add_test( NAME ${test_exe_name}
-      COMMAND $<TARGET_FILE:${test_exe_name}> )
+   gtest_add_tests( TARGET ${test_exe_name} SOURCES ${ARG_UNPARSED_ARGUMENTS} )
 
 endfunction( vecmem_add_test )
 


### PR DESCRIPTION
This is just a proposal, we don't have to definitely go for this...

I was reminded recently that one can integrate GoogleTest tests a little better with CTest than we're doing it now. What we're doing is not too bad, but doing what I propose in this PR, may be nicer.

So CMake has a built-in module, [GoogleTest](https://cmake.org/cmake/help/latest/module/GoogleTest.html), which can scan a piece of code for GTest's macros, and then set up separate CTest tests for each test case. By calling a single test executable with different command line arguments, selecting a separate test case for each CTest job.

So that running CTest would go from looking like:

```
[bash][atlas]:build > ctest
Test project /home/krasznaa/ATLAS/projects/vecmem/build
    Start 1: vecmem_test_core
1/4 Test #1: vecmem_test_core .................   Passed    2.46 sec
    Start 2: vecmem_test_cuda
2/4 Test #2: vecmem_test_cuda .................   Passed    0.18 sec
    Start 3: vecmem_test_hip
3/4 Test #3: vecmem_test_hip ..................   Passed    0.15 sec
    Start 4: vecmem_test_sycl
4/4 Test #4: vecmem_test_sycl .................   Passed    2.49 sec

100% tests passed, 0 tests failed out of 4

Total Test time (real) =   5.28 sec
[bash][atlas]:build >
```

To:

```
[bash][atlas]:build > ctest
Test project /home/krasznaa/ATLAS/projects/vecmem/build
        Start   1: core_allocator_test.basic
  1/118 Test   #1: core_allocator_test.basic ........................................   Passed    0.00 sec
        Start   2: core_allocator_test.primitive
  2/118 Test   #2: core_allocator_test.primitive ....................................   Passed    0.00 sec
        Start   3: core_allocator_test.array
  3/118 Test   #3: core_allocator_test.array ........................................   Passed    0.00 sec
...
        Start 116: sycl_jagged_containers_test.set_in_contiguous_kernel
116/118 Test #116: sycl_jagged_containers_test.set_in_contiguous_kernel .............   Passed    0.33 sec
        Start 117: sycl_jagged_containers_test.filter
117/118 Test #117: sycl_jagged_containers_test.filter ...............................   Passed    0.33 sec
        Start 118: sycl_jagged_containers_test.zero_capacity
118/118 Test #118: sycl_jagged_containers_test.zero_capacity ........................   Passed    0.33 sec

100% tests passed, 0 tests failed out of 118

Total Test time (real) =   7.87 sec
[bash][atlas]:build >
```

(Cumulatively the tests are a little slower, as the GPU tests incur the "startup overhead" multiple times like this.)

What do you think? Would it be better to have the tests be declared like this to CTest, or in the way that we do it now?

P.S. Note that the "templated tests" show up as a single CTest item. With names like:

```
        Start 106: */sycl_memory_resource_test.allocations/*
106/118 Test #106: */sycl_memory_resource_test.allocations/* ........................   Passed    0.03 sec
        Start 107: */sycl_host_accessible_memory_resource_test.int_value/*
107/118 Test #107: */sycl_host_accessible_memory_resource_test.int_value/* ..........   Passed    0.03 sec
        Start 108: */sycl_host_accessible_memory_resource_test.double_value/*
108/118 Test #108: */sycl_host_accessible_memory_resource_test.double_value/* .......   Passed    0.03 sec
        Start 109: */sycl_host_accessible_memory_resource_test.custom_value/*
109/118 Test #109: */sycl_host_accessible_memory_resource_test.custom_value/* .......   Passed    0.03 sec
```

I did check, these tests do run every instantiation of these tests "internally" correctly.