### PR TITLE
Windows Warning Fixes, main branch (2021.10.31.)

### DIFF
--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -178,7 +178,7 @@ __global__ void fillTransformKernel(
 void fillTransform(vecmem::data::jagged_vector_view<int> vec) {
 
     // Launch the kernel
-    fillTransformKernel<<<vec.m_size, 1>>>(vec);
+    fillTransformKernel<<<static_cast<unsigned int>(vec.m_size), 1>>>(vec);
 
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -454,13 +454,13 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
     copy(managed_data, host_vector);
 
     // Check the contents of the vector.
-    EXPECT_EQ(host_vector.size(), 6);
-    EXPECT_EQ(host_vector.at(0).size(), 0);
-    EXPECT_EQ(host_vector.at(1).size(), 1);
-    EXPECT_EQ(host_vector.at(2).size(), 200);
-    EXPECT_EQ(host_vector.at(3).size(), 1);
-    EXPECT_EQ(host_vector.at(4).size(), 100);
-    EXPECT_EQ(host_vector.at(5).size(), 2);
+    EXPECT_EQ(host_vector.size(), 6u);
+    EXPECT_EQ(host_vector.at(0).size(), 0u);
+    EXPECT_EQ(host_vector.at(1).size(), 1u);
+    EXPECT_EQ(host_vector.at(2).size(), 200u);
+    EXPECT_EQ(host_vector.at(3).size(), 1u);
+    EXPECT_EQ(host_vector.at(4).size(), 100u);
+    EXPECT_EQ(host_vector.at(5).size(), 2u);
 
     // Create the jagged vector buffer in device memory.
     vecmem::data::jagged_vector_buffer<int> device_data(
@@ -481,11 +481,11 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
     copy(device_data, host_vector);
 
     // Check the contents of the vector.
-    EXPECT_EQ(host_vector.size(), 6);
-    EXPECT_EQ(host_vector.at(0).size(), 0);
-    EXPECT_EQ(host_vector.at(1).size(), 1);
-    EXPECT_EQ(host_vector.at(2).size(), 200);
-    EXPECT_EQ(host_vector.at(3).size(), 1);
-    EXPECT_EQ(host_vector.at(4).size(), 100);
-    EXPECT_EQ(host_vector.at(5).size(), 2);
+    EXPECT_EQ(host_vector.size(), 6u);
+    EXPECT_EQ(host_vector.at(0).size(), 0u);
+    EXPECT_EQ(host_vector.at(1).size(), 1u);
+    EXPECT_EQ(host_vector.at(2).size(), 200u);
+    EXPECT_EQ(host_vector.at(3).size(), 1u);
+    EXPECT_EQ(host_vector.at(4).size(), 100u);
+    EXPECT_EQ(host_vector.at(5).size(), 2u);
 }


### PR DESCRIPTION
Fixed warnings in the CUDA and SYCL tests, showing up on Windows. In all cases the warnings being about a reduction of "precision" on a given variable.

Unfortunately the CI will remain blind to these issues, as we won't be realistically testing the CUDA and SYCL code on Windows in it. 😦

At the same time, the CUDA warning was fairly weird. It only showed up when using [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild) for the build. With [NMake](https://docs.microsoft.com/en-us/cpp/build/reference/nmake-reference) it did **not** show up. :confused: