### PR TITLE
Shared Library Linking Update, main branch (2021.12.08.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -15,12 +15,10 @@ if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
     ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
 
    # Basic flags for all build modes.
-   foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
-      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wall" )
-      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wextra" )
-      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wshadow" )
-      vecmem_add_flag( CMAKE_CXX_FLAGS_${mode} "-Wunused-local-typedefs" )
-   endforeach()
+   vecmem_add_flag( CMAKE_CXX_FLAGS "-Wall" )
+   vecmem_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
+   vecmem_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
+   vecmem_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
 
    # More rigorous tests for the Debug builds.
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "-Werror" )
@@ -36,4 +34,12 @@ elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC" )
    # More rigorous tests for the Debug builds.
    vecmem_add_flag( CMAKE_CXX_FLAGS_DEBUG "/WX" )
 
+endif()
+
+# Do not allow symbols to be missing from shared libraries.
+if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )
+   vecmem_add_flag( CMAKE_SHARED_LINKER_FLAGS "-Wl,-undefined,error" )
+elseif( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
+        ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
+   vecmem_add_flag( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined" )
 endif()


### PR DESCRIPTION
Triggered by the updates in #149, I added `-Wl,--no-undefined` for shared library linking with GCC/Clang. To make a bit more sure that the linking setup for our libraries is correct.

At the same time simplified the setup of the basic C\+\+ warning flags for GCC/Clang a little. These need to be set up a bit more awkwardly for HIP and SYCL, because of imperfections in our implementation of those languages in CMake. But for C\+\+ we don't have to be that complicated...