### PR TITLE
SYCL Improvements, main branch (2022.02.02.)

### DIFF
--- a/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
+++ b/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -78,7 +78,11 @@ message( STATUS "The SYCL compiler identification is "
 
 # Set up what source/object file names to use.
 set( CMAKE_SYCL_SOURCE_FILE_EXTENSIONS "sycl" )
-set( CMAKE_SYCL_OUTPUT_EXTENSION ".o" )
+if( UNIX )
+   set( CMAKE_SYCL_OUTPUT_EXTENSION ".o" )
+else()
+   set( CMAKE_SYCL_OUTPUT_EXTENSION ".obj" )
+endif()
 set( CMAKE_SYCL_COMPILER_ENV_VAR "SYCLCXX" )
 
 # Set how the compiler should pass include directories to the SYCL compiler.
@@ -99,6 +103,13 @@ set( CMAKE_SYCL_FLAGS_DEBUG_INIT "${CMAKE_CXX_FLAGS_DEBUG_INIT}" )
 set( CMAKE_SYCL_FLAGS_RELEASE_INIT "${CMAKE_CXX_FLAGS_RELEASE_INIT}" )
 set( CMAKE_SYCL_FLAGS_RELWITHDEBINFO_INIT
    "${CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT}" )
+
+# Implicit include paths and libraries, based on the C++ compiler in use.
+set( CMAKE_SYCL_IMPLICIT_INCLUDE_DIRECTORIES
+   "${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}" )
+set( CMAKE_SYCL_IMPLICIT_LINK_LIBRARIES "${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}" )
+set( CMAKE_SYCL_IMPLICIT_LINK_DIRECTORIES
+   "${CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES}" )
 
 # Set up C++17 by default.
 set( CMAKE_SYCL_STANDARD 17 CACHE STRING "C++ standard to use with SYCL" )

--- a/cmake/sycl/CMakeSYCLCompiler.cmake.in
+++ b/cmake/sycl/CMakeSYCLCompiler.cmake.in
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -18,6 +18,13 @@ set( CMAKE_SYCL_COMPILE_OPTIONS_PIC @CMAKE_SYCL_COMPILE_OPTIONS_PIC@ )
 set( CMAKE_SYCL_FLAGS "@CMAKE_SYCL_FLAGS_INIT@" )
 set( CMAKE_SYCL_LINKER_PREFERENCE 50 )
 set( CMAKE_SYCL_LINKER_PREFERENCE_PROPAGATES 1 )
+
+# Do not let CMake specify "system/implicit directories" for the SYCL compiler.
+set( CMAKE_SYCL_IMPLICIT_INCLUDE_DIRECTORIES
+   "@CMAKE_SYCL_IMPLICIT_INCLUDE_DIRECTORIES@" )
+set( CMAKE_SYCL_IMPLICIT_LINK_LIBRARIES "@CMAKE_SYCL_IMPLICIT_LINK_LIBRARIES@" )
+set( CMAKE_SYCL_IMPLICIT_LINK_DIRECTORIES
+   "@CMAKE_SYCL_IMPLICIT_LINK_DIRECTORIES@" )
 
 # Set up the optimisation flags for the SYCL compiler.
 set( CMAKE_SYCL_FLAGS_INIT " " )


### PR DESCRIPTION
Added a setting for the SYCL compiler's implicit directories/libraries. Thereby avoiding having cmake specify `-isystem /usr/include`, which breaks Clang. (And not just the Intel compiler.)

This fixes the issues described in https://github.com/intel/llvm/issues/4940 and in https://github.com/acts-project/traccc/pull/112. I finally had to figure out a proper fix in order to be able to set up a CI job for [traccc](https://github.com/acts-project/traccc), since it would be very inconvenient to pick up Boost from anything other than `/usr` in the CI. (The fixes are simple in the end, but finding the right incantation took some digging...)

While at it, I switched to using the `.obj` extension for object files on non-UNIX systems. (Cough... Windows... cough...)

Pinging @SylvainJoube and @konradkusiak97.