### PR TITLE
Introduce vecmem::copy::memset, main branch (2022.05.02.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -66,6 +66,10 @@ public:
     template <typename TYPE>
     void setup(data::vector_view<TYPE>& data);
 
+    /// Set all bytes of the vector to some value
+    template <typename TYPE>
+    void memset(data::vector_view<TYPE>& data, int value);
+
     /// Copy a 1-dimensional vector to the specified memory resource
     template <typename TYPE>
     data::vector_buffer<std::remove_cv_t<TYPE>> to(
@@ -97,6 +101,14 @@ public:
     /// Copy the internal state of a jagged vector buffer to the target device
     template <typename TYPE>
     void setup(data::jagged_vector_buffer<TYPE>& data);
+
+    /// Set all bytes of the jagged vector to some value
+    template <typename TYPE>
+    void memset(data::jagged_vector_view<TYPE>& data, int value);
+
+    /// Set all bytes of the jagged vector to some value
+    template <typename TYPE>
+    void memset(data::jagged_vector_buffer<TYPE>& data, int value);
 
     /// Copy a jagged vector to the specified memory resource
     template <typename TYPE>
@@ -168,6 +180,10 @@ protected:
     virtual void do_memset(std::size_t size, void* ptr, int value);
 
 private:
+    /// Helper function implementing @c memset for jagged vectors
+    template <typename TYPE>
+    void memset_impl(std::size_t size, data::vector_view<TYPE>* data,
+                     int value);
     /// Helper function performing the copy of a jagged array/vector
     template <typename TYPE1, typename TYPE2>
     void copy_views(std::size_t size, const data::vector_view<TYPE1>* from,

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,7 +20,7 @@ void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type) {
 
     // Perform a simple POSIX memory copy.
-    memcpy(to_ptr, from_ptr, size);
+    ::memcpy(to_ptr, from_ptr, size);
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4,
@@ -32,7 +32,7 @@ void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
 void copy::do_memset(std::size_t size, void* ptr, int value) {
 
     // Perform the POSIX memory setting operation.
-    memset(ptr, value, size);
+    ::memset(ptr, value, size);
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(4, "Set %lu bytes to %i at %p with POSIX memset", size,


### PR DESCRIPTION
Introduced some `vecmem::copy::memset` functions for [traccc](https://github.com/acts-project/traccc)'s benefit.

(Re-)Setting memory inside of a buffer turned out to be a good idea in some algorithms. These functions should allow us to do these (re-)sets in a backend agnostic way in algorithmic code.

To be a bit more concrete, I'm replacing the following kernels with memset operations in my upcoming PR to [traccc](https://github.com/acts-project/traccc):
  - https://github.com/acts-project/traccc/blob/main/device/cuda/src/seeding/doublet_counting.cu#L15-L25
  - https://github.com/acts-project/traccc/blob/main/device/cuda/src/seeding/doublet_finding.cu#L15-L28
  - etc.

Pinging @beomki-yeo as well. :wink:

P.S. `vecmem::copy::memcpy_impl` can be optimised in the future, along the lines of `vecmem::copy::copy_views`. But I didn't want to spend time on doing that for now. Since in [traccc](https://github.com/acts-project/traccc) I only need this for 1-dimensional vectors for now.