### PR TITLE
Buffer Alignment Fixes, main branch (2022.01.25.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -112,6 +112,8 @@ private:
     vecmem::unique_alloc_ptr<value_type[]> m_outer_memory;
     /// Data object for the @c vecmem::data::vector_view array on the host
     vecmem::unique_alloc_ptr<value_type[]> m_outer_host_memory;
+    /// Size of the buffer held by @c m_inner_memory;
+    std::size_t m_inner_memory_size;
     /// Data object owning the memory of the "inner vectors"
     vecmem::unique_alloc_ptr<char[]> m_inner_memory;
 

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -10,6 +10,7 @@
 // System include(s).
 #include <cassert>
 #include <cstddef>
+#include <memory>
 #include <numeric>
 #include <vector>
 
@@ -25,18 +26,6 @@ std::vector<std::size_t> get_sizes(
         result[i] = jvv.m_ptr[i].size();
     }
     return result;
-}
-
-/// Get the padding needed after the size array for correct alignment
-template <typename TYPE>
-std::size_t get_buffer_alignment_padding(std::size_t size) {
-
-    // Total size of the size array.
-    const std::size_t size_size =
-        size * sizeof(typename vecmem::data::jagged_vector_buffer<
-                      TYPE>::value_type::size_type);
-    // Return the padding needed after the size array.
-    return (alignof(TYPE) - (size_size % alignof(TYPE)));
 }
 
 /// Function allocating memory for @c vecmem::data::jagged_vector_buffer
@@ -60,19 +49,27 @@ allocate_jagged_buffer_outer_memory(
 template <typename TYPE>
 vecmem::unique_alloc_ptr<char[]> allocate_jagged_buffer_inner_memory(
     const std::vector<std::size_t>& sizes, vecmem::memory_resource& resource,
-    bool isResizable) {
-    typename vecmem::data::jagged_vector_buffer<TYPE>::size_type byteSize =
-        std::accumulate(sizes.begin(), sizes.end(),
-                        static_cast<std::size_t>(0)) *
-        sizeof(TYPE);
+    bool isResizable, std::size_t& bufferSize) {
+
+    // Alignment for the vector elements.
+    static constexpr std::size_t alignment = alignof(TYPE);
+
+    // Determine the allocation size.
+    bufferSize = std::accumulate(sizes.begin(), sizes.end(),
+                                 static_cast<std::size_t>(0)) *
+                 sizeof(TYPE);
+    // Increase this size if the buffer describes a resizable vector.
     if (isResizable) {
-        byteSize +=
+        bufferSize +=
             sizes.size() * sizeof(typename vecmem::data::jagged_vector_buffer<
-                                  TYPE>::value_type::size_type) +
-            get_buffer_alignment_padding<TYPE>(sizes.size());
+                                  TYPE>::value_type::size_type);
+        // Further increase this size so that we could for sure align the
+        // payload data correctly.
+        bufferSize = ((bufferSize + alignment - 1) / alignment) * alignment;
     }
 
-    return vecmem::make_unique_alloc<char[]>(resource, byteSize);
+    // Return a smart pointer with the allocation.
+    return vecmem::make_unique_alloc<char[]>(resource, bufferSize);
 }
 
 }  // namespace
@@ -101,8 +98,9 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
           sizes.size(),
           (host_access_resource == nullptr ? resource
                                            : *host_access_resource))),
-      m_inner_memory(
-          ::allocate_jagged_buffer_inner_memory<TYPE>(sizes, resource, false)) {
+      m_inner_memory_size(0u),
+      m_inner_memory(::allocate_jagged_buffer_inner_memory<TYPE>(
+          sizes, resource, false, m_inner_memory_size)) {
 
     // Point the base class at the newly allocated memory.
     base_type::m_ptr =
@@ -131,8 +129,9 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
           sizes.size(),
           (host_access_resource == nullptr ? resource
                                            : *host_access_resource))),
+      m_inner_memory_size(0u),
       m_inner_memory(::allocate_jagged_buffer_inner_memory<TYPE>(
-          capacities, resource, true)) {
+          capacities, resource, true, m_inner_memory_size)) {
 
     // Some sanity check.
     assert(sizes.size() == capacities.size());
@@ -142,17 +141,36 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
         ((host_access_resource != nullptr) ? m_outer_memory.get()
                                            : m_outer_host_memory.get());
 
-    // Set up the host accessible memory array.
-    std::ptrdiff_t ptrdiff =
-        (capacities.size() * sizeof(typename value_type::size_type)) +
-        get_buffer_alignment_padding<TYPE>(capacities.size());
+    // Size of the data payload.
+    const std::size_t dataSize =
+        std::accumulate(capacities.begin(), capacities.end(),
+                        static_cast<std::size_t>(0)) *
+        sizeof(TYPE);
+
+    //
+    // Construct a correctly aligned "start pointer" for the data elements.
+    //
+    // Construct the unaligned pointer by simply jumping over the "size array".
+    void* unaligned_start_ptr =
+        m_inner_memory.get() +
+        (capacities.size() * sizeof(typename value_type::size_type));
+    // The remaining size of the buffer, with the "size array" size removed.
+    std::size_t buffer_size =
+        m_inner_memory_size -
+        (capacities.size() * sizeof(typename value_type::size_type));
+    // Construct the "start pointer" using std::align.
+    char* start_ptr = static_cast<char*>(
+        std::align(alignof(TYPE), dataSize, unaligned_start_ptr, buffer_size));
+
+    // Set up the vecmem::vector_view objects in the host accessible memory.
+    std::ptrdiff_t ptrdiff = 0;
     for (std::size_t i = 0; i < capacities.size(); ++i) {
         new (host_ptr() + i) value_type(
             static_cast<typename value_type::size_type>(capacities[i]),
             reinterpret_cast<typename value_type::size_pointer>(
                 m_inner_memory.get() +
                 i * sizeof(typename value_type::size_type)),
-            reinterpret_cast<TYPE*>(m_inner_memory.get() + ptrdiff));
+            reinterpret_cast<TYPE*>(start_ptr + ptrdiff));
         ptrdiff += capacities[i] * sizeof(TYPE);
     }
 }

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -46,3 +46,9 @@ void fillTransform(vecmem::data::jagged_vector_view<int> vec);
 /// Function transforming the elements of an array of vectors
 void arrayTransform(
     vecmem::static_array<vecmem::data::vector_view<int>, 4> data);
+
+/// Function performing a trivial operation on a "large" vector buffer
+void largeBufferTransform(vecmem::data::vector_view<unsigned long> data);
+
+/// Function performing a trivial operation on a "large" jagged vector buffer
+void largeBufferTransform(vecmem::data::jagged_vector_view<unsigned long> data);


### PR DESCRIPTION
As @beomki-yeo discovered in #159, the vector buffers were not laying out their memory quite correctly until now.

When using an element type with `sizeof(TYPE) > sizeof(unsigned int)`, it could happen that the pointers provided by the buffers for the vector elements would not have an alignment that CUDA device code would be happy with. Resulting in a cryptic error from the CUDA runtime.

This PR introduces code that would pad the buffers in a way that would make the vector elements aligned correctly for both 1D and 2D (jagged) re-sizable vectors. (Since the issue was only there for re-sizable vectors in the first place.)

I also added tests inspired by Beomki's code to explicitly test both `vecmem::data::vector_buffer` and `vecmem::data::jagged_vector_buffer` for this from now on.

Others thinking about this a bit will definitely help. As I'm not absolutely convinced that I did this correctly. Actually, I'm a bit more convinced about the code I wrote for jagged vectors than the one I did for "normal" ones. (I wrote the jagged vector code after the normal one...)