### PR TITLE
Visual Studio 2022 Update, main branch (2022.02.24.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -30,7 +30,7 @@ jobs:
           - OS: "macos-latest"
             GENERATOR: "Xcode"
           - OS: "windows-latest"
-            GENERATOR: "Visual Studio 16 2019"
+            GENERATOR: "Visual Studio 17 2022"
 
     # The system to run on.
     runs-on: ${{ matrix.PLATFORM.OS }}


### PR DESCRIPTION
Updated the Windows CI build to Visual Studio 2022. VS 2019 was finally removed from the windows-latest runners, after quite a lot of teasing... (CI jobs started failing today. Or at least I only noticed it today.)

Note that we will need to do the same in [algebra-plugins](https://github.com/acts-project/algebra-plugins) as well.