### PR TITLE
SYCL Improvements, main branch (2022.01.28.)

### DIFF
--- a/cmake/vecmem-check-sycl-code-compiles.cmake
+++ b/cmake/vecmem-check-sycl-code-compiles.cmake
@@ -1,12 +1,21 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# CMake version requirement.
+cmake_minimum_required( VERSION 3.14 )
+
+# CMake include(s).
+include( CMakeParseArguments )
 
 # Helper function for checking if some SYCL files can be built into an
 # executable.
 function( vecmem_check_sycl_code_compiles _variable )
+
+   # Parse the optional function arguments.
+   cmake_parse_arguments( ARG "" "" "COMPILE_DEFINITIONS" ${ARGN} )
 
    # Enable the SYCL language.
    enable_language( SYCL )
@@ -26,7 +35,8 @@ function( vecmem_check_sycl_code_compiles _variable )
    # Perform the build attempt.
    try_compile( ${_variable}
       "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_variable}"
-      SOURCES ${ARGN} )
+      SOURCES ${ARG_UNPARSED_ARGUMENTS}
+      COMPILE_DEFINITIONS ${ARG_COMPILE_DEFINITIONS} )
 
    # Print a result message.
    if( ${_variable} )

--- a/cmake/vecmem-compiler-options-sycl.cmake
+++ b/cmake/vecmem-compiler-options-sycl.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -20,7 +20,6 @@ foreach( mode RELEASE RELWITHDEBINFO MINSIZEREL DEBUG )
 endforeach()
 
 # More rigorous tests for the Debug builds.
-vecmem_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-Werror" )
 if( NOT WIN32 )
    vecmem_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-pedantic" )
 endif()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -79,3 +79,12 @@ vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_MEMSET
 if( VECMEM_HAVE_SYCL_MEMSET )
    target_compile_definitions( vecmem_sycl PRIVATE VECMEM_HAVE_SYCL_MEMSET )
 endif()
+
+# Check if a definitely error-free source file can be compiled successfully with
+# -Werror, and only add it to the debug builds if it can be.
+vecmem_check_sycl_code_compiles( VECMEM_SYCL_WERROR_USABLE
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/warning_test.sycl"
+   COMPILE_DEFINITIONS "-Werror" )
+if( VECMEM_SYCL_WERROR_USABLE )
+   vecmem_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-Werror" )
+endif()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -63,6 +63,8 @@ if( NOT VECMEM_HAVE_SYCL_ASSERT )
       # Set up the vecmem::sycl_polyfill library.
       vecmem_add_library( vecmem_sycl_polyfill sycl_polyfill TYPE STATIC
          "src/utils/sycl/cuda_assert_polyfill.sycl" )
+      set_target_properties( vecmem_sycl_polyfill PROPERTIES
+         POSITION_INDEPENDENT_CODE ON )
       target_link_libraries( vecmem_sycl INTERFACE vecmem::sycl_polyfill )
 
    else()

--- a/sycl/cmake/warning_test.sycl
+++ b/sycl/cmake/warning_test.sycl
@@ -1,0 +1,13 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+int main() {
+    return 0;
+}

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -10,6 +10,14 @@ enable_language( SYCL )
 # Project include(s).
 include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
+
+# Activate the -Werror flag for debug builds, based on what was found in the
+# vecmem::sycl library's setup. (Here we assume that vecmem::sycl's build was
+# configured before we would get here, so the variable would already be in the
+# cache.)
+if( VECMEM_SYCL_WERROR_USABLE )
+   vecmem_add_flag( CMAKE_SYCL_FLAGS_DEBUG "-Werror" )
+endif()
 
 # Test all of the SYCL library's features.
 vecmem_add_test( sycl


### PR DESCRIPTION
These have both bothered me a number of times already, so I finally wanted to give a proper solution to them.

First off, `vecmem::sycl_polyfill` needed to be switched to position independent code. Otherwise `vecmem::sycl` can not be linked successfully to shared libraries, in the cases where the polyfill is needed.

The more complicated issue was that with recent [intel/llvm](https://github.com/intel/llvm) nightlies, when building code for the CUDA or HIP backend, such warnings would be printed by the compiler due to issues in the compiler itself:

```
warning: linking module '/home/krasznaa/software/intel/clang/nightly-20220115/x86_64-ubuntu2004-gcc9-opt/lib/clang/14.0.0/../../clc/remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc': Linking two modules of different target triples: '/home/krasznaa/software/intel/clang/nightly-20220115/x86_64-ubuntu2004-gcc9-opt/lib/clang/14.0.0/../../clc/remangled-l64-signed_char.libspirv-nvptx64--nvidiacl.bc' is 'nvptx64-unknown-nvidiacl' whereas '/data/ssd-1tb/projects/vecmem/vecmem/sycl/src/utils/sycl/device_selector.sycl' is 'nvptx64-nvidia-cuda'
 [-Wlinker-warnings]
```

So now I turned off the use of `-Werror` when even an empty `.sycl` file would not manage to compile successfully with it being used. I was considering adding `-Wno-linker-warnings` in some cases, but this seemed more robust. (Hopefully the Intel code will stop issuing these annoying warnings in not too long...)