### PR TITLE
Source File Grouping, main branch (2021.11.04.)

### DIFF
--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -26,6 +26,9 @@ function( vecmem_add_library fullname basename )
    # Parse the function's options.
    cmake_parse_arguments( ARG "" "TYPE" "" ${ARGN} )
 
+   # Group the source files.
+   vecmem_group_source_files( ${ARG_UNPARSED_ARGUMENTS} )
+
    # Create the library.
    add_library( ${fullname} ${ARG_TYPE} ${ARG_UNPARSED_ARGUMENTS} )
 
@@ -75,6 +78,9 @@ function( vecmem_add_test name )
    # Parse the function's options.
    cmake_parse_arguments( ARG "" "" "LINK_LIBRARIES" ${ARGN} )
 
+   # Group the source files.
+   vecmem_group_source_files( ${ARG_UNPARSED_ARGUMENTS} )
+
    # Create the test executable.
    set( test_exe_name "vecmem_test_${name}" )
    add_executable( ${test_exe_name} ${ARG_UNPARSED_ARGUMENTS} )
@@ -109,3 +115,28 @@ function( vecmem_add_flag name value )
    set( ${name} "${${name}} ${value}" PARENT_SCOPE )
 
 endfunction( vecmem_add_flag )
+
+# Function used internally to describe to IDEs how they should group source
+# files of libraries and executables in their interface.
+#
+# Usage: vecmem_group_source_files( ${_sources} )
+#
+function( vecmem_group_source_files )
+
+   # Collect all the passed file names:
+   cmake_parse_arguments( ARG "" "" "" ${ARGN} )
+
+   # Loop over all of them:
+   foreach( f ${ARG_UNPARSED_ARGUMENTS} )
+      # Ignore absolute path names.
+      if( NOT IS_ABSOLUTE "${f}" )
+         # Get the file's path:
+         get_filename_component( _path "${f}" PATH )
+         # Replace the forward slashes with double backward slashes:
+         string( REPLACE "/" "\\\\" _group "${_path}" )
+         # Put the file into the right group:
+         source_group( "${_group}" FILES "${f}" )
+      endif()
+   endforeach()
+
+endfunction( vecmem_group_source_files )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -152,7 +152,10 @@ check_cxx_source_compiles( "
   " VECMEM_HAVE_DEFAULT_RESOURCE)
 
 if(NOT VECMEM_HAVE_DEFAULT_RESOURCE)
-   target_sources(vecmem_core PRIVATE src/memory/default_resource_polyfill.cpp)
+   target_sources( vecmem_core
+      PRIVATE "src/memory/default_resource_polyfill.cpp" )
+   source_group( "src\\\\memory"
+      FILES "src/memory/default_resource_polyfill.cpp" )
 endif()
 
 # Figure out how to produce SYCL debug printouts.


### PR DESCRIPTION
Introduced grouping for the source files, so that they would show up a little bit more nicely in [Xcode](https://developer.apple.com/xcode/) and [Visual Studio](https://visualstudio.microsoft.com/).

Since I myself practically only use [Visual Studio Code](https://code.visualstudio.com/) for my code editing these days, on which this setting has absolutely no effect, this was not an urgent update in this project. But since I've been talking about this as a possibility for such a long time already, most recently in https://github.com/acts-project/detray/pull/145, I really needed to demonstrate what I'm talking about exactly.

The change with this is that we go from the project showing up like this in Xcode:

![Screen Shot 2021-11-04 at 2 40 16 PM](https://user-images.githubusercontent.com/30694331/140324296-d1f6f1a8-4077-4d6f-9b0a-77b7a06d0b47.png)

To it shoring up like this instead:

![Screen Shot 2021-11-04 at 2 40 50 PM](https://user-images.githubusercontent.com/30694331/140324232-190335ed-316b-43d1-9e28-e8816097a9c6.png)

It's not a huge improvement, but an improvement non the less... 😛