### PR TITLE
Implement a custom main function for CUDA tests

### DIFF
--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -14,6 +14,22 @@ include( vecmem-compiler-options-cuda )
 # External dependency/dependencies.
 find_package( CUDAToolkit REQUIRED )
 
+add_library(
+   vecmem_testing_cuda_main
+   STATIC
+   test_cuda_main.cpp
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
+)
+
+target_link_libraries(
+   vecmem_testing_cuda_main
+   PUBLIC
+   CUDA::cudart
+   GTest::gtest
+   vecmem::core
+)
+
 # Test all of the CUDA library's features.
 vecmem_add_test( cuda
    "test_cuda_memory_resources.cpp"
@@ -26,7 +42,7 @@ vecmem_add_test( cuda
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.hpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.cpp"
-   LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda GTest::gtest_main
+   LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda vecmem_testing_cuda_main
                   vecmem_testing_common )
 
 # Set up a separate test that would ensure a C++17 standard. But only with
@@ -34,7 +50,7 @@ vecmem_add_test( cuda
 if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "11.0" )
    vecmem_add_test( cuda_cxx17
       "test_cuda_memory_resources.cu"
-      LINK_LIBRARIES vecmem::cuda GTest::gtest_main vecmem_testing_common )
+      LINK_LIBRARIES vecmem::cuda vecmem_testing_cuda_main vecmem_testing_common )
    set_target_properties( vecmem_test_cuda_cxx17 PROPERTIES
       CUDA_STANDARD 17 )
 endif()

--- a/tests/cuda/test_cuda_main.cpp
+++ b/tests/cuda/test_cuda_main.cpp
@@ -1,0 +1,27 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include "../../cuda/src/utils/cuda_error_handling.hpp"
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+
+    int r = RUN_ALL_TESTS();
+
+    int devices = 0;
+
+    cudaGetDeviceCount(&devices);
+
+    if (devices > 0) {
+        VECMEM_CUDA_ERROR_CHECK(cudaDeviceReset());
+    }
+
+    return r;
+}


### PR DESCRIPTION
One of the goals of vecmem's tests is to make sure that there are no memory leaks. For CPU code, we can test this by using valgrind, and for CUDA we can test the same thing using `cuda-memcheck`. However, the CUDA memchecker has a peculiar feature where the leak checker (`--leak-check full`) only works if you make a call to `cudaDeviceReset` at the end of your program. We currently rely on our tests being linked against the GTest standard main function, which for obvious reasons does not include this test. In this commit, I add a new CUDA-specific Google Test main function which we can use instead, which makes the correct call to the CUDA device reset function.