### PR TITLE
CUDA Runtime Dynamic Linking, main branch (2022.02.05.)

### DIFF
--- a/cmake/vecmem-compiler-options-cuda.cmake
+++ b/cmake/vecmem-compiler-options-cuda.cmake
@@ -4,6 +4,9 @@
 #
 # Mozilla Public License Version 2.0
 
+# CUDAToolkit requires CMake 3.17.
+cmake_minimum_required( VERSION 3.17 )
+
 # Include the helper function(s).
 include( vecmem-functions )
 
@@ -16,6 +19,10 @@ set( CMAKE_CUDA_STANDARD 14 CACHE STRING "The (CUDA) C++ standard to use" )
 # Set the architecture to build code for.
 set( CMAKE_CUDA_ARCHITECTURES "52" CACHE STRING
    "CUDA architectures to build device code for" )
+
+# Link against the dynamic CUDA runtime library by default.
+set( CMAKE_CUDA_RUNTIME_LIBRARY "dynamic" CACHE STRING
+   "Choice for the CUDA runtime library to use" )
 
 # Make CUDA generate debug symbols for the device code as well in a debug
 # build.

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -1,8 +1,11 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# CUDAToolkit requires CMake 3.17.
+cmake_minimum_required( VERSION 3.17 )
 
 # Enable CUDA as a language.
 enable_language( CUDA )


### PR DESCRIPTION
Made the build use the dynamic CUDA runtime library by default. All CUDA components are linked explicitly against `CUDA::cudart` since the beginning, and not against `CUDA::cudart_static`. So it's a surprise that an issue only came up now, with Visual Studio 2022 + CUDA 11.6. 😕 (Which combination I tried out today for the first time.)

```
[ 97%] Linking CXX executable ..\..\bin\vecmem_test_cuda.exe
        cd C:\Users\akraszna\ATLAS\VecMem\build\tests\cuda
        "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=CMakeFiles\vecmem_test_cuda.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests -- C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\MSVC\1430~1.307\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\vecmem_test_cuda.dir\objects1.rsp @C:\Users\akraszna\AppData\Local\Temp\nm1DB.tmp
Visual Studio Non-Incremental Link
LINK:
C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\MSVC\1430~1.307\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\vecmem_test_cuda.dir\objects1.rsp /out:..\..\bin\vecmem_test_cuda.exe /implib:..\..\lib\vecmem_test_cuda.lib /pdb:C:\Users\akraszna\ATLAS\VecMem\build\bin\vecmem_test_cuda.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console -LIBPATH:C:\PROGRA~1\NVIDIA~2\CUDA\v11.6\lib\x64 C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\lib\x64\cudart.lib ..\..\lib\vecmem_cuda.lib ..\..\lib\vecmem_testing_cuda_main.lib ..\..\lib\vecmem_testing_common.lib C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\lib\x64\cudart.lib ..\..\lib\vecmem_core.lib ..\..\lib\gtest.lib cudadevrt.lib cudart_static.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:..\..\bin\vecmem_test_cuda.exe.manifest
LINK: command "C:\PROGRA~1\MICROS~3\2022\COMMUN~1\VC\Tools\MSVC\1430~1.307\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\vecmem_test_cuda.dir\objects1.rsp /out:..\..\bin\vecmem_test_cuda.exe /implib:..\..\lib\vecmem_test_cuda.lib /pdb:C:\Users\akraszna\ATLAS\VecMem\build\bin\vecmem_test_cuda.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console -LIBPATH:C:\PROGRA~1\NVIDIA~2\CUDA\v11.6\lib\x64 C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\lib\x64\cudart.lib ..\..\lib\vecmem_cuda.lib ..\..\lib\vecmem_testing_cuda_main.lib ..\..\lib\vecmem_testing_common.lib C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\lib\x64\cudart.lib ..\..\lib\vecmem_core.lib ..\..\lib\gtest.lib cudadevrt.lib cudart_static.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:..\..\bin\vecmem_test_cuda.exe.manifest" failed (exit code 1169) with the following output:
cudart_static.lib(generated_cuda_runtime_api.obj) : error LNK2005: cudaDeviceSynchronize already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(generated_cuda_runtime_api.obj) : error LNK2005: cudaGetDevice already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(generated_cuda_runtime_api.obj) : error LNK2005: cudaGetErrorString already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(generated_cuda_runtime_api.obj) : error LNK2005: cudaGetLastError already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(generated_cuda_runtime_api.obj) : error LNK2005: cudaLaunchKernel already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaPopCallConfiguration already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaPushCallConfiguration already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaRegisterFatBinary already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaRegisterFatBinaryEnd already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaRegisterFunction already defined in cudart.lib(cudart64_110.dll)
cudart_static.lib(cuda_runtime_api.obj) : error LNK2005: __cudaUnregisterFatBinary already defined in cudart.lib(cudart64_110.dll)
   Creating library ..\..\lib\vecmem_test_cuda.lib and object ..\..\lib\vecmem_test_cuda.exp
..\..\bin\vecmem_test_cuda.exe : fatal error LNK1169: one or more multiply defined symbols found
NMAKE : fatal error U1077: '"C:\Program Files\CMake\bin\cmake.exe"' : return code '0xffffffff'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\nmake.exe"' : return code '0x2'
Stop.
```

Added explicit requirements for CMake 3.17 in a few more places, since both `FindCUDAToolkit.cmake` and the [CMAKE_CUDA_RUNTIME_LIBRARY](https://cmake.org/cmake/help/latest/variable/CMAKE_CUDA_RUNTIME_LIBRARY.html) setting need >=3.17 to work.