### PR TITLE
vecmem::get for vecmem::static_array, main branch (2021.11.04.)

### DIFF
--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -287,4 +287,20 @@ VECMEM_HOST_AND_DEVICE bool operator!=(const static_array<T, N>& lhs,
      */
     return false;
 }
+
+template <std::size_t I, class T, std::size_t N,
+          std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr T& get(
+              static_array<T, N>& a) noexcept {
+
+    return a[I];
+}
+
+template <
+    std::size_t I, class T, std::size_t N,
+    std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr const T& get(
+        const static_array<T, N>& a) noexcept {
+
+    return a[I];
+}
+
 }  // namespace vecmem

--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -68,6 +68,22 @@ VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::operator[](
 }
 
 template <typename T, std::size_t N>
+template <std::size_t I,
+          std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr auto
+              static_array<T, N>::get() noexcept->reference {
+
+    return m_array[I];
+}
+
+template <typename T, std::size_t N>
+template <std::size_t I,
+          std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr auto
+              static_array<T, N>::get() const noexcept->const_reference {
+
+    return m_array[I];
+}
+
+template <typename T, std::size_t N>
 VECMEM_HOST_AND_DEVICE constexpr auto static_array<T, N>::front(void)
     -> reference {
     /*
@@ -292,7 +308,7 @@ template <std::size_t I, class T, std::size_t N,
           std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr T& get(
               static_array<T, N>& a) noexcept {
 
-    return a[I];
+    return a.template get<I>();
 }
 
 template <
@@ -300,7 +316,7 @@ template <
     std::enable_if_t<I<N, bool> > VECMEM_HOST_AND_DEVICE constexpr const T& get(
         const static_array<T, N>& a) noexcept {
 
-    return a[I];
+    return a.template get<I>();
 }
 
 }  // namespace vecmem

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -156,6 +156,27 @@ public:
     constexpr const_reference operator[](size_type i) const;
 
     /**
+     * @brief Compile-time bounds-checked accessor method
+     *
+     * @tparam I The index to access
+     * @return A non-const reference to the value at @c I
+     */
+    template <std::size_t I,
+              std::enable_if_t<I<N, bool> = true>
+                  VECMEM_HOST_AND_DEVICE constexpr reference get() noexcept;
+
+    /**
+     * @brief Compile-time bounds-checked constant accessor method
+     *
+     * @tparam I The index to access
+     * @return A constant reference to the value at @c I
+     */
+    template <std::size_t I,
+              std::enable_if_t<I<N, bool> = true>
+                  VECMEM_HOST_AND_DEVICE constexpr const_reference get()
+                      const noexcept;
+
+    /**
      * @brief Access the front element of the array.
      *
      * @return The first element of the array.

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -318,12 +318,5 @@ template <std::size_t I, class T, std::size_t N,
 
 }  // namespace vecmem
 
-namespace std {
-
-/// Make the @c vecmem::get functions available in the @c std namespace as well
-using vecmem::get;
-
-}  // namespace std
-
 // Include the implementation.
 #include "impl/static_array.ipp"

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -297,13 +297,33 @@ private:
     typename details::array_type<T, N>::type m_array;
 };
 
+/// Equality check on two arrays
 template <typename T, std::size_t N>
 VECMEM_HOST_AND_DEVICE bool operator==(const static_array<T, N> &lhs,
                                        const static_array<T, N> &rhs);
-
+/// Non-equality check on two arrays
 template <typename T, std::size_t N>
 VECMEM_HOST_AND_DEVICE bool operator!=(const static_array<T, N> &lhs,
                                        const static_array<T, N> &rhs);
+
+/// Get one element from a @c vecmem::static_array
+template <std::size_t I, class T, std::size_t N,
+          std::enable_if_t<I<N, bool> = true> VECMEM_HOST_AND_DEVICE constexpr T
+              &get(static_array<T, N> &a) noexcept;
+/// Get one element from a @c vecmem::static_array
+template <std::size_t I, class T, std::size_t N,
+          std::enable_if_t<I<N, bool> = true>
+              VECMEM_HOST_AND_DEVICE constexpr const T &get(
+                  const static_array<T, N> &a) noexcept;
+
 }  // namespace vecmem
 
+namespace std {
+
+/// Make the @c vecmem::get functions available in the @c std namespace as well
+using vecmem::get;
+
+}  // namespace std
+
+// Include the implementation.
 #include "impl/static_array.ipp"

--- a/tests/core/test_core_static_array.cpp
+++ b/tests/core/test_core_static_array.cpp
@@ -128,3 +128,12 @@ TEST_F(core_static_array_test, matrix) {
     EXPECT_EQ(matrix[2][0], 0);
     EXPECT_EQ(matrix[2][2], 7);
 }
+
+TEST_F(core_static_array_test, get) {
+
+    constexpr vecmem::static_array<int, 3> a{5, 20, 22};
+    constexpr int a0 = vecmem::get<0>(a);
+    constexpr int a1 = std::get<1>(a);
+    EXPECT_EQ(a0, 5);
+    EXPECT_EQ(a1, 20);
+}

--- a/tests/core/test_core_static_array.cpp
+++ b/tests/core/test_core_static_array.cpp
@@ -133,7 +133,7 @@ TEST_F(core_static_array_test, get) {
 
     constexpr vecmem::static_array<int, 3> a{5, 20, 22};
     constexpr int a0 = vecmem::get<0>(a);
-    constexpr int a1 = std::get<1>(a);
+    constexpr int a1 = vecmem::get<1>(a);
     EXPECT_EQ(a0, 5);
     EXPECT_EQ(a1, 20);
 }

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -36,7 +36,7 @@ __global__ void linearTransformKernel(
 
     // Perform the linear transformation.
     outputvec.at(i) =
-        inputvec.at(i) * constantarray1.at(0) + std::get<1>(constantarray2);
+        inputvec.at(i) * constantarray1.at(0) + vecmem::get<1>(constantarray2);
     return;
 }
 

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -35,7 +35,8 @@ __global__ void linearTransformKernel(
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) + constantarray2[1];
+    outputvec.at(i) =
+        inputvec.at(i) * constantarray1.at(0) + std::get<1>(constantarray2);
     return;
 }
 

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -40,7 +40,7 @@ __global__ void linearTransformKernel(
 
     // Perform the linear transformation.
     outputvec.at(i) =
-        inputvec.at(i) * constantarray1.at(0) + std::get<1>(constantarray2);
+        inputvec.at(i) * constantarray1.at(0) + vecmem::get<1>(constantarray2);
     return;
 }
 

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -39,7 +39,8 @@ __global__ void linearTransformKernel(
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) + constantarray2[1];
+    outputvec.at(i) =
+        inputvec.at(i) * constantarray1.at(0) + std::get<1>(constantarray2);
     return;
 }
 

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -70,7 +70,7 @@ TEST_F(sycl_containers_test, shared_memory) {
 
                 // Perform the linear transformation.
                 outputvec.at(id) = inputvec.at(id) * constantarray1.at(0) +
-                                   std::get<1>(constantarray2);
+                                   vecmem::get<1>(constantarray2);
                 return;
             });
     });

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -69,8 +69,8 @@ TEST_F(sycl_containers_test, shared_memory) {
                 vecmem::device_vector<int> outputvec(output);
 
                 // Perform the linear transformation.
-                outputvec.at(id) =
-                    inputvec.at(id) * constantarray1.at(0) + constantarray2[1];
+                outputvec.at(id) = inputvec.at(id) * constantarray1.at(0) +
+                                   std::get<1>(constantarray2);
                 return;
             });
     });


### PR DESCRIPTION
Introduced `vecmem::get` / `std::get` functions for `vecmem::static_array`, to address #140.

Adding such functions was quite trivial, so I didn't see why we shouldn't do it. :wink:

I didn't want to only define `std::get` functions though. So I went with this approach. Where the functions are called `vecmem::get`, but they are made available in the `std::` namespace as well. You guys can debate me on this however...

Note that I chose not to implement the following functions:

```c++
template< std::size_t I, class T, std::size_t N >
constexpr T&& get( static_array<T,N>&& a ) noexcept;

template< std::size_t I, class T, std::size_t N >
constexpr const T&& get( const static_array<T,N>&& a ) noexcept;
```

Even though they do exist for `std::array`.

https://en.cppreference.com/w/cpp/container/array/get

I guess they could be useful in some super edge cases, but for the type of arrays that we will be using, I just didn't see why we should try to complicate the lives of the device compilers...