### PR TITLE
Deduplicate common memory resource test definition

### DIFF
--- a/tests/common/tests/test_generic_basic.hpp
+++ b/tests/common/tests/test_generic_basic.hpp
@@ -1,0 +1,32 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "vecmem/memory/memory_resource.hpp"
+
+/// Base test case for the CUDA memory resources
+///
+/// This just makes sure that the memory resources defined in the
+/// @c vecmem::cuda library are more-or-less functional.
+///
+class memory_resource_test_basic
+    : public testing::TestWithParam<vecmem::memory_resource*> {};
+
+/// Perform some very basic tests that do not need host accessibility
+TEST_P(memory_resource_test_basic, allocations) {
+
+    vecmem::memory_resource* resource = GetParam();
+    for (std::size_t size = 1000; size < 100000; size += 1000) {
+        void* ptr = resource->allocate(size);
+        resource->deallocate(ptr, size);
+    }
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memory_resource_test_basic);

--- a/tests/common/tests/test_generic_host_accessible.hpp
+++ b/tests/common/tests/test_generic_host_accessible.hpp
@@ -1,0 +1,102 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <vector>
+
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+
+/// Custom non-trivial type used in the tests.
+struct TestType {
+    TestType(int a, long b = 123) : m_a(a), m_b(b) {}
+    int m_a;
+    long m_b;
+};
+/// Helper operator for @c TestType
+bool operator==(const TestType& value1, const TestType& value2) {
+    return ((value1.m_a == value2.m_a) && (value1.m_b == value2.m_b));
+}
+
+/// Comparison operator for fundamental types
+template <typename T>
+bool almost_equal(const T& value1, const T& value2) {
+    return (std::abs(value1 - value2) < 0.001);
+}
+
+/// Comparison operator for the custom test type
+template <>
+bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
+    return (value1 == value2);
+}
+
+/// Test case for host-accessible CUDA memory resources
+///
+/// Providing a slightly more elaborate test for memory resources that can be
+/// read/written from host code.
+///
+class memory_resource_test_host_accessible
+    : public testing::TestWithParam<vecmem::memory_resource*> {
+
+protected:
+    /// Function performing some basic tests using @c vecmem::vector
+    template <typename T>
+    void test_host_accessible_resource(vecmem::vector<T>& test_vector) {
+
+        // Set up the test vector, and create a reference vector.
+        std::vector<T> reference_vector;
+        reference_vector.reserve(100);
+        test_vector.reserve(100);
+
+        // Fill them up with some dummy content.
+        for (int i = 0; i < 20; ++i) {
+            reference_vector.push_back(i * 2);
+            test_vector.push_back(i * 2);
+        }
+        // Make sure that they are the same.
+        EXPECT_EQ(reference_vector.size(), test_vector.size());
+        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
+                               test_vector.begin()));
+
+        // Remove a couple of elements from the vectors.
+        for (int i : {26, 38, 25}) {
+            (void)std::remove(reference_vector.begin(), reference_vector.end(),
+                              i);
+            (void)std::remove(test_vector.begin(), test_vector.end(), i);
+        }
+        // Make sure that they are still the same.
+        EXPECT_EQ(reference_vector.size(), test_vector.size());
+        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
+                               test_vector.begin(), ::almost_equal<T>));
+    }
+
+};  // class cuda_host_accessible_memory_resource_test
+
+/// Test the host accessible memory resource with an integer type.
+TEST_P(memory_resource_test_host_accessible, int_value) {
+    vecmem::vector<int> test_vector(GetParam());
+    test_host_accessible_resource(test_vector);
+}
+
+/// Test the host accessible memory resource with a floating point type.
+TEST_P(memory_resource_test_host_accessible, double_value) {
+    vecmem::vector<double> test_vector(GetParam());
+    test_host_accessible_resource(test_vector);
+}
+
+/// Test the host accessible memory resource with a custom type.
+TEST_P(memory_resource_test_host_accessible, custom_value) {
+    vecmem::vector< ::TestType> test_vector(GetParam());
+    test_host_accessible_resource(test_vector);
+}
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(
+    memory_resource_test_host_accessible);

--- a/tests/common/tests/test_generic_stress.hpp
+++ b/tests/common/tests/test_generic_stress.hpp
@@ -1,0 +1,51 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+
+/// Test case for the "stress tests"
+class memory_resource_test_stress
+    : public testing::TestWithParam<vecmem::memory_resource*> {};
+
+/// Test that the memory resource would behave correctly with a large number
+/// of allocations/de-allocations.
+TEST_P(memory_resource_test_stress, stress_test) {
+
+    // Repeat the allocations multiple times.
+    for (int i = 0; i < 100; ++i) {
+
+        // Create an object that would hold on to the allocated memory
+        // "for one iteration".
+        std::vector<vecmem::vector<int> > vectors;
+
+        // Fill a random number of vectors.
+        const int n_vectors = std::rand() % 100;
+        for (int j = 0; j < n_vectors; ++j) {
+
+            // Fill them with a random number of "constant" elements.
+            vectors.emplace_back(GetParam());
+            const int n_elements = std::rand() % 100;
+            for (int k = 0; k < n_elements; ++k) {
+                vectors.back().push_back(j);
+            }
+        }
+
+        // Check that all vectors have the intended content after all of this.
+        for (int j = 0; j < n_vectors; ++j) {
+            for (int value : vectors.at(j)) {
+                EXPECT_EQ(value, j);
+            }
+        }
+    }
+}

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -7,7 +7,9 @@
 
 // Local include(s).
 #include "../common/memory_resource_name_gen.hpp"
-#include "vecmem/containers/vector.hpp"
+#include "../common/tests/test_generic_basic.hpp"
+#include "../common/tests/test_generic_host_accessible.hpp"
+#include "../common/tests/test_generic_stress.hpp"
 #include "vecmem/memory/arena_memory_resource.hpp"
 #include "vecmem/memory/binary_page_memory_resource.hpp"
 #include "vecmem/memory/choice_memory_resource.hpp"
@@ -22,139 +24,6 @@
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
-
-// System include(s).
-#include <algorithm>
-#include <cmath>
-#include <cstdlib>
-#include <vector>
-
-namespace {
-
-/// Custom non-trivial type used in the tests.
-struct TestType {
-    TestType(int a, long b = 123) : m_a(a), m_b(b) {}
-    int m_a;
-    long m_b;
-};
-/// Helper operator for @c TestType
-bool operator==(const TestType& value1, const TestType& value2) {
-    return ((value1.m_a == value2.m_a) && (value1.m_b == value2.m_b));
-}
-
-/// Comparison operator for fundamental types
-template <typename T>
-bool almost_equal(const T& value1, const T& value2) {
-    return (std::abs(value1 - value2) < 0.001);
-}
-
-/// Comparison operator for the custom test type
-template <>
-bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
-    return (value1 == value2);
-}
-
-}  // namespace
-
-/// Test case for the core memory resources
-///
-/// This just makes sure that the memory resources defined in the
-/// @c vecmem::core library are more-or-less functional. Detailed tests of the
-/// different memory resources are implemented in other test cases.
-///
-class core_memory_resource_test
-    : public testing::TestWithParam<vecmem::memory_resource*> {
-
-protected:
-    /// Function performing some basic tests using @c vecmem::vector
-    template <typename T>
-    void test_resource(vecmem::vector<T>& test_vector) {
-
-        // Set up the test vector, and create a reference vector.
-        std::vector<T> reference_vector;
-        reference_vector.reserve(100);
-        test_vector.reserve(100);
-
-        // Fill them up with some dummy content.
-        for (int i = 0; i < 20; ++i) {
-            reference_vector.push_back(i * 2);
-            test_vector.push_back(i * 2);
-        }
-        // Make sure that they are the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin()));
-
-        // Remove a couple of elements from the vectors.
-        for (int i : {26, 38, 25}) {
-            (void)std::remove(reference_vector.begin(), reference_vector.end(),
-                              i);
-            (void)std::remove(test_vector.begin(), test_vector.end(), i);
-        }
-        // Make sure that they are still the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin(), ::almost_equal<T>));
-    }
-
-};  // class core_memory_resource_test
-
-/// Test the memory resource with an integer type.
-TEST_P(core_memory_resource_test, int_value) {
-
-    vecmem::vector<int> test_vector(GetParam());
-    test_resource(test_vector);
-}
-
-/// Test the memory resource with a floating point type.
-TEST_P(core_memory_resource_test, double_value) {
-
-    vecmem::vector<double> test_vector(GetParam());
-    test_resource(test_vector);
-}
-
-/// Test the memory resource with a custom type.
-TEST_P(core_memory_resource_test, custom_value) {
-
-    vecmem::vector< ::TestType> test_vector(GetParam());
-    test_resource(test_vector);
-}
-
-/// Test case for the "stress tests"
-class core_memory_resource_stress_test
-    : public testing::TestWithParam<vecmem::memory_resource*> {};
-
-/// Test that the memory resource would behave correctly with a large number
-/// of allocations/de-allocations.
-TEST_P(core_memory_resource_stress_test, stress_test) {
-
-    // Repeat the allocations multiple times.
-    for (int i = 0; i < 100; ++i) {
-
-        // Create an object that would hold on to the allocated memory
-        // "for one iteration".
-        std::vector<vecmem::vector<int> > vectors;
-
-        // Fill a random number of vectors.
-        const int n_vectors = std::rand() % 100;
-        for (int j = 0; j < n_vectors; ++j) {
-
-            // Fill them with a random number of "constant" elements.
-            vectors.emplace_back(GetParam());
-            const int n_elements = std::rand() % 100;
-            for (int k = 0; k < n_elements; ++k) {
-                vectors.back().push_back(j);
-            }
-        }
-
-        // Check that all vectors have the intended content after all of this.
-        for (int j = 0; j < n_vectors; ++j) {
-            for (int value : vectors.at(j)) {
-                EXPECT_EQ(value, j);
-            }
-        }
-    }
-}
 
 // Utility memory resource used to define others.
 static vecmem::terminal_memory_resource terminal_resource;
@@ -186,13 +55,37 @@ static vecmem::debug_memory_resource debug_arena_resource(arena_resource);
 
 // Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(
-    core_memory_resource_tests, core_memory_resource_test,
-    testing::Values(&host_resource, &binary_resource, &contiguous_resource,
-                    &arena_resource, &instrumenting_resource,
-                    &identity_resource, &conditional_resource,
-                    &coalescing_resource_1, &coalescing_resource_2,
-                    &choice_resource, &debug_host_resource,
-                    &debug_binary_resource, &debug_arena_resource),
+    core_memory_resource_tests, memory_resource_test_basic,
+    testing::Values(&host_resource, &binary_resource, &arena_resource,
+                    &instrumenting_resource, &identity_resource,
+                    &conditional_resource, &coalescing_resource_1,
+                    &coalescing_resource_2, &choice_resource,
+                    &debug_host_resource, &debug_binary_resource,
+                    &debug_arena_resource),
+    vecmem::testing::memory_resource_name_gen(
+        {{&host_resource, "host_resource"},
+         {&binary_resource, "binary_resource"},
+         {&contiguous_resource, "contiguous_resource"},
+         {&arena_resource, "arena_resource"},
+         {&instrumenting_resource, "instrumenting_resource"},
+         {&identity_resource, "identity_resource"},
+         {&conditional_resource, "conditional_resource"},
+         {&coalescing_resource_1, "coalescing_resource_1"},
+         {&coalescing_resource_2, "coalescing_resource_2"},
+         {&choice_resource, "choice_resource"},
+         {&debug_host_resource, "debug_host_resource"},
+         {&debug_binary_resource, "debug_binary_resource"},
+         {&debug_arena_resource, "debug_arena_resource"}}));
+
+// Instantiate the test suite(s).
+INSTANTIATE_TEST_SUITE_P(
+    core_memory_resource_tests, memory_resource_test_host_accessible,
+    testing::Values(&host_resource, &binary_resource, &arena_resource,
+                    &instrumenting_resource, &identity_resource,
+                    &conditional_resource, &coalescing_resource_1,
+                    &coalescing_resource_2, &choice_resource,
+                    &debug_host_resource, &debug_binary_resource,
+                    &debug_arena_resource),
     vecmem::testing::memory_resource_name_gen(
         {{&host_resource, "host_resource"},
          {&binary_resource, "binary_resource"},
@@ -209,7 +102,7 @@ INSTANTIATE_TEST_SUITE_P(
          {&debug_arena_resource, "debug_arena_resource"}}));
 
 INSTANTIATE_TEST_SUITE_P(
-    core_memory_resource_stress_tests, core_memory_resource_stress_test,
+    core_memory_resource_stress_tests, memory_resource_test_stress,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
                     &instrumenting_resource, &identity_resource,
                     &conditional_resource, &coalescing_resource_1,

--- a/tests/cuda/test_cuda_memory_resources.cpp
+++ b/tests/cuda/test_cuda_memory_resources.cpp
@@ -7,7 +7,8 @@
 
 // Local include(s).
 #include "../common/memory_resource_name_gen.hpp"
-#include "vecmem/containers/vector.hpp"
+#include "../common/tests/test_generic_basic.hpp"
+#include "../common/tests/test_generic_host_accessible.hpp"
 #include "vecmem/memory/cuda/device_memory_resource.hpp"
 #include "vecmem/memory/cuda/host_memory_resource.hpp"
 #include "vecmem/memory/cuda/managed_memory_resource.hpp"
@@ -15,36 +16,14 @@
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
-// System include(s).
-#include <algorithm>
-#include <cmath>
-#include <vector>
-
 // Memory resources.
 static vecmem::cuda::device_memory_resource device_resource;
 static vecmem::cuda::host_memory_resource host_resource;
 static vecmem::cuda::managed_memory_resource managed_resource;
 
-/// Base test case for the CUDA memory resources
-///
-/// This just makes sure that the memory resources defined in the
-/// @c vecmem::cuda library are more-or-less functional.
-///
-class cuda_memory_resource_test
-    : public testing::TestWithParam<vecmem::memory_resource*> {};
-
-/// Perform some very basic tests that do not need host accessibility
-TEST_P(cuda_memory_resource_test, allocations) {
-
-    vecmem::memory_resource* resource = GetParam();
-    for (std::size_t size = 1000; size < 100000; size += 1000) {
-        void* ptr = resource->allocate(size);
-        resource->deallocate(ptr, size);
-    }
-}
-
 // Instantiate the allocation tests on all of the resources.
-INSTANTIATE_TEST_SUITE_P(cuda_memory_resource_tests, cuda_memory_resource_test,
+INSTANTIATE_TEST_SUITE_P(cuda_memory_resource_tests_basic,
+                         memory_resource_test_basic,
                          testing::Values(&device_resource, &host_resource,
                                          &managed_resource),
                          vecmem::testing::memory_resource_name_gen(
@@ -52,99 +31,9 @@ INSTANTIATE_TEST_SUITE_P(cuda_memory_resource_tests, cuda_memory_resource_test,
                               {&host_resource, "host_resource"},
                               {&managed_resource, "managed_resource"}}));
 
-namespace {
-
-/// Custom non-trivial type used in the tests.
-struct TestType {
-    TestType(int a, long b = 123) : m_a(a), m_b(b) {}
-    int m_a;
-    long m_b;
-};
-/// Helper operator for @c TestType
-bool operator==(const TestType& value1, const TestType& value2) {
-    return ((value1.m_a == value2.m_a) && (value1.m_b == value2.m_b));
-}
-
-/// Comparison operator for fundamental types
-template <typename T>
-bool almost_equal(const T& value1, const T& value2) {
-    return (std::abs(value1 - value2) < 0.001);
-}
-
-/// Comparison operator for the custom test type
-template <>
-bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
-    return (value1 == value2);
-}
-
-}  // namespace
-
-/// Test case for host-accessible CUDA memory resources
-///
-/// Providing a slightly more elaborate test for memory resources that can be
-/// read/written from host code.
-///
-class cuda_host_accessible_memory_resource_test
-    : public cuda_memory_resource_test {
-
-protected:
-    /// Function performing some basic tests using @c vecmem::vector
-    template <typename T>
-    void test_host_accessible_resource(vecmem::vector<T>& test_vector) {
-
-        // Set up the test vector, and create a reference vector.
-        std::vector<T> reference_vector;
-        reference_vector.reserve(100);
-        test_vector.reserve(100);
-
-        // Fill them up with some dummy content.
-        for (int i = 0; i < 20; ++i) {
-            reference_vector.push_back(i * 2);
-            test_vector.push_back(i * 2);
-        }
-        // Make sure that they are the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin()));
-
-        // Remove a couple of elements from the vectors.
-        for (int i : {26, 38, 25}) {
-            (void)std::remove(reference_vector.begin(), reference_vector.end(),
-                              i);
-            (void)std::remove(test_vector.begin(), test_vector.end(), i);
-        }
-        // Make sure that they are still the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin(), ::almost_equal<T>));
-    }
-
-};  // class cuda_host_accessible_memory_resource_test
-
-/// Test the host accessible memory resource with an integer type.
-TEST_P(cuda_host_accessible_memory_resource_test, int_value) {
-
-    vecmem::vector<int> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a floating point type.
-TEST_P(cuda_host_accessible_memory_resource_test, double_value) {
-
-    vecmem::vector<double> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a custom type.
-TEST_P(cuda_host_accessible_memory_resource_test, custom_value) {
-
-    vecmem::vector< ::TestType> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
 // Instantiate the full test suite on the host-accessible memory resources.
 INSTANTIATE_TEST_SUITE_P(cuda_host_accessible_memory_resource_tests,
-                         cuda_host_accessible_memory_resource_test,
+                         memory_resource_test_host_accessible,
                          testing::Values(&host_resource, &managed_resource),
                          vecmem::testing::memory_resource_name_gen(
                              {{&host_resource, "host_resource"},

--- a/tests/hip/test_hip_memory_resources.cpp
+++ b/tests/hip/test_hip_memory_resources.cpp
@@ -7,139 +7,28 @@
 
 // Local include(s).
 #include "../common/memory_resource_name_gen.hpp"
-#include "vecmem/containers/vector.hpp"
+#include "../common/tests/test_generic_basic.hpp"
+#include "../common/tests/test_generic_host_accessible.hpp"
 #include "vecmem/memory/hip/device_memory_resource.hpp"
 #include "vecmem/memory/hip/host_memory_resource.hpp"
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
-// System include(s).
-#include <algorithm>
-#include <cmath>
-#include <vector>
-
 // Memory resources.
 static vecmem::hip::device_memory_resource device_resource;
 static vecmem::hip::host_memory_resource host_resource;
 
-/// Base test case for the HIP memory resources
-///
-/// This just makes sure that the memory resources defined in the
-/// @c vecmem::hip library are more-or-less functional.
-///
-class hip_memory_resource_test
-    : public testing::TestWithParam<vecmem::memory_resource*> {};
-
-/// Perform some very basic tests that do not need host accessibility
-TEST_P(hip_memory_resource_test, allocations) {
-
-    vecmem::memory_resource* resource = GetParam();
-    for (std::size_t size = 1000; size < 100000; size += 1000) {
-        void* ptr = resource->allocate(size);
-        resource->deallocate(ptr, size);
-    }
-}
-
 // Instantiate the allocation tests on all of the resources.
-INSTANTIATE_TEST_SUITE_P(hip_memory_resource_tests, hip_memory_resource_test,
+INSTANTIATE_TEST_SUITE_P(hip_memory_resource_tests, memory_resource_test_basic,
                          testing::Values(&device_resource, &host_resource),
                          vecmem::testing::memory_resource_name_gen(
                              {{&device_resource, "device_resource"},
                               {&host_resource, "host_resource"}}));
 
-namespace {
-
-/// Custom non-trivial type used in the tests.
-struct TestType {
-    TestType(int a, long b = 123) : m_a(a), m_b(b) {}
-    int m_a;
-    long m_b;
-};
-/// Helper operator for @c TestType
-bool operator==(const TestType& value1, const TestType& value2) {
-    return ((value1.m_a == value2.m_a) && (value1.m_b == value2.m_b));
-}
-
-/// Comparison operator for fundamental types
-template <typename T>
-bool almost_equal(const T& value1, const T& value2) {
-    return (std::abs(value1 - value2) < 0.001);
-}
-
-/// Comparison operator for the custom test type
-template <>
-bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
-    return (value1 == value2);
-}
-
-}  // namespace
-
-/// Test case for host-accessible (the) HIP memory resource(s)
-///
-/// Providing a slightly more elaborate test for memory resources that can be
-/// read/written from host code.
-///
-class hip_host_accessible_memory_resource_test
-    : public hip_memory_resource_test {
-
-protected:
-    /// Function performing some basic tests using @c vecmem::vector
-    template <typename T>
-    void test_host_accessible_resource(vecmem::vector<T>& test_vector) {
-
-        // Set up the test vector, and create a reference vector.
-        std::vector<T> reference_vector;
-        reference_vector.reserve(100);
-        test_vector.reserve(100);
-
-        // Fill them up with some dummy content.
-        for (int i = 0; i < 20; ++i) {
-            reference_vector.push_back(i * 2);
-            test_vector.push_back(i * 2);
-        }
-        // Make sure that they are the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin()));
-
-        // Remove a couple of elements from the vectors.
-        for (int i : {26, 38, 25}) {
-            std::remove(reference_vector.begin(), reference_vector.end(), i);
-            std::remove(test_vector.begin(), test_vector.end(), i);
-        }
-        // Make sure that they are still the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin(), ::almost_equal<T>));
-    }
-
-};  // class hip_host_accessible_memory_resource_test
-
-/// Test the host accessible memory resource with an integer type.
-TEST_P(hip_host_accessible_memory_resource_test, int_value) {
-
-    vecmem::vector<int> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a floating point type.
-TEST_P(hip_host_accessible_memory_resource_test, double_value) {
-
-    vecmem::vector<double> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a custom type.
-TEST_P(hip_host_accessible_memory_resource_test, custom_value) {
-
-    vecmem::vector< ::TestType> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
 // Instantiate the full test suite on the host-accessible memory resources.
 INSTANTIATE_TEST_SUITE_P(hip_host_accessible_memory_resource_tests,
-                         hip_host_accessible_memory_resource_test,
+                         memory_resource_test_host_accessible,
                          testing::Values(&host_resource),
                          vecmem::testing::memory_resource_name_gen(
                              {{&host_resource, "host_resource"}}));

--- a/tests/sycl/test_sycl_memory_resources.cpp
+++ b/tests/sycl/test_sycl_memory_resources.cpp
@@ -7,7 +7,8 @@
 
 // Local include(s).
 #include "../common/memory_resource_name_gen.hpp"
-#include "vecmem/containers/vector.hpp"
+#include "../common/tests/test_generic_basic.hpp"
+#include "../common/tests/test_generic_host_accessible.hpp"
 #include "vecmem/memory/sycl/device_memory_resource.hpp"
 #include "vecmem/memory/sycl/host_memory_resource.hpp"
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
@@ -15,36 +16,13 @@
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
-// System include(s).
-#include <algorithm>
-#include <cmath>
-#include <vector>
-
 // Memory resources.
 static vecmem::sycl::device_memory_resource device_resource;
 static vecmem::sycl::host_memory_resource host_resource;
 static vecmem::sycl::shared_memory_resource shared_resource;
 
-/// Base test case for the SYCL memory resources
-///
-/// This just makes sure that the memory resources defined in the
-/// @c vecmem::sycl library are more-or-less functional.
-///
-class sycl_memory_resource_test
-    : public testing::TestWithParam<vecmem::memory_resource*> {};
-
-/// Perform some very basic tests that do not need host accessibility
-TEST_P(sycl_memory_resource_test, allocations) {
-
-    vecmem::memory_resource* resource = GetParam();
-    for (std::size_t size = 1000; size < 100000; size += 1000) {
-        void* ptr = resource->allocate(size);
-        resource->deallocate(ptr, size);
-    }
-}
-
 // Instantiate the allocation tests on all of the resources.
-INSTANTIATE_TEST_SUITE_P(sycl_memory_resource_tests, sycl_memory_resource_test,
+INSTANTIATE_TEST_SUITE_P(sycl_memory_resource_tests, memory_resource_test_basic,
                          testing::Values(&device_resource, &host_resource,
                                          &shared_resource),
                          vecmem::testing::memory_resource_name_gen(
@@ -52,99 +30,9 @@ INSTANTIATE_TEST_SUITE_P(sycl_memory_resource_tests, sycl_memory_resource_test,
                               {&host_resource, "host_resource"},
                               {&shared_resource, "shared_resource"}}));
 
-namespace {
-
-/// Custom non-trivial type used in the tests.
-struct TestType {
-    TestType(int a, long b = 123) : m_a(a), m_b(b) {}
-    int m_a;
-    long m_b;
-};
-/// Helper operator for @c TestType
-bool operator==(const TestType& value1, const TestType& value2) {
-    return ((value1.m_a == value2.m_a) && (value1.m_b == value2.m_b));
-}
-
-/// Comparison operator for fundamental types
-template <typename T>
-bool almost_equal(const T& value1, const T& value2) {
-    return (std::abs(value1 - value2) < 0.001);
-}
-
-/// Comparison operator for the custom test type
-template <>
-bool almost_equal<TestType>(const TestType& value1, const TestType& value2) {
-    return (value1 == value2);
-}
-
-}  // namespace
-
-/// Test case for host-accessible SYCL memory resources
-///
-/// Providing a slightly more elaborate test for memory resources that can be
-/// read/written from host code.
-///
-class sycl_host_accessible_memory_resource_test
-    : public sycl_memory_resource_test {
-
-protected:
-    /// Function performing some basic tests using @c vecmem::vector
-    template <typename T>
-    void test_host_accessible_resource(vecmem::vector<T>& test_vector) {
-
-        // Set up the test vector, and create a reference vector.
-        std::vector<T> reference_vector;
-        reference_vector.reserve(100);
-        test_vector.reserve(100);
-
-        // Fill them up with some dummy content.
-        for (int i = 0; i < 20; ++i) {
-            reference_vector.push_back(i * 2);
-            test_vector.push_back(i * 2);
-        }
-        // Make sure that they are the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin()));
-
-        // Remove a couple of elements from the vectors.
-        for (int i : {26, 38, 25}) {
-            (void)std::remove(reference_vector.begin(), reference_vector.end(),
-                              i);
-            (void)std::remove(test_vector.begin(), test_vector.end(), i);
-        }
-        // Make sure that they are still the same.
-        EXPECT_EQ(reference_vector.size(), test_vector.size());
-        EXPECT_TRUE(std::equal(reference_vector.begin(), reference_vector.end(),
-                               test_vector.begin(), ::almost_equal<T>));
-    }
-
-};  // class sycl_host_accessible_memory_resource_test
-
-/// Test the host accessible memory resource with an integer type.
-TEST_P(sycl_host_accessible_memory_resource_test, int_value) {
-
-    vecmem::vector<int> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a floating point type.
-TEST_P(sycl_host_accessible_memory_resource_test, double_value) {
-
-    vecmem::vector<double> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
-/// Test the host accessible memory resource with a custom type.
-TEST_P(sycl_host_accessible_memory_resource_test, custom_value) {
-
-    vecmem::vector< ::TestType> test_vector(GetParam());
-    test_host_accessible_resource(test_vector);
-}
-
 // Instantiate the full test suite on the host-accessible memory resources.
 INSTANTIATE_TEST_SUITE_P(sycl_host_accessible_memory_resource_tests,
-                         sycl_host_accessible_memory_resource_test,
+                         memory_resource_test_host_accessible,
                          testing::Values(&host_resource, &shared_resource),
                          vecmem::testing::memory_resource_name_gen(
                              {{&host_resource, "host_resource"},


### PR DESCRIPTION
Right now, we have pretty much exactly the same tests for the core resources as well as the CUDA ones, the HIP ones, and the SYCL ones. That's a lot of code duplication! This commit attempts to fix that problem by lifting all the testing code into one common definition, which is then used by the different testing executables.

I use header files for this, which contain the test definitions. I then import them into the test files. Technically there could be some linker problems with this, but in the tests I feel like this is not at much of a problem.