### PR TITLE
Asynchronous CUDA Copies, main branch (2021.11.29.)

### DIFF
--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -29,12 +29,18 @@ vecmem_add_library( vecmem_cuda cuda
    # Utilities.
    "include/vecmem/utils/cuda/copy.hpp"
    "src/utils/cuda/copy.cpp"
+   "include/vecmem/utils/cuda/async_copy.hpp"
+   "src/utils/cuda/async_copy.cpp"
    "src/utils/cuda_error_handling.hpp"
    "src/utils/cuda_error_handling.cpp"
    "src/utils/cuda_wrappers.hpp"
    "src/utils/cuda_wrappers.cpp"
    "src/utils/select_device.hpp"
-   "src/utils/select_device.cpp" )
+   "src/utils/select_device.cpp"
+   "include/vecmem/utils/cuda/stream_wrapper.hpp"
+   "src/utils/stream_wrapper.cpp"
+   "src/utils/opaque_stream.hpp"
+   "src/utils/opaque_stream.cpp" )
 target_link_libraries( vecmem_cuda
    PUBLIC vecmem::core
    PRIVATE CUDA::cudart )

--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -1,0 +1,46 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/utils/copy.hpp"
+#include "vecmem/utils/cuda/stream_wrapper.hpp"
+#include "vecmem/vecmem_cuda_export.hpp"
+
+namespace vecmem::cuda {
+
+/// Specialisation of @c vecmem::copy for CUDA
+///
+/// This specialisation of @c vecmem::copy, unlike @c vecmem::cuda::copy,
+/// performs all of its operations asynchronously. Using the CUDA stream
+/// that is given to its constructor.
+///
+/// It is up to the user to ensure that copy operations are performed in the
+/// right order, and they would finish before an operation that needs them
+/// is executed.
+///
+class VECMEM_CUDA_EXPORT async_copy : public vecmem::copy {
+
+public:
+    /// Constructor with the stream to operate on
+    async_copy(const stream_wrapper& stream);
+
+protected:
+    /// Perform an asynchronous memory copy using CUDA
+    virtual void do_copy(std::size_t size, const void* from, void* to,
+                         type::copy_type cptype) override;
+    /// Fill a memory area using CUDA asynchronously
+    virtual void do_memset(std::size_t size, void* ptr, int value) override;
+
+private:
+    /// The stream that the copies are performed on
+    stream_wrapper m_stream;
+
+};  // class async_copy
+
+}  // namespace vecmem::cuda

--- a/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
+++ b/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
@@ -1,0 +1,81 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/vecmem_cuda_export.hpp"
+
+// System include(s).
+#include <memory>
+#include <string>
+
+namespace vecmem::cuda {
+
+// Forward declaration(s).
+namespace details {
+class opaque_stream;
+}
+
+// Disable the warning(s) about inheriting from/using standard library types
+// with an exported class.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif  // MSVC
+
+/// Wrapper class for @c cudaStream_t
+///
+/// It is necessary for passing around CUDA stream objects in code that should
+/// not be directly exposed to the CUDA header(s).
+///
+class VECMEM_CUDA_EXPORT stream_wrapper {
+
+public:
+    /// Invalid/default device identifier
+    static constexpr int INVALID_DEVICE = -1;
+
+    /// Construct a new stream (for the specified device)
+    stream_wrapper(int device = INVALID_DEVICE);
+    /// Wrap an existing @c cudaStream_t object
+    ///
+    /// Without taking ownership of it!
+    ///
+    stream_wrapper(void* stream);
+
+    /// Copy constructor
+    stream_wrapper(const stream_wrapper& parent);
+    /// Move constructor
+    stream_wrapper(stream_wrapper&& parent);
+
+    /// Destructor
+    ~stream_wrapper();
+
+    /// Copy assignment
+    stream_wrapper& operator=(const stream_wrapper& rhs);
+    /// Move assignment
+    stream_wrapper& operator=(stream_wrapper&& rhs);
+
+    /// Access a typeless pointer to the managed @c cudaStream_t object
+    void* stream() const;
+
+    /// Wait for all queued tasks from the stream to complete
+    void synchronize();
+
+private:
+    /// Bare pointer to the wrapped @c cudaStream_t object
+    void* m_stream;
+    /// Smart pointer to the managed @c cudaStream_t object
+    std::shared_ptr<details::opaque_stream> m_managedStream;
+
+};  // class stream_wrapper
+
+}  // namespace vecmem::cuda
+
+// Re-enable the warning(s).
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC

--- a/cuda/src/utils/cuda/async_copy.cpp
+++ b/cuda/src/utils/cuda/async_copy.cpp
@@ -1,0 +1,87 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// VecMem include(s).
+#include "vecmem/utils/cuda/async_copy.hpp"
+
+#include "../cuda_error_handling.hpp"
+#include "../cuda_wrappers.hpp"
+#include "vecmem/utils/debug.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+// System include(s).
+#include <cassert>
+#include <string>
+
+namespace vecmem::cuda {
+
+/// Helper array for translating between the vecmem and CUDA copy type
+/// definitions
+static constexpr cudaMemcpyKind copy_type_translator[copy::type::count] = {
+    cudaMemcpyHostToDevice, cudaMemcpyDeviceToHost, cudaMemcpyHostToHost,
+    cudaMemcpyDeviceToDevice, cudaMemcpyDefault};
+
+/// Helper array for providing a printable name for the copy type definitions
+static const std::string copy_type_printer[copy::type::count] = {
+    "host to device", "device to host", "host to host", "device to device",
+    "unknown"};
+
+async_copy::async_copy(const stream_wrapper& stream) : m_stream(stream) {}
+
+void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
+                         type::copy_type cptype) {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory copy");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
+    assert(static_cast<int>(cptype) >= 0);
+    assert(static_cast<int>(cptype) < static_cast<int>(copy::type::count));
+
+    // Perform the copy.
+    VECMEM_CUDA_ERROR_CHECK(cudaMemcpyAsync(to_ptr, from_ptr, size,
+                                            copy_type_translator[cptype],
+                                            details::get_stream(m_stream)));
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(
+        4,
+        "Initiated asynchronous %s memory copy of %lu bytes from %p to "
+        "%p",
+        copy_type_printer[cptype].c_str(), size, from_ptr, to_ptr);
+}
+
+void async_copy::do_memset(std::size_t size, void* ptr, int value) {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory filling");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(ptr != nullptr);
+
+    // Perform the operation.
+    VECMEM_CUDA_ERROR_CHECK(
+        cudaMemsetAsync(ptr, value, size, details::get_stream(m_stream)));
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(
+        4, "Initiated setting %lu bytes to %i at %p asynchronously with CUDA",
+        size, value, ptr);
+}
+
+}  // namespace vecmem::cuda

--- a/cuda/src/utils/cuda_wrappers.cpp
+++ b/cuda/src/utils/cuda_wrappers.cpp
@@ -14,6 +14,9 @@
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+
 namespace vecmem::cuda::details {
 
 int get_device() {
@@ -21,6 +24,12 @@ int get_device() {
     int d = 0;
     VECMEM_CUDA_ERROR_IGNORE(cudaGetDevice(&d));
     return d;
+}
+
+cudaStream_t get_stream(const stream_wrapper& stream) {
+
+    assert(stream.stream() != nullptr);
+    return reinterpret_cast<cudaStream_t>(stream.stream());
 }
 
 }  // namespace vecmem::cuda::details

--- a/cuda/src/utils/cuda_wrappers.hpp
+++ b/cuda/src/utils/cuda_wrappers.hpp
@@ -6,7 +6,14 @@
  * Mozilla Public License Version 2.0
  */
 
+// Local include(s).
+#include "vecmem/utils/cuda/stream_wrapper.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
 namespace vecmem::cuda::details {
+
 /**
  * @brief Get current CUDA device number.
  *
@@ -17,4 +24,8 @@ namespace vecmem::cuda::details {
  * result in an error, the function just returns 0 in that case.
  */
 int get_device();
+
+/// Get concrete @c cudaStream_t object out of our wrapper
+cudaStream_t get_stream(const stream_wrapper& stream);
+
 }  // namespace vecmem::cuda::details

--- a/cuda/src/utils/opaque_stream.cpp
+++ b/cuda/src/utils/opaque_stream.cpp
@@ -1,0 +1,34 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "opaque_stream.hpp"
+
+#include "cuda_error_handling.hpp"
+
+namespace vecmem::cuda::details {
+
+opaque_stream::opaque_stream() : m_stream(nullptr) {
+
+    VECMEM_CUDA_ERROR_CHECK(cudaStreamCreate(&m_stream));
+}
+
+opaque_stream::~opaque_stream() {
+
+    // Don't check the return value of the stream destruction. This is because
+    // if the holder of this opaque stream is only destroyed during the
+    // termination of the application in which it was created, the CUDA runtime
+    // may have already deleted all streams by the time that this function would
+    // try to delete it.
+    //
+    // This is not the most robust thing ever, but detecting reliably when this
+    // destructor is executed as part of the final operations of an application,
+    // would be too platform specific and fragile of an operation.
+    cudaStreamDestroy(m_stream);
+}
+
+}  // namespace vecmem::cuda::details

--- a/cuda/src/utils/opaque_stream.hpp
+++ b/cuda/src/utils/opaque_stream.hpp
@@ -1,0 +1,32 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+namespace vecmem::cuda::details {
+
+/// RAII wrapper around @c cudaStream_t
+///
+/// It is used only internally by the VecMem code, so it does not need to
+/// provide any nice interface.
+///
+class opaque_stream {
+
+public:
+    /// Default constructor
+    opaque_stream();
+    /// Destructor
+    ~opaque_stream();
+
+    /// Stream managed by the object
+    cudaStream_t m_stream;
+
+};  // class opaque_stream
+
+}  // namespace vecmem::cuda::details

--- a/cuda/src/utils/stream_wrapper.cpp
+++ b/cuda/src/utils/stream_wrapper.cpp
@@ -1,0 +1,85 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/utils/cuda/stream_wrapper.hpp"
+
+#include "cuda_error_handling.hpp"
+#include "cuda_wrappers.hpp"
+#include "opaque_stream.hpp"
+#include "select_device.hpp"
+
+// CUDA include(s).
+#include <cuda_runtime_api.h>
+
+namespace vecmem::cuda {
+
+stream_wrapper::stream_wrapper(int device)
+    : m_stream(nullptr), m_managedStream() {
+
+    // Make sure that the stream is constructed on the correct device.
+    details::select_device dev_selector(
+        device == INVALID_DEVICE ? details::get_device() : device);
+
+    // Construct the stream.
+    m_managedStream = std::make_shared<details::opaque_stream>();
+    m_stream = m_managedStream->m_stream;
+}
+
+stream_wrapper::stream_wrapper(void* stream)
+    : m_stream(stream), m_managedStream() {}
+
+stream_wrapper::stream_wrapper(const stream_wrapper& parent)
+    : m_stream(parent.m_stream), m_managedStream(parent.m_managedStream) {}
+
+stream_wrapper::stream_wrapper(stream_wrapper&& parent)
+    : m_stream(parent.m_stream),
+      m_managedStream(std::move(parent.m_managedStream)) {}
+
+stream_wrapper::~stream_wrapper() {}
+
+stream_wrapper& stream_wrapper::operator=(const stream_wrapper& rhs) {
+
+    // Avoid self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Copy the stream.
+    m_stream = rhs.m_stream;
+    m_managedStream = rhs.m_managedStream;
+
+    // Return this object.
+    return *this;
+}
+
+stream_wrapper& stream_wrapper::operator=(stream_wrapper&& rhs) {
+
+    // Avoid self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Move the managed queue object, and copy the pointer.
+    m_stream = rhs.m_stream;
+    m_managedStream = std::move(rhs.m_managedStream);
+
+    // Return this object.
+    return *this;
+}
+
+void* stream_wrapper::stream() const {
+
+    return m_stream;
+}
+
+void stream_wrapper::synchronize() {
+
+    VECMEM_CUDA_ERROR_CHECK(cudaStreamSynchronize(details::get_stream(*this)));
+}
+
+}  // namespace vecmem::cuda

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -24,6 +24,8 @@ vecmem_add_test( cuda
    "test_cuda_jagged_vector_view_kernels.cuh"
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.hpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.cpp"
    LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda GTest::gtest_main
                   vecmem_testing_common )
 

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -12,6 +12,7 @@
 #include "vecmem/memory/cuda/device_memory_resource.hpp"
 #include "vecmem/memory/cuda/host_memory_resource.hpp"
 #include "vecmem/memory/cuda/managed_memory_resource.hpp"
+#include "vecmem/utils/cuda/async_copy.hpp"
 #include "vecmem/utils/cuda/copy.hpp"
 
 // GoogleTest include(s).
@@ -86,6 +87,52 @@ TEST_F(cuda_containers_test, explicit_memory) {
                     m_copy.to(vecmem::get_data(inputvec), device_resource),
                     outputvecdevice);
     m_copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host);
+
+    // Check the output.
+    EXPECT_EQ(inputvec.size(), outputvec.size());
+    for (std::size_t i = 0; i < outputvec.size(); ++i) {
+        EXPECT_EQ(outputvec.at(i),
+                  inputvec.at(i) * constants[0] + constants[1]);
+    }
+}
+
+/// Test a linear transformation while hand-managing the asynchronous memory
+/// copies
+TEST_F(cuda_containers_test, async_memory) {
+
+    // The host/device memory resources.
+    vecmem::cuda::device_memory_resource device_resource;
+    vecmem::cuda::host_memory_resource host_resource;
+
+    // The copy utility.
+    vecmem::cuda::stream_wrapper stream;
+    vecmem::cuda::async_copy copy(stream);
+
+    // Create input/output vectors on the host.
+    vecmem::vector<int> inputvec({1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                                 &host_resource);
+    vecmem::vector<int> outputvec(inputvec.size(), &host_resource);
+    EXPECT_EQ(inputvec.size(), outputvec.size());
+
+    // Allocate a device memory block for the output container.
+    auto outputvechost = vecmem::get_data(outputvec);
+    vecmem::data::vector_buffer<int> outputvecdevice(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(
+            outputvec.size()),
+        device_resource);
+
+    // Create the array that is used in the linear transformation.
+    vecmem::array<int, 2> constants(host_resource);
+    constants[0] = 2;
+    constants[1] = 3;
+
+    // Perform a linear transformation with explicit memory copies.
+    linearTransform(copy.to(vecmem::get_data(constants), device_resource,
+                            vecmem::copy::type::host_to_device),
+                    copy.to(vecmem::get_data(inputvec), device_resource),
+                    outputvecdevice, stream);
+    copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host);
+    stream.synchronize();
 
     // Check the output.
     EXPECT_EQ(inputvec.size(), outputvec.size());

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -7,6 +7,7 @@
 
 // Local include(s).
 #include "../../cuda/src/utils/cuda_error_handling.hpp"
+#include "../../cuda/src/utils/cuda_wrappers.hpp"
 #include "test_cuda_containers_kernels.cuh"
 #include "vecmem/containers/const_device_array.hpp"
 #include "vecmem/containers/const_device_vector.hpp"
@@ -49,6 +50,19 @@ void linearTransform(vecmem::data::vector_view<const int> constants,
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}
+
+void linearTransform(vecmem::data::vector_view<const int> constants,
+                     vecmem::data::vector_view<const int> input,
+                     vecmem::data::vector_view<int> output,
+                     const vecmem::cuda::stream_wrapper& stream) {
+
+    // Launch the kernel.
+    linearTransformKernel<<<1, input.size(), 0,
+                            vecmem::cuda::details::get_stream(stream)>>>(
+        constants, input, output);
+    // Check whether it succeeded to launch.
+    VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
 }
 
 /// Kernel performing some basic atomic operations.

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -10,6 +10,7 @@
 // Local include(s).
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/utils/cuda/stream_wrapper.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -18,6 +19,12 @@
 void linearTransform(vecmem::data::vector_view<const int> constants,
                      vecmem::data::vector_view<const int> input,
                      vecmem::data::vector_view<int> output);
+
+/// Perform an asynchronous linear transformation using the received vectors
+void linearTransform(vecmem::data::vector_view<const int> constants,
+                     vecmem::data::vector_view<const int> input,
+                     vecmem::data::vector_view<int> output,
+                     const vecmem::cuda::stream_wrapper& stream);
 
 /// Function incrementing the elements of the received vector using atomics
 void atomicTransform(unsigned int iterations,


### PR DESCRIPTION
After the comments from @fwyzard in the morning, I decided to look at asynchronous CUDA copies once again. :smile: This is what I came up with...

In the same way in which the code hides `sycl::queue` from the public interface of `vecmem::sycl`, I hid `cudaStream_t` from the public interface of `vecmem::cuda`. Through the introduction of a `vecmem::cuda::stream_wrapper`, and an underlying `vecmem::cuda::details::opaque_stream` type.

With those in place I added a `vecmem::cuda::async_copy` type. I behaves exactly like `vecmem::cuda::copy`, besides doing everything asynchronously.

Finally I added a trivial test, just to see that things don't break in a very obvious way.