### PR TITLE
Language Export, main branch (2021.11.08.)

### DIFF
--- a/cmake/vecmem-check-language.cmake
+++ b/cmake/vecmem-check-language.cmake
@@ -4,16 +4,18 @@
 #
 # Mozilla Public License Version 2.0
 
-# Make sure that the code is not included more than once.
-include_guard( GLOBAL )
-
 # CMake include(s).
 include( CheckLanguage )
 
+# Cache the location of this directory.
+set( VECMEM_LANGUAGE_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH
+   "Directory holding the VecMem language files" )
+mark_as_advanced( VECMEM_LANGUAGE_DIR )
+
 # Teach CMake about VecMem's custom language files.
 list( INSERT CMAKE_MODULE_PATH 0
-   "${CMAKE_CURRENT_LIST_DIR}/hip"
-   "${CMAKE_CURRENT_LIST_DIR}/sycl" )
+   "${VECMEM_LANGUAGE_DIR}/hip"
+   "${VECMEM_LANGUAGE_DIR}/sycl" )
 
 # Code mimicking CMake's CheckLanguage.cmake module. But making sure that the
 # VecMem specific code is used while looking for the non-standard languages.
@@ -46,8 +48,8 @@ macro( vecmem_check_language lang )
             "cmake_minimum_required( VERSION ${CMAKE_VERSION} )\n"
             "project( Check${lang} LANGUAGES CXX )\n"
             "list( INSERT CMAKE_MODULE_PATH 0 "
-            "      \"${CMAKE_CURRENT_LIST_DIR}/hip\" "
-            "      \"${CMAKE_CURRENT_LIST_DIR}/sycl\" )\n"
+            "      \"${VECMEM_LANGUAGE_DIR}/hip\" "
+            "      \"${VECMEM_LANGUAGE_DIR}/sycl\" )\n"
             "enable_language( ${lang} )\n"
             "file( WRITE \"\${CMAKE_CURRENT_BINARY_DIR}/result.cmake\"\n"
             "   \"set( CMAKE_${lang}_COMPILER \\\"\${CMAKE_${lang}_COMPILER}\\\" )\" )" )

--- a/cmake/vecmem-config.cmake.in
+++ b/cmake/vecmem-config.cmake.in
@@ -13,11 +13,50 @@ set_and_check( vecmem_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@" )
 set_and_check( vecmem_LIBRARY_DIR "@PACKAGE_CMAKE_INSTALL_LIBDIR@" )
 set_and_check( vecmem_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_CMAKEDIR@" )
 
+# Include the file listing all the imported targets and options.
+include( "${vecmem_CMAKE_DIR}/vecmem-config-targets.cmake" )
+
+# Set up additional variables, based on the imported targets. These are mostly
+# just here for handling COMPONENT arguments for find_package(...).
+set( vecmem_CORE_LIBRARY vecmem::core )
+if( TARGET vecmem::cuda )
+   set( vecmem_CUDA_LIBRARY vecmem::cuda )
+else()
+   set( vecmem_CUDA_LIBRARY vecmem::cuda-NOTFOUND )
+endif()
+if( TARGET vecmem::hip )
+   set( vecmem_HIP_LIBRARY vecmem::hip )
+else()
+   set( vecmem_HIP_LIBRARY vecmem::hip-NOTFOUND )
+endif()
+if( TARGET vecmem::sycl )
+   set( vecmem_SYCL_LIBRARY vecmem::sycl )
+else()
+   set( vecmem_SYCL_LIBRARY vecmem::sycl-NOTFOUND )
+endif()
+
+# If the user asked for the CUDA/HIP/SYCL components explicitly, make
+# sure that they would exist in the installation.
+set( vecmem_REQUIRED_LIBS vecmem_CORE_LIBRARY )
+foreach( comp "CUDA" "HIP" "SYCL" )
+   if( "${vecmem_FIND_COMPONENTS}" MATCHES "${comp}" )
+      list( APPEND vecmem_REQUIRED_LIBS vecmem_${comp}_LIBRARY )
+   endif()
+endforeach()
+
 # Print a standard information message about the package being found.
 include( FindPackageHandleStandardArgs )
 find_package_handle_standard_args( vecmem REQUIRED_VARS
-   CMAKE_CURRENT_LIST_FILE
+   CMAKE_CURRENT_LIST_FILE ${vecmem_REQUIRED_LIBS}
    VERSION_VAR vecmem_VERSION )
 
-# Include the file listing all the imported targets and options.
-include( "${vecmem_CMAKE_DIR}/vecmem-config-targets.cmake" )
+# Clean up.
+unset( vecmem_REQUIRED_LIBS )
+
+# Set up the "language helper code" coming with the installation, if the
+# user asks for it.
+set_and_check( vecmem_LANGUAGE_FILE
+   "${vecmem_CMAKE_DIR}/vecmem-check-language.cmake" )
+if( "${vecmem_FIND_COMPONENTS}" MATCHES "LANGUAGE" )
+   include( "${vecmem_LANGUAGE_FILE}" )
+endif()

--- a/cmake/vecmem-packaging.cmake
+++ b/cmake/vecmem-packaging.cmake
@@ -29,3 +29,13 @@ install( FILES
    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vecmem-config.cmake"
    "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/vecmem-config-version.cmake"
    DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+
+# Install the "language helper" files.
+install( FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vecmem-check-language.cmake"
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+install( DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/cmake/hip"
+                   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/sycl"
+   DESTINATION "${CMAKE_INSTALL_CMAKEDIR}" )
+
+# Clean up.
+unset( CMAKE_INSTALL_CMAKEDIR )


### PR DESCRIPTION
Made VecMem export its "language files" during installation. Making it possible to make use of VecMem's SYCL and HIP build
infrastructure after "finding" an installed version of VecMem. Like the following:

```cmake
cmake_minimum_required( VERSION 3.18 )
project( VecMemTest VERSION 1.0.0 LANGUAGES CXX )

find_package( vecmem REQUIRED COMPONENTS LANGUAGE )

vecmem_check_language( SYCL )
if( CMAKE_SYCL_COMPILER )
   enable_language( SYCL )
endif()
```

At the same time introduced "component flags" for the CUDA, HIP and SYCL libraries, so that `find_package(...)` calls could explicitly ask for some of the optional libraries to be available. Like:

```cmake
cmake_minimum_required( VERSION 3.18 )
project( VecMemTest VERSION 1.0.0 LANGUAGES CXX )

find_package( vecmem REQUIRED COMPONENTS CUDA )
```

Which would fail in the following way, in case `vecmem::cuda` is not part of the installation:

```
[bash][atspot01]:test_build > cmake -DCMAKE_PREFIX_PATH=/home/krasznaa/ATLAS/projects/vecmem/install ../test/
-- The CXX compiler identification is Clang 13.0.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /atlas/software/intel/clang/2021-07/x86_64-ubuntu1804-gcc8-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at /atlas/software/cmake/3.21.3/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find vecmem (missing: vecmem_CUDA_LIBRARY) (found version
  "0.7.0")
Call Stack (most recent call first):
  /atlas/software/cmake/3.21.3/x86_64-ubuntu1804-gcc7-opt/share/cmake-3.21/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /home/krasznaa/ATLAS/projects/vecmem/install/lib/cmake/vecmem-0.7.0/vecmem-config.cmake:63 (find_package_handle_standard_args)
  CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/krasznaa/ATLAS/projects/vecmem/test_build/CMakeFiles/CMakeOutput.log".
[bash][atspot01]:test_build >
```

As I discussed with @stephenswat in the morning, this will be necessary to bring "proper SYCL support" to [acts-project/traccc](https://github.com/acts-project/traccc).

Pinging @konradkusiak97.