### PR TITLE
sycl::atomic_ref, main branch (2022.02.24.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -168,7 +168,7 @@ if(NOT VECMEM_HAVE_DEFAULT_RESOURCE)
       FILES "src/memory/default_resource_polyfill.cpp" )
 endif()
 
-# Figure out how to produce SYCL debug printouts.
+# Figure out how to use various SYCL features.
 if( VECMEM_BUILD_SYCL_LIBRARY )
 
    # Test which printf function(s) is/are available.
@@ -189,5 +189,13 @@ if( VECMEM_BUILD_SYCL_LIBRARY )
          " Enabling debug messages will likely not work." )
       target_compile_definitions( vecmem_core PUBLIC
          VECMEM_ONEAPI_PRINTF_FUNCTION=printf )
+   endif()
+
+   # Test whether sycl::atomic_ref is available.
+   vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_ATOMIC_REF
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/atomic_ref_test.sycl" )
+   if( VECMEM_HAVE_SYCL_ATOMIC_REF )
+      target_compile_definitions( vecmem_core PUBLIC
+         VECMEM_HAVE_SYCL_ATOMIC_REF )
    endif()
 endif()

--- a/core/cmake/atomic_ref_test.sycl
+++ b/core/cmake/atomic_ref_test.sycl
@@ -1,0 +1,21 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+int main() {
+    // Try to use sycl::atomic_ref.
+    int dummy = 0;
+    sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space>
+        atomic_dummy(dummy);
+    atomic_dummy.store(3);
+    atomic_dummy.fetch_add(1);
+    return 0;
+}


### PR DESCRIPTION
When `sycl::atomic_ref` is available, `vecmem::atomic` is now set up simply as a thin layer above that class.

Since oneAPI only added support for `sycl::atomic_ref` relatively recently, the CMake configuration needs to check whether that type is available with the particular SYCL compiler that we use, or not. If not, we stick to the code that we had so far. If it **is** available, then `vecmem::atomic` just inherits from `sycl::atomic_ref`. ("Making use" of `sycl::atomic_ref` inside of `vecmem::atomic` turned out way more expensive LoC-wise.)

Note that while writing this PR, I had to realise that a larger change should actually be done. I'm thinking of renaming `vecmem::atomic` to `vecmem::atomic_ref`, and making it use `sycl::atomic_ref` and `cuda::atomic_ref` (https://nvidia.github.io/libcudacxx/) underneath as appropriate. And even [std::atomic_ref](https://en.cppreference.com/w/cpp/atomic/atomic_ref) once we switch to C\+\+20 with these projects. :wink: (This will require updating all users of this type a little bit.)