### PR TITLE
CI Updates, main branch (2022.03.09.)

### DIFF
--- a/.github/ci_setup.sh
+++ b/.github/ci_setup.sh
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 #
@@ -15,8 +15,8 @@ PLATFORM_NAME=$1
 
 # Set up the correct environment for the SYCL tests.
 if [ "${PLATFORM_NAME}" = "SYCL" ]; then
-   source /opt/intel/oneapi/setvars.sh
-   export CXX=`which clang++`
-   export SYCLCXX=`which dpcpp`
+   if [ -f "/opt/intel/oneapi/setvars.sh" ]; then
+      source /opt/intel/oneapi/setvars.sh
+   fi
    export SYCL_DEVICE_FILTER=host
 fi

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -69,16 +69,27 @@ jobs:
         PLATFORM:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda:v11"
+            OPTIONS:
           - NAME: "CUDA"
             CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
+            OPTIONS:
           - NAME: "HIP"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm:v11"
+            OPTIONS:
           - NAME: "SYCL"
             CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v20"
+            OPTIONS:
           - NAME: "SYCL"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v20"
-          - NAME: "SYCL"
-            CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v20"
+            OPTIONS: -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
+        include:
+          - BUILD:
+              TYPE: "Release"
+              MSG_LVL: 0
+            PLATFORM:
+              NAME: "SYCL"
+              CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v20"
+              OPTIONS: -DVECMEM_BUILD_HIP_LIBRARY=FALSE
 
     # The system to run on.
     runs-on: ubuntu-latest
@@ -97,7 +108,7 @@ jobs:
     - name: Configure
       run: |
         source ${GITHUB_WORKSPACE}/.github/ci_setup.sh ${{ matrix.PLATFORM.NAME }}
-        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD.TYPE }} -DVECMEM_DEBUG_MSG_LVL=${{ matrix.BUILD.MSG_LVL }} -DVECMEM_BUILD_${{ matrix.PLATFORM.NAME }}_LIBRARY=TRUE -DVECMEM_BUILD_BENCHMARKING=TRUE -S ${GITHUB_WORKSPACE} -B build
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.BUILD.TYPE }} -DVECMEM_DEBUG_MSG_LVL=${{ matrix.BUILD.MSG_LVL }} -DVECMEM_BUILD_${{ matrix.PLATFORM.NAME }}_LIBRARY=TRUE -DVECMEM_BUILD_BENCHMARKING=TRUE ${{ matrix.PLATFORM.OPTIONS }} -S ${GITHUB_WORKSPACE} -B build
     # Perform the build.
     - name: Build
       run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -26,11 +26,11 @@ jobs:
             MSG_LVL: 5
         PLATFORM:
           - OS: "ubuntu-latest"
-            GENERATOR: "Unix Makefiles"
+            GENERATOR: -G "Unix Makefiles"
           - OS: "macos-latest"
-            GENERATOR: "Xcode"
+            GENERATOR: -G "Xcode"
           - OS: "windows-latest"
-            GENERATOR: "Visual Studio 17 2022"
+            GENERATOR:
 
     # The system to run on.
     runs-on: ${{ matrix.PLATFORM.OS }}
@@ -45,7 +45,7 @@ jobs:
                  -DVECMEM_DEBUG_MSG_LVL=${{ matrix.BUILD.MSG_LVL }}
                  -DVECMEM_BUILD_BENCHMARKING=TRUE
                  -S ${{ github.workspace }} -B build
-                 -G "${{ matrix.PLATFORM.GENERATOR }}"
+                 ${{ matrix.PLATFORM.GENERATOR }}
     # Perform the build.
     - name: Build
       run: cmake --build build --config ${{ matrix.BUILD.TYPE }}
@@ -74,7 +74,11 @@ jobs:
           - NAME: "HIP"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm:v11"
           - NAME: "SYCL"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v12"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v20"
+          - NAME: "SYCL"
+            CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v20"
+          - NAME: "SYCL"
+            CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v20"
 
     # The system to run on.
     runs-on: ubuntu-latest

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,11 +1,8 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
-
-# Project include(s).
-include( vecmem-compiler-options-cpp )
 
 # Set up Google Benchmark.
 option(

--- a/benchmarks/core/CMakeLists.txt
+++ b/benchmarks/core/CMakeLists.txt
@@ -1,8 +1,11 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Project include(s).
+include( vecmem-compiler-options-cpp )
 
 # Set up the benchmark(s) for the core library.
 add_executable(vecmem_benchmark_core "benchmark_core.cpp")

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -1,8 +1,12 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
+
+# Project include(s).
+include( vecmem-compiler-options-cpp )
+include( vecmem-compiler-options-cuda )
 
 # Set up the benchmark(s) for the CUDA library.
 add_executable(vecmem_benchmark_cuda "benchmark_cuda.cpp")

--- a/benchmarks/googlebenchmark/CMakeLists.txt
+++ b/benchmarks/googlebenchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -13,12 +13,14 @@ message( STATUS "Building Google Benchmark as part of the VecMem project" )
 
 # Declare where to get googlebenchmark from.
 FetchContent_Declare( googlebenchmark
-   URL "https://github.com/google/benchmark/archive/refs/tags/v1.6.0.tar.gz"
-   URL_MD5 "a7cb118b00430e22cb16774a28fce7ec" )
+   URL "https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz"
+   URL_MD5 "8c33c51f9b7154e6c290df3750081c87" )
 
 # Option(s) used in the build of Google Benchmark.
 set( BENCHMARK_ENABLE_TESTING OFF CACHE BOOL
    "Enable/disable testing of the benchmark library" )
+set( BENCHMARK_ENABLE_WERROR OFF CACHE BOOL
+   "Enable/disable using -Werror in the build of Google Benchmark" )
 
 # Get it into the current directory.
 FetchContent_Populate( googlebenchmark )


### PR DESCRIPTION
This is a collection of a number of updates. We recently added some more Docker images to [acts-project/machines](https://github.com/acts-project/machines) with @paulgessinger, which I now wanted to finally make use of. So I basically only wanted to update `build.yml`. Every other change in the PR is only there to support those updates. :stuck_out_tongue:

I added additional build jobs with the CUDA and HIP backends of Intel's compiler, to explicitly test those in the CI finally as well. The HIP backend unfortunately does not work in Debug mode at the moment, so the configuration needs to be a bit elaborate for that.

I had to update to the very latest version of [Google Benchmark](https://github.com/google/benchmark) to avoid warnings coming from the oneAPI C\+\+ compiler to make the build fail.

This also highlighted that the setup of the compiler flags for the benchmarks included in the repository was not quite perfect. Though that was not why the oneAPI compiler would receive the `-Werror` flag... (Still, I decided to clean that up as part of this PR.)

Finally, I removed the explicit setting for the build system generator on `windows-latest`. This should make the project more robust against future updates of GitHub.