### PR TITLE
CUDA Windows Fix, main branch (2021.12.09.)

### DIFF
--- a/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
+++ b/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
@@ -27,6 +27,10 @@ class opaque_stream;
 #pragma warning(push)
 #pragma warning(disable : 4251)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1394
+#endif  // CUDA disgnostics
 
 /// Wrapper class for @c cudaStream_t
 ///
@@ -81,3 +85,6 @@ private:
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // CUDA disgnostics


### PR DESCRIPTION
Disabled the NVCC specific warning about using `std::unique_ptr` in an exported (DLL) class. (`vecmem::cuda::stream_wrapper`)

It was already disabled for MSVC, but I forgot that the class would be seen by NVCC as well...