### PR TITLE
Windows Support Update, main branch (2021.11.19.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -68,6 +68,8 @@ jobs:
         PLATFORM:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda:v11"
+          - NAME: "CUDA"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
           - NAME: "HIP"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm:v11"
           - NAME: "SYCL"

--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -10,11 +10,6 @@ include( vecmem-functions )
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 
-# Turn on the correct setting for the __cplusplus macro with MSVC.
-if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
-   vecmem_add_flag( CMAKE_CXX_FLAGS "/Zc:__cplusplus" )
-endif()
-
 # Turn on a number of warnings for the "known compilers".
 if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
     ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -103,6 +103,13 @@ target_compile_definitions( vecmem_core PUBLIC
    $<BUILD_INTERFACE:VECMEM_DEBUG_MSG_LVL=${VECMEM_DEBUG_MSG_LVL}>
    $<BUILD_INTERFACE:VECMEM_SOURCE_DIR_LENGTH=${VECMEM_SOURCE_DIR_LENGTH}> )
 
+# The library headers make checks on the value of the __cplusplus macro. So we
+# need to make sure that MSVC would always set that macro up when using this
+# library.
+target_compile_options( vecmem_core PUBLIC
+   $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CXX>>:/Zc:__cplusplus>
+   $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<COMPILE_LANGUAGE:CUDA>>:-Xcompiler /Zc:__cplusplus> )
+
 # Figure out where to get <memory_resource> from.
 include( CheckCXXSourceCompiles )
 check_cxx_source_compiles( "

--- a/core/include/vecmem/memory/details/memory_resource_base.hpp
+++ b/core/include/vecmem/memory/details/memory_resource_base.hpp
@@ -17,6 +17,10 @@
 #pragma warning(push)
 #pragma warning(disable : 4275)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1388
+#endif  // CUDA disgnostics
 
 namespace vecmem::details {
 
@@ -51,3 +55,6 @@ protected:
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // CUDA disgnostics

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -26,3 +26,13 @@ vecmem_add_test( cuda
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
    LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda GTest::gtest_main
                   vecmem_testing_common )
+
+# Set up a separate test that would ensure a C++17 standard. But only with
+# CUDA 11+.
+if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "11.0" )
+   vecmem_add_test( cuda_cxx17
+      "test_cuda_memory_resources.cu"
+      LINK_LIBRARIES vecmem::cuda GTest::gtest_main vecmem_testing_common )
+   set_target_properties( vecmem_test_cuda_cxx17 PROPERTIES
+      CUDA_STANDARD 17 )
+endif()

--- a/tests/cuda/test_cuda_memory_resources.cu
+++ b/tests/cuda/test_cuda_memory_resources.cu
@@ -1,0 +1,9 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "test_cuda_memory_resources.cpp"


### PR DESCRIPTION
As I discovered in https://github.com/acts-project/algebra-plugins/pull/42, using VecMem on Windows from another project is not as trivial as I thought it was. :frowning:

Now I made MSVC always set `__cplusplus` when using `vecmem::core`. Removing the setting meant just for the build of this project. Setting the appropriate flags through generator expressions, to make the code as robust as possible.

I also enabled the appropriate flag for setting `__cplusplus` with NVCC on windows. Since in [algebra-plugins](https://github.com/acts-project/algebra-plugins) we also need that.

Finally, suppressed the warning about exporting a class that inherits from a non-exported class, when using the NVCC compiler on Windows. Unfortunately I couldn't find any good documentation on when CUDA stopped using `#pragma diag_suppress` and switched to `#pragma nv_diag_suppress`. So the CI should tell us if this was before CUDA 10.2 or not... :thinking:

To make sure that all of this was working correctly, I made a copy of the CUDA memory resource test, and made NVCC compile it as well.