### PR TITLE
Correctly import cassert.h in unique obj deleter

### DIFF
--- a/core/include/vecmem/memory/details/unique_obj_deleter.hpp
+++ b/core/include/vecmem/memory/details/unique_obj_deleter.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <type_traits>
 
 namespace vecmem::details {


### PR DESCRIPTION
A simple fix for a simple problem: I was running into some error where `assert` was an undefined name, and this turned out to be because one of the vecmem headers did not import it correctly. This commit fixes that.