### PR TITLE
Static Array Update, main branch (2021.12.09.)

### DIFF
--- a/core/include/vecmem/containers/details/static_array_traits.hpp
+++ b/core/include/vecmem/containers/details/static_array_traits.hpp
@@ -1,0 +1,31 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem {
+namespace details {
+
+/// Helper type for an array with a given type and size
+///
+/// This is needed to handle zero-sized arrays correctly. As those are not
+/// part of the C++ standard.
+///
+template <typename T, std::size_t size>
+struct static_array_type {
+    typedef T type[size];
+};
+
+template <typename T>
+struct static_array_type<T, 0> {
+    struct type {};
+};
+
+}  // namespace details
+}  // namespace vecmem

--- a/core/include/vecmem/containers/details/static_vector_traits.hpp
+++ b/core/include/vecmem/containers/details/static_vector_traits.hpp
@@ -1,0 +1,31 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem {
+namespace details {
+
+/// Helper type for an array in a static_vector with a given type and size
+///
+/// This is needed to handle zero-sized arrays correctly. As those are not
+/// part of the C++ standard.
+///
+template <typename T, std::size_t size>
+struct static_vector_type {
+    typedef T type[size];
+};
+
+template <typename T>
+struct static_vector_type<T, 0> {
+    typedef T* type;
+};
+
+}  // namespace details
+}  // namespace vecmem

--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -8,17 +8,15 @@
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
 #include <cstddef>
 #include <stdexcept>
 #include <type_traits>
 
-#include "vecmem/utils/types.hpp"
-
 namespace vecmem {
-
-template <typename T, std::size_t N>
-VECMEM_HOST_AND_DEVICE constexpr static_array<T, N>::static_array(void)
-    : m_array() {}
 
 template <typename T, std::size_t N>
 VECMEM_HOST constexpr auto static_array<T, N>::at(size_type i) -> reference {
@@ -245,23 +243,6 @@ VECMEM_HOST_AND_DEVICE void static_array<T, N>::fill(const_reference value) {
     for (std::size_t i = 0; i < N; ++i) {
         m_array[i] = value;
     }
-}
-
-template <typename T, std::size_t N>
-template <typename Tp1, typename... Tp>
-VECMEM_HOST_AND_DEVICE constexpr void static_array<T, N>::static_array_impl(
-    size_type i, Tp1&& a1, Tp&&... a) {
-
-    m_array[i] = a1;
-    static_array_impl(i + 1, std::forward<Tp>(a)...);
-}
-
-template <typename T, std::size_t N>
-template <typename Tp1>
-VECMEM_HOST_AND_DEVICE constexpr void static_array<T, N>::static_array_impl(
-    size_type i, Tp1&& a1) {
-
-    m_array[i] = a1;
 }
 
 template <typename T, std::size_t N>

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -10,7 +10,7 @@
 
 // Local include(s).
 #include "vecmem/containers/details/reverse_iterator.hpp"
-#include "vecmem/utils/type_traits.hpp"
+#include "vecmem/containers/details/static_array_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
 // System include(s).
@@ -30,8 +30,8 @@ namespace vecmem {
  * @tparam N The size of the array.
  */
 template <typename T, std::size_t N>
-class static_array {
-public:
+struct static_array {
+
     /// @name Type definitions, mimicking @c std::array
     /// @{
 
@@ -60,45 +60,6 @@ public:
     /// Constant reverse iterator type
     using const_reverse_iterator =
         vecmem::details::reverse_iterator<const_iterator>;
-
-    /// @}
-
-    /// @name Constructors
-    /// @{
-
-    /**
-     * @brief Trivial constructor.
-     *
-     * This constructor does nothing, and leaves the inner array
-     * uninitialized.
-     */
-    VECMEM_HOST_AND_DEVICE
-    constexpr static_array(void);
-
-    /**
-     * @brief Construct an array from a parameter pack of arbitrary size.
-     *
-     * This constructor is of arbitrary arity, and inserts those elements in
-     * order into the array.
-     *
-     * @tparam Tp The parameter pack for the arguments.
-     *
-     * @warning The std::array implementation of this constructor requires
-     * the parameter list to be of size equal to or less than the array
-     * itself. This class is slightly different, as it requires the argument
-     * list to be exactly the same length. This protects the user from
-     * accidentally initializing an array with fewer values than necessary.
-     *
-     * @note All parameters passed to this function must be convertible to
-     * the array value type, but the values do not need to be homogeneous.
-     */
-    template <typename... Tp, typename = std::enable_if_t<sizeof...(Tp) == N>,
-              typename = std::enable_if_t<
-                  details::conjunction_v<std::is_convertible<Tp, T>...> > >
-    VECMEM_HOST_AND_DEVICE constexpr static_array(Tp &&... a) : m_array() {
-
-        static_array_impl(0, std::forward<Tp>(a)...);
-    }
 
     /// @}
 
@@ -299,24 +260,10 @@ public:
 
     /// @}
 
-private:
-    /**
-     * @brief Private helper-constructor for the parameter pack constructor.
-     */
-    template <typename Tp1, typename... Tp>
-    VECMEM_HOST_AND_DEVICE constexpr void static_array_impl(size_type i,
-                                                            Tp1 &&a1,
-                                                            Tp &&... a);
-    /**
-     * @brief Private helper-constructor for the parameter pack constructor.
-     */
-    template <typename Tp1>
-    VECMEM_HOST_AND_DEVICE constexpr void static_array_impl(size_type i,
-                                                            Tp1 &&a1);
-
     /// Array holding the container's data
-    typename details::array_type<T, N>::type m_array;
-};
+    typename details::static_array_type<T, N>::type m_array;
+
+};  // struct static_array
 
 /// Equality check on two arrays
 template <typename T, std::size_t N>

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -8,6 +8,7 @@
 
 // Local include(s).
 #include "vecmem/containers/details/reverse_iterator.hpp"
+#include "vecmem/containers/details/static_vector_traits.hpp"
 #include "vecmem/utils/type_traits.hpp"
 #include "vecmem/utils/types.hpp"
 
@@ -44,9 +45,8 @@ public:
     /// The size of the vector elements
     static constexpr size_type value_size = sizeof(value_type);
     /// Type of the array holding the payload of the vector elements
-    typedef
-        typename details::array_type<char, array_max_size * value_size>::type
-            array_type;
+    typedef typename details::static_vector_type<
+        char, array_max_size * value_size>::type array_type;
 
     /// Value reference type
     typedef value_type& reference;

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -27,21 +27,6 @@ template <typename iterator_type, typename value_type>
 using is_iterator_of = std::is_convertible<
     typename std::iterator_traits<iterator_type>::value_type, value_type>;
 
-/// Helper type for an array with a given type and size
-///
-/// This is needed to handle zero-sized arrays correctly. As those are not
-/// part of the C++ standard.
-///
-template <typename T, std::size_t size>
-struct array_type {
-    typedef T type[size];
-};
-
-template <typename T>
-struct array_type<T, 0> {
-    typedef T* type;
-};
-
 /// Helper trait for detecting when a type is a non-const version of another
 ///
 /// This comes into play multiple times to enable certain constructors

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -152,12 +152,12 @@ TEST_F(core_container_test, static_array) {
     for (int i = 0; i < ARRAY_SIZE; ++i) {
         EXPECT_EQ(test_array3.at(i), 12);
     }
-    const vecmem::static_array<int, 0> test_array4;
+    const vecmem::static_array<int, 0> test_array4{};
     EXPECT_EQ(test_array4.size(), 0);
     EXPECT_EQ(test_array4.max_size(), 0);
     EXPECT_TRUE(test_array4.empty());
 
-    constexpr vecmem::static_array<int, 0> test_array5;
+    constexpr vecmem::static_array<int, 0> test_array5{};
     constexpr auto test_array5_size = test_array5.size();
     EXPECT_EQ(test_array5_size, 0);
     constexpr auto test_array5_max_size = test_array5.max_size();

--- a/tests/core/test_core_static_array.cpp
+++ b/tests/core/test_core_static_array.cpp
@@ -34,7 +34,7 @@ TEST_F(core_static_array_test, bounds_check_exception) {
 }
 
 TEST_F(core_static_array_test, initializer) {
-    vecmem::static_array<int, 3> arr(4, 76, 1);
+    vecmem::static_array<int, 3> arr{4, 76, 1};
 
     EXPECT_EQ(arr[0], 4);
     EXPECT_EQ(arr[1], 76);
@@ -50,7 +50,7 @@ TEST_F(core_static_array_test, bracket_initializer) {
 }
 
 TEST_F(core_static_array_test, assignment) {
-    vecmem::static_array<int, 3> proto(4, 76, 1);
+    vecmem::static_array<int, 3> proto{4, 76, 1};
     vecmem::static_array<int, 3> arr = proto;
 
     EXPECT_EQ(arr[0], 4);
@@ -59,7 +59,7 @@ TEST_F(core_static_array_test, assignment) {
 }
 
 TEST_F(core_static_array_test, copy) {
-    vecmem::static_array<int, 3> proto(4, 76, 1);
+    vecmem::static_array<int, 3> proto{4, 76, 1};
     vecmem::static_array<int, 3> arr(proto);
 
     EXPECT_EQ(arr[0], 4);
@@ -68,9 +68,9 @@ TEST_F(core_static_array_test, copy) {
 }
 
 TEST_F(core_static_array_test, equality) {
-    vecmem::static_array<int, 3> a1(4, 76, 1);
-    vecmem::static_array<int, 3> a2(4, 76, 1);
-    vecmem::static_array<int, 3> a3(4, 76, 2);
+    vecmem::static_array<int, 3> a1{4, 76, 1};
+    vecmem::static_array<int, 3> a2{4, 76, 1};
+    vecmem::static_array<int, 3> a3{4, 76, 2};
 
     EXPECT_TRUE(a1 == a1);
     EXPECT_TRUE(a2 == a2);
@@ -84,9 +84,9 @@ TEST_F(core_static_array_test, equality) {
 }
 
 TEST_F(core_static_array_test, inequality) {
-    vecmem::static_array<int, 3> a1(4, 76, 1);
-    vecmem::static_array<int, 3> a2(4, 76, 1);
-    vecmem::static_array<int, 3> a3(4, 76, 2);
+    vecmem::static_array<int, 3> a1{4, 76, 1};
+    vecmem::static_array<int, 3> a2{4, 76, 1};
+    vecmem::static_array<int, 3> a3{4, 76, 2};
 
     EXPECT_FALSE(a1 != a1);
     EXPECT_FALSE(a2 != a2);
@@ -100,16 +100,16 @@ TEST_F(core_static_array_test, inequality) {
 }
 
 TEST_F(core_static_array_test, front) {
-    vecmem::static_array<int, 3> arr1(4, 76, 1);
-    vecmem::static_array<int, 1> arr2(7);
+    vecmem::static_array<int, 3> arr1{4, 76, 1};
+    vecmem::static_array<int, 1> arr2{7};
 
     EXPECT_EQ(arr1.front(), 4);
     EXPECT_EQ(arr2.front(), 7);
 }
 
 TEST_F(core_static_array_test, back) {
-    vecmem::static_array<int, 3> arr1(4, 76, 1);
-    vecmem::static_array<int, 1> arr2(7);
+    vecmem::static_array<int, 3> arr1{4, 76, 1};
+    vecmem::static_array<int, 1> arr2{7};
 
     EXPECT_EQ(arr1.back(), 1);
     EXPECT_EQ(arr2.back(), 7);

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -8,6 +8,7 @@
 // Local include(s).
 #include "test_cuda_containers_kernels.cuh"
 #include "vecmem/containers/array.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/memory/cuda/device_memory_resource.hpp"
 #include "vecmem/memory/cuda/host_memory_resource.hpp"
@@ -200,4 +201,38 @@ TEST_F(cuda_containers_test, extendable_memory) {
     for (int value : output) {
         EXPECT_LT(10, value);
     }
+}
+
+/// Test the usage of an @c array<vector<...>> construct
+TEST_F(cuda_containers_test, array_memory) {
+
+    // The memory resource(s).
+    vecmem::cuda::managed_memory_resource managed_resource;
+
+    // Create an array of vectors.
+    vecmem::static_array<vecmem::vector<int>, 4> vec_array{
+        vecmem::vector<int>{{1, 2, 3, 4}, &managed_resource},
+        vecmem::vector<int>{{5, 6}, &managed_resource},
+        vecmem::vector<int>{{7, 8, 9}, &managed_resource},
+        vecmem::vector<int>{&managed_resource}};
+
+    // Create an appropriate data object out of it.
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> vec_data{
+        vecmem::get_data(vec_array[0]), vecmem::get_data(vec_array[1]),
+        vecmem::get_data(vec_array[2]), vecmem::get_data(vec_array[3])};
+
+    // Run a kernel on it.
+    arrayTransform(vec_data);
+
+    // Check its contents.
+    EXPECT_EQ(vec_array.at(0).at(0), 2);
+    EXPECT_EQ(vec_array.at(0).at(1), 4);
+    EXPECT_EQ(vec_array.at(0).at(2), 6);
+    EXPECT_EQ(vec_array.at(0).at(3), 8);
+    EXPECT_EQ(vec_array.at(1).at(0), 10);
+    EXPECT_EQ(vec_array.at(1).at(1), 12);
+    EXPECT_EQ(vec_array.at(2).at(0), 14);
+    EXPECT_EQ(vec_array.at(2).at(1), 16);
+    EXPECT_EQ(vec_array.at(2).at(2), 18);
+    EXPECT_EQ(vec_array.at(3).size(), 0u);
 }

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -199,3 +199,37 @@ void fillTransform(vecmem::data::jagged_vector_view<int> vec) {
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
 }
+
+/// Kernel multiplying each element of the received structure by 2.
+__global__ void arrayTransformKernel(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data) {
+
+    // Find the current indices,
+    const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    const std::size_t j = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i >= data.size()) {
+        return;
+    }
+    if (j >= data[i].size()) {
+        return;
+    }
+
+    // Create the "device type".
+    vecmem::static_array<vecmem::device_vector<int>, 4> vec{data[0], data[1],
+                                                            data[2], data[3]};
+
+    // Perform the transformation.
+    vec[i][j] *= 2;
+}
+
+void arrayTransform(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data) {
+
+    // Launch the kernel.
+    const dim3 dimensions(4u, 4u);
+    arrayTransformKernel<<<1, dimensions>>>(data);
+
+    // Check whether it succeeded to run.
+    VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
+    VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+}

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -10,6 +10,7 @@
 // Local include(s).
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/static_array.hpp"
 #include "vecmem/utils/cuda/stream_wrapper.hpp"
 
 // System include(s).
@@ -41,3 +42,7 @@ void filterTransform(vecmem::data::jagged_vector_view<const int> input,
 
 /// Function filling the jagged vector to its capacity
 void fillTransform(vecmem::data::jagged_vector_view<int> vec);
+
+/// Function transforming the elements of an array of vectors
+void arrayTransform(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data);

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -247,3 +247,37 @@ void fillTransform(vecmem::data::jagged_vector_view<int> vec) {
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
 }
+
+/// Kernel multiplying each element of the received structure by 2.
+__global__ void arrayTransformKernel(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data) {
+
+    // Find the current indices,
+    const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    const std::size_t j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    if (i >= data.size()) {
+        return;
+    }
+    if (j >= data[i].size()) {
+        return;
+    }
+
+    // Create the "device type".
+    vecmem::static_array<vecmem::device_vector<int>, 4> vec{data[0], data[1],
+                                                            data[2], data[3]};
+
+    // Perform the transformation.
+    vec[i][j] *= 2;
+}
+
+void arrayTransform(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data) {
+
+    // Launch the kernel.
+    const dim3 dimensions(4u, 4u);
+    hipLaunchKernelGGL(arrayTransformKernel, 1, dimensions, 0, nullptr, data);
+
+    // Check whether it succeeded to run.
+    VECMEM_HIP_ERROR_CHECK(hipGetLastError());
+    VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+}

--- a/tests/hip/test_hip_containers_kernels.hpp
+++ b/tests/hip/test_hip_containers_kernels.hpp
@@ -9,6 +9,7 @@
 // Local include(s).
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/static_array.hpp"
 
 // System include(s).
 #include <cstddef>
@@ -38,3 +39,7 @@ void filterTransform(vecmem::data::jagged_vector_view<const int> input,
 
 /// Function filling the jagged vector to its capacity
 void fillTransform(vecmem::data::jagged_vector_view<int> vec);
+
+/// Function transforming the elements of an array of vectors
+void arrayTransform(
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> data);

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -260,3 +260,62 @@ TEST_F(sycl_containers_test, extendable_memory) {
         EXPECT_LT(10, value);
     }
 }
+
+/// Test the usage of an @c array<vector<...>> construct
+TEST_F(sycl_containers_test, array_memory) {
+
+    // Create the SYCL queue that we'll be using in the test.
+    cl::sycl::queue queue{vecmem::sycl::device_selector()};
+
+    // The memory resource(s).
+    vecmem::sycl::shared_memory_resource shared_resource(&queue);
+
+    // Create an array of vectors.
+    vecmem::static_array<vecmem::vector<int>, 4> vec_array{
+        vecmem::vector<int>{{1, 2, 3, 4}, &shared_resource},
+        vecmem::vector<int>{{5, 6}, &shared_resource},
+        vecmem::vector<int>{{7, 8, 9}, &shared_resource},
+        vecmem::vector<int>{&shared_resource}};
+
+    // Create an appropriate data object out of it.
+    vecmem::static_array<vecmem::data::vector_view<int>, 4> vec_data{
+        vecmem::get_data(vec_array[0]), vecmem::get_data(vec_array[1]),
+        vecmem::get_data(vec_array[2]), vecmem::get_data(vec_array[3])};
+
+    // Run a kernel on it that multiplies each element in the array of vectors
+    // by 2.
+    queue
+        .submit([&vec_data](cl::sycl::handler& h) {
+            h.parallel_for<class ArrayVecTest>(
+                cl::sycl::range<2>(4, 4),
+                [data = vec_data](cl::sycl::item<2> id) {
+                    // Check if anything needs to be done.
+                    if (id[0] >= data.size()) {
+                        return;
+                    }
+                    if (id[1] >= data[id[0]].size()) {
+                        return;
+                    }
+
+                    // Create the "device type".
+                    vecmem::static_array<vecmem::device_vector<int>, 4> vec{
+                        data[0], data[1], data[2], data[3]};
+
+                    // Perform the transformation.
+                    vec[id[0]][id[1]] *= 2;
+                });
+        })
+        .wait_and_throw();
+
+    // Check its contents.
+    EXPECT_EQ(vec_array.at(0).at(0), 2);
+    EXPECT_EQ(vec_array.at(0).at(1), 4);
+    EXPECT_EQ(vec_array.at(0).at(2), 6);
+    EXPECT_EQ(vec_array.at(0).at(3), 8);
+    EXPECT_EQ(vec_array.at(1).at(0), 10);
+    EXPECT_EQ(vec_array.at(1).at(1), 12);
+    EXPECT_EQ(vec_array.at(2).at(0), 14);
+    EXPECT_EQ(vec_array.at(2).at(1), 16);
+    EXPECT_EQ(vec_array.at(2).at(2), 18);
+    EXPECT_EQ(vec_array.at(3).size(), 0u);
+}


### PR DESCRIPTION
Triggered by #151, I came up with this.

As I wrote there, `vecmem::static_array` has done things in a slightly funky way so far. But I had to realise that the libstdc\+\+ developers came up with a better design for their array class after all. :stuck_out_tongue: So I now embraced that setup in `vecmem::static_array` as well.

This means that the class would not have any explicit constructors. It is now declared as a "simple" struct with just a single member variable. Which the language can figure out itself how to generate functional constructors for...

One downside of this is that while with the previous implementation it was possible to write things like

```c++
vecmem::static_array<int, 4> a(1, 2, 3, 4);
```

, now "only" the curly-braced formalism works. I.e.:

```c++
vecmem::static_array<int, 4> a{1, 2, 3, 4};
```

But
  - `std::array` behaves the same;
  - this should be a small enough price to pay for making `vecmem::static_array` functional with non-copyable/non-movable elements.

I also had to tweak `vecmem::static_vector` slightly, since it was sharing some code with `vecmem::static_array` until now. But with the new implementation it doesn't do that anymore.

I added a simple test for all device languages, just to make sure that this would work. And it seems to. :smile: