### PR TITLE
Test Fixes, main branch (2021.11.04.)

### DIFF
--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -82,8 +82,9 @@ function( vecmem_add_test name )
       target_link_libraries( ${test_exe_name} PRIVATE ${ARG_LINK_LIBRARIES} )
    endif()
 
-   # Run the executable as the test.
-   gtest_add_tests( TARGET ${test_exe_name} SOURCES ${ARG_UNPARSED_ARGUMENTS} )
+   # Discover all of the tests from the execuable, and set them up as individual
+   # CTest tests.
+   gtest_discover_tests( ${test_exe_name} )
 
 endfunction( vecmem_add_test )
 

--- a/cuda/src/utils/cuda_error_handling.hpp
+++ b/cuda/src/utils/cuda_error_handling.hpp
@@ -26,7 +26,7 @@
 /// results
 #define VECMEM_CUDA_ERROR_IGNORE(EXP) \
     do {                              \
-        EXP;                          \
+        (void)EXP;                    \
     } while (false)
 
 namespace vecmem {

--- a/cuda/src/utils/cuda_wrappers.cpp
+++ b/cuda/src/utils/cuda_wrappers.cpp
@@ -6,16 +6,21 @@
  * Mozilla Public License Version 2.0
  */
 
-#include <cuda_runtime_api.h>
+// Project include(s).
+#include "cuda_wrappers.hpp"
 
 #include "cuda_error_handling.hpp"
 
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
 namespace vecmem::cuda::details {
+
 int get_device() {
-    int d;
 
-    VECMEM_CUDA_ERROR_CHECK(cudaGetDevice(&d));
-
+    int d = 0;
+    VECMEM_CUDA_ERROR_IGNORE(cudaGetDevice(&d));
     return d;
 }
+
 }  // namespace vecmem::cuda::details

--- a/cuda/src/utils/cuda_wrappers.hpp
+++ b/cuda/src/utils/cuda_wrappers.hpp
@@ -12,6 +12,9 @@ namespace vecmem::cuda::details {
  *
  * This function wraps the cudaGetDevice function in a way that returns the
  * device number rather than use a reference argument to write to.
+ *
+ * Note that calling the function on a machine with no CUDA device does not
+ * result in an error, the function just returns 0 in that case.
  */
 int get_device();
 }  // namespace vecmem::cuda::details

--- a/hip/src/utils/get_device.cpp
+++ b/hip/src/utils/get_device.cpp
@@ -18,7 +18,7 @@ namespace vecmem::hip::details {
 int get_device() {
 
     int result = 0;
-    VECMEM_HIP_ERROR_CHECK(hipGetDevice(&result));
+    VECMEM_HIP_ERROR_IGNORE(hipGetDevice(&result));
     return result;
 }
 

--- a/hip/src/utils/get_device.hpp
+++ b/hip/src/utils/get_device.hpp
@@ -9,6 +9,10 @@
 namespace vecmem::hip::details {
 
 /// Helper function for determining the "currently active device"
+///
+/// Note that calling the function on a machine with no HIP device does not
+/// result in an error, the function just returns 0 in that case.
+///
 int get_device();
 
 }  // namespace vecmem::hip::details

--- a/hip/src/utils/hip_error_handling.hpp
+++ b/hip/src/utils/hip_error_handling.hpp
@@ -23,7 +23,7 @@
 /// results
 #define VECMEM_HIP_ERROR_IGNORE(EXP) \
     do {                             \
-        EXP;                         \
+        (void)EXP;                   \
     } while (false)
 
 namespace vecmem {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,11 +26,11 @@ add_library( vecmem_testing_common STATIC
    "common/memory_resource_name_gen.hpp"
    "common/memory_resource_name_gen.cpp"
    "common/memory_resource_test_basic.hpp"
-   "common/memory_resource_test_basic.cpp"
+   "common/memory_resource_test_basic.ipp"
    "common/memory_resource_test_host_accessible.hpp"
-   "common/memory_resource_test_host_accessible.cpp"
+   "common/memory_resource_test_host_accessible.ipp"
    "common/memory_resource_test_stress.hpp"
-   "common/memory_resource_test_stress.cpp" )
+   "common/memory_resource_test_stress.ipp" )
 target_link_libraries( vecmem_testing_common
    PUBLIC vecmem::core GTest::gtest )
 

--- a/tests/common/memory_resource_test_basic.hpp
+++ b/tests/common/memory_resource_test_basic.hpp
@@ -20,5 +20,5 @@
 class memory_resource_test_basic
     : public testing::TestWithParam<vecmem::memory_resource*> {};
 
-// Allow the test(s) to be used in different compilation units
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memory_resource_test_basic);
+// Include the implementation.
+#include "memory_resource_test_basic.ipp"

--- a/tests/common/memory_resource_test_basic.hpp
+++ b/tests/common/memory_resource_test_basic.hpp
@@ -19,3 +19,6 @@
 ///
 class memory_resource_test_basic
     : public testing::TestWithParam<vecmem::memory_resource*> {};
+
+// Allow the test(s) to be used in different compilation units
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memory_resource_test_basic);

--- a/tests/common/memory_resource_test_basic.ipp
+++ b/tests/common/memory_resource_test_basic.ipp
@@ -6,8 +6,7 @@
  * Mozilla Public License Version 2.0
  */
 
-// Local include(s).
-#include "memory_resource_test_basic.hpp"
+#pragma once
 
 /// Perform some very basic tests that do not need host accessibility
 TEST_P(memory_resource_test_basic, allocations) {

--- a/tests/common/memory_resource_test_host_accessible.hpp
+++ b/tests/common/memory_resource_test_host_accessible.hpp
@@ -29,6 +29,5 @@ protected:
 
 };  // class memory_resource_test_host_accessible
 
-// Allow the test(s) to be used in different compilation units
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(
-    memory_resource_test_host_accessible);
+// Include the implementation.
+#include "memory_resource_test_host_accessible.ipp"

--- a/tests/common/memory_resource_test_host_accessible.hpp
+++ b/tests/common/memory_resource_test_host_accessible.hpp
@@ -28,3 +28,7 @@ protected:
     void test_host_accessible_resource(vecmem::vector<T>& test_vector);
 
 };  // class memory_resource_test_host_accessible
+
+// Allow the test(s) to be used in different compilation units
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(
+    memory_resource_test_host_accessible);

--- a/tests/common/memory_resource_test_host_accessible.ipp
+++ b/tests/common/memory_resource_test_host_accessible.ipp
@@ -6,8 +6,7 @@
  * Mozilla Public License Version 2.0
  */
 
-// Local include(s).
-#include "memory_resource_test_host_accessible.hpp"
+#pragma once
 
 // System include(s).
 #include <algorithm>

--- a/tests/common/memory_resource_test_stress.hpp
+++ b/tests/common/memory_resource_test_stress.hpp
@@ -16,3 +16,6 @@
 /// Test case for the "stress tests"
 class memory_resource_test_stress
     : public testing::TestWithParam<vecmem::memory_resource*> {};
+
+// Allow the test(s) to be used in different compilation units
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memory_resource_test_stress);

--- a/tests/common/memory_resource_test_stress.hpp
+++ b/tests/common/memory_resource_test_stress.hpp
@@ -17,5 +17,5 @@
 class memory_resource_test_stress
     : public testing::TestWithParam<vecmem::memory_resource*> {};
 
-// Allow the test(s) to be used in different compilation units
-GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(memory_resource_test_stress);
+// Include the implementation.
+#include "memory_resource_test_stress.ipp"

--- a/tests/common/memory_resource_test_stress.ipp
+++ b/tests/common/memory_resource_test_stress.ipp
@@ -6,9 +6,9 @@
  * Mozilla Public License Version 2.0
  */
 
-// Local include(s).
-#include "memory_resource_test_stress.hpp"
+#pragma once
 
+// Local include(s).
 #include "vecmem/containers/vector.hpp"
 
 // System include(s).


### PR DESCRIPTION
Replaced [gtest_add_tests(...)](https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_add_tests) with [gtest_discover_tests(...)](https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_discover_tests) in `vecmem_add_test`.

Unfortunately the old function was not compatible with parametrized tests being declared in separate compilation units. Which actually made us blind to the latest tests not actually working correctly. Exactly as we discussed with @stephenswat just yesterday...

Luckily, exactly as @stephenswat suggested, [GoogleTest](https://cmake.org/cmake/help/latest/module/GoogleTest.html) does actually provide the ability to discover tests from the compiled binaries. This is what [gtest_discover_tests(...)](https://cmake.org/cmake/help/latest/module/GoogleTest.html#command:gtest_discover_tests) is meant to do. And now finally the number of tests reported by `ctest` is exactly the number of tests reported by the individual test executables, summed up. :smile:

I now added all the `GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(...)` calls back to the common test headers, to make them function correctly. As it turns out, as silly as I am, I just never ran the tests correctly while working on #136. :frowning: