### PR TITLE
Copy Optimisation, main branch (2022.05.30.)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -23,6 +23,13 @@ if(VECMEM_SETUP_GOOGLEBENCHMARK)
    endif()
 endif()
 
+# Build a common, helper library.
+add_library( vecmem_benchmark_common STATIC
+   "common/make_jagged_vector.hpp"
+   "common/make_jagged_vector.cpp" )
+target_link_libraries( vecmem_benchmark_common
+   PUBLIC vecmem::core )
+
 # Include the library specific tests.
 add_subdirectory(core)
 if(VECMEM_BUILD_CUDA_LIBRARY)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -25,6 +25,8 @@ endif()
 
 # Build a common, helper library.
 add_library( vecmem_benchmark_common STATIC
+   "common/make_jagged_sizes.hpp"
+   "common/make_jagged_sizes.cpp"
    "common/make_jagged_vector.hpp"
    "common/make_jagged_vector.cpp" )
 target_link_libraries( vecmem_benchmark_common
@@ -34,4 +36,7 @@ target_link_libraries( vecmem_benchmark_common
 add_subdirectory(core)
 if(VECMEM_BUILD_CUDA_LIBRARY)
    add_subdirectory(cuda)
+endif()
+if(VECMEM_BUILD_SYCL_LIBRARY)
+   add_subdirectory(sycl)
 endif()

--- a/benchmarks/common/make_jagged_sizes.cpp
+++ b/benchmarks/common/make_jagged_sizes.cpp
@@ -1,0 +1,35 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "make_jagged_sizes.hpp"
+
+// System include(s).
+#include <algorithm>
+#include <random>
+
+namespace vecmem::benchmark {
+
+std::vector<std::size_t> make_jagged_sizes(std::size_t outerSize,
+                                           std::size_t maxInnerSize) {
+
+    // Set up a simple random number generator for the inner vector sizes.
+    std::default_random_engine eng;
+    eng.seed(outerSize + maxInnerSize);
+    std::uniform_int_distribution<std::size_t> gen(0, maxInnerSize);
+
+    // Generate the result vector.
+    std::vector<std::size_t> result(outerSize);
+    std::generate(result.begin(), result.end(),
+                  [&eng, &gen]() { return gen(eng); });
+
+    // Give it to the user.
+    return result;
+}
+
+}  // namespace vecmem::benchmark

--- a/benchmarks/common/make_jagged_sizes.hpp
+++ b/benchmarks/common/make_jagged_sizes.hpp
@@ -1,0 +1,30 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <cstddef>
+#include <vector>
+
+namespace vecmem::benchmark {
+
+/// Helper function for generating the sizes for a jagged vector (buffer)
+///
+/// It implements a pretty simple thing, but since this is used in multiple
+/// places, it made sense to put it into a central location.
+///
+/// @param outerSize The fixed "outer size" of the jagged vector (buffer)
+/// @param maxInnerSize The maximum for the random "inner sizes" of the
+///                     resulting vector (buffer)
+/// @return A vector of sizes corresponding to the received parameters
+///
+std::vector<std::size_t> make_jagged_sizes(std::size_t outerSize,
+                                           std::size_t maxInnerSize);
+
+}  // namespace vecmem::benchmark

--- a/benchmarks/common/make_jagged_vector.cpp
+++ b/benchmarks/common/make_jagged_vector.cpp
@@ -9,26 +9,16 @@
 // Local include(s).
 #include "make_jagged_vector.hpp"
 
-// System include(s).
-#include <random>
-
 namespace vecmem::benchmark {
 
-jagged_vector<int> make_jagged_vector(std::size_t outerSize,
-                                      std::size_t maxInnerSize,
+jagged_vector<int> make_jagged_vector(const std::vector<std::size_t>& sizes,
                                       memory_resource& mr) {
 
     // Create the result object.
     jagged_vector<int> result(&mr);
-    result.reserve(outerSize);
-
-    // Set up a simple random number generator for the inner vector sizes.
-    std::default_random_engine eng;
-    std::uniform_int_distribution<std::size_t> gen(0, maxInnerSize);
-
-    // Set up each of its inner vectors.
-    for (std::size_t i = 0; i < outerSize; ++i) {
-        result.push_back(jagged_vector<int>::value_type(gen(eng), &mr));
+    result.reserve(sizes.size());
+    for (std::size_t size : sizes) {
+        result.push_back(jagged_vector<int>::value_type(size, &mr));
     }
 
     // Return the vector.

--- a/benchmarks/common/make_jagged_vector.cpp
+++ b/benchmarks/common/make_jagged_vector.cpp
@@ -1,0 +1,38 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "make_jagged_vector.hpp"
+
+// System include(s).
+#include <random>
+
+namespace vecmem::benchmark {
+
+jagged_vector<int> make_jagged_vector(std::size_t outerSize,
+                                      std::size_t maxInnerSize,
+                                      memory_resource& mr) {
+
+    // Create the result object.
+    jagged_vector<int> result(&mr);
+    result.reserve(outerSize);
+
+    // Set up a simple random number generator for the inner vector sizes.
+    std::default_random_engine eng;
+    std::uniform_int_distribution<std::size_t> gen(0, maxInnerSize);
+
+    // Set up each of its inner vectors.
+    for (std::size_t i = 0; i < outerSize; ++i) {
+        result.push_back(jagged_vector<int>::value_type(gen(eng), &mr));
+    }
+
+    // Return the vector.
+    return result;
+}
+
+}  // namespace vecmem::benchmark

--- a/benchmarks/common/make_jagged_vector.hpp
+++ b/benchmarks/common/make_jagged_vector.hpp
@@ -14,6 +14,7 @@
 
 // System include(s).
 #include <cstddef>
+#include <vector>
 
 namespace vecmem::benchmark {
 
@@ -22,14 +23,11 @@ namespace vecmem::benchmark {
 /// It creates a jagged vector with a fixed "outer size", and random sized
 /// "inner vectors" that would not be larger than some specified value.
 ///
-/// @param outerSize The fixed "outer size" of the resulting vector
-/// @param maxInnerSize The maximum for the random "inner sizes" of the
-///                     resulting vector
+/// @param sizes The sizes of the vectors in the jagged vector
 /// @param mr The memory resource to use
 /// @return A jagged vector with the specifier properties
 ///
-jagged_vector<int> make_jagged_vector(std::size_t outerSize,
-                                      std::size_t maxInnerSize,
+jagged_vector<int> make_jagged_vector(const std::vector<std::size_t>& sizes,
                                       memory_resource& mr);
 
 }  // namespace vecmem::benchmark

--- a/benchmarks/common/make_jagged_vector.hpp
+++ b/benchmarks/common/make_jagged_vector.hpp
@@ -1,0 +1,35 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// VecMem include(s).
+#include <vecmem/containers/jagged_vector.hpp>
+#include <vecmem/memory/memory_resource.hpp>
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem::benchmark {
+
+/// Function creating a jagged vector with some general size specifications
+///
+/// It creates a jagged vector with a fixed "outer size", and random sized
+/// "inner vectors" that would not be larger than some specified value.
+///
+/// @param outerSize The fixed "outer size" of the resulting vector
+/// @param maxInnerSize The maximum for the random "inner sizes" of the
+///                     resulting vector
+/// @param mr The memory resource to use
+/// @return A jagged vector with the specifier properties
+///
+jagged_vector<int> make_jagged_vector(std::size_t outerSize,
+                                      std::size_t maxInnerSize,
+                                      memory_resource& mr);
+
+}  // namespace vecmem::benchmark

--- a/benchmarks/core/CMakeLists.txt
+++ b/benchmarks/core/CMakeLists.txt
@@ -8,13 +8,16 @@
 include( vecmem-compiler-options-cpp )
 
 # Set up the benchmark(s) for the core library.
-add_executable(vecmem_benchmark_core "benchmark_core.cpp")
+add_executable( vecmem_benchmark_core
+    "benchmark_core.cpp"
+    "benchmark_copy.cpp" )
 
 target_link_libraries(
     vecmem_benchmark_core
 
     PRIVATE
     vecmem::core
+    vecmem_benchmark_common
     benchmark::benchmark
     benchmark::benchmark_main
 )

--- a/benchmarks/core/benchmark_copy.cpp
+++ b/benchmarks/core/benchmark_copy.cpp
@@ -1,0 +1,48 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// VecMem include(s).
+#include <vecmem/memory/host_memory_resource.hpp>
+#include <vecmem/utils/copy.hpp>
+
+// Common benchmark include(s).
+#include "../common/make_jagged_vector.hpp"
+
+// Google benchmark include(s).
+#include <benchmark/benchmark.h>
+
+// System include(s).
+#include <vector>
+
+namespace vecmem::benchmark {
+
+/// The (host) memory resource to use in the benchmark(s).
+static host_memory_resource host_mr;
+/// The copy object to use in the benchmark(s).
+static copy host_copy;
+
+/// Function benchmarking the @c vecmem::copy jagged vector operations
+void jaggedVectorHostCopy(::benchmark::State& state) {
+
+    // Create the "source vector".
+    jagged_vector<int> source =
+        make_jagged_vector(state.range(0), state.range(1), host_mr);
+    const data::jagged_vector_data<int> source_data = get_data(source);
+    // Create the "destination vector".
+    jagged_vector<int> dest;
+
+    // Perform the copy benchmark.
+    for (auto _ : state) {
+        dest.clear();
+        host_copy(source_data, dest);
+    }
+}
+// Set up the benchmark.
+BENCHMARK(jaggedVectorHostCopy)->Ranges({{10, 100000}, {50, 5000}});
+
+}  // namespace vecmem::benchmark

--- a/benchmarks/core/benchmark_copy.cpp
+++ b/benchmarks/core/benchmark_copy.cpp
@@ -11,12 +11,14 @@
 #include <vecmem/utils/copy.hpp>
 
 // Common benchmark include(s).
+#include "../common/make_jagged_sizes.hpp"
 #include "../common/make_jagged_vector.hpp"
 
 // Google benchmark include(s).
 #include <benchmark/benchmark.h>
 
 // System include(s).
+#include <numeric>
 #include <vector>
 
 namespace vecmem::benchmark {
@@ -26,23 +28,132 @@ static host_memory_resource host_mr;
 /// The copy object to use in the benchmark(s).
 static copy host_copy;
 
-/// Function benchmarking the @c vecmem::copy jagged vector operations
-void jaggedVectorHostCopy(::benchmark::State& state) {
+/// Function benchmarking "unknown" host-to-device jagged vector copies
+void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
+
+    // Generate the sizes of the jagged vector/buffer for the test.
+    const std::vector<std::size_t> sizes =
+        make_jagged_sizes(state.range(0), state.range(1));
+
+    // Set custom "counters" for the benchmark.
+    const std::size_t bytes = std::accumulate(sizes.begin(), sizes.end(),
+                                              static_cast<std::size_t>(0u)) *
+                              sizeof(int);
+    state.counters["Bytes"] = static_cast<double>(bytes);
+    state.counters["Rate"] =
+        ::benchmark::Counter(static_cast<double>(bytes),
+                             ::benchmark::Counter::kIsIterationInvariantRate,
+                             ::benchmark::Counter::kIs1024);
 
     // Create the "source vector".
-    jagged_vector<int> source =
-        make_jagged_vector(state.range(0), state.range(1), host_mr);
+    jagged_vector<int> source = make_jagged_vector(sizes, host_mr);
     const data::jagged_vector_data<int> source_data = get_data(source);
-    // Create the "destination vector".
-    jagged_vector<int> dest;
+    // Create the "destination buffer".
+    data::jagged_vector_buffer<int> dest(sizes, host_mr);
+    host_copy.setup(dest);
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        dest.clear();
         host_copy(source_data, dest);
     }
 }
 // Set up the benchmark.
-BENCHMARK(jaggedVectorHostCopy)->Ranges({{10, 100000}, {50, 5000}});
+BENCHMARK(jaggedVectorUnknownHtoDCopy)->Ranges({{10, 100000}, {50, 5000}});
+
+/// Function benchmarking "known" host-to-device jagged vector copies
+void jaggedVectorKnownHtoDCopy(::benchmark::State& state) {
+
+    // Generate the sizes of the jagged vector/buffer for the test.
+    const std::vector<std::size_t> sizes =
+        make_jagged_sizes(state.range(0), state.range(1));
+
+    // Set custom "counters" for the benchmark.
+    const std::size_t bytes = std::accumulate(sizes.begin(), sizes.end(),
+                                              static_cast<std::size_t>(0u)) *
+                              sizeof(int);
+    state.counters["Bytes"] = static_cast<double>(bytes);
+    state.counters["Rate"] =
+        ::benchmark::Counter(static_cast<double>(bytes),
+                             ::benchmark::Counter::kIsIterationInvariantRate,
+                             ::benchmark::Counter::kIs1024);
+
+    // Create the "source vector".
+    jagged_vector<int> source = make_jagged_vector(sizes, host_mr);
+    const data::jagged_vector_data<int> source_data = get_data(source);
+    // Create the "destination buffer".
+    data::jagged_vector_buffer<int> dest(sizes, host_mr);
+    host_copy.setup(dest);
+
+    // Perform the copy benchmark.
+    for (auto _ : state) {
+        host_copy(source_data, dest, copy::type::host_to_device);
+    }
+}
+// Set up the benchmark.
+BENCHMARK(jaggedVectorKnownHtoDCopy)->Ranges({{10, 100000}, {50, 5000}});
+
+/// Function benchmarking "unknown" device-to-host jagged vector copies
+void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
+
+    // Generate the sizes of the jagged vector/buffer for the test.
+    const std::vector<std::size_t> sizes =
+        make_jagged_sizes(state.range(0), state.range(1));
+
+    // Set custom "counters" for the benchmark.
+    const std::size_t bytes = std::accumulate(sizes.begin(), sizes.end(),
+                                              static_cast<std::size_t>(0u)) *
+                              sizeof(int);
+    state.counters["Bytes"] = static_cast<double>(bytes);
+    state.counters["Rate"] =
+        ::benchmark::Counter(static_cast<double>(bytes),
+                             ::benchmark::Counter::kIsIterationInvariantRate,
+                             ::benchmark::Counter::kIs1024);
+
+    // Create the "source buffer".
+    data::jagged_vector_buffer<int> source(sizes, host_mr);
+    host_copy.setup(source);
+    // Create the "destination vector".
+    jagged_vector<int> dest = make_jagged_vector(sizes, host_mr);
+    data::jagged_vector_data<int> dest_data = get_data(dest);
+
+    // Perform the copy benchmark.
+    for (auto _ : state) {
+        host_copy(source, dest_data);
+    }
+}
+// Set up the benchmark.
+BENCHMARK(jaggedVectorUnknownDtoHCopy)->Ranges({{10, 100000}, {50, 5000}});
+
+/// Function benchmarking "known" device-to-host jagged vector copies
+void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
+
+    // Generate the sizes of the jagged vector/buffer for the test.
+    const std::vector<std::size_t> sizes =
+        make_jagged_sizes(state.range(0), state.range(1));
+
+    // Set custom "counters" for the benchmark.
+    const std::size_t bytes = std::accumulate(sizes.begin(), sizes.end(),
+                                              static_cast<std::size_t>(0u)) *
+                              sizeof(int);
+    state.counters["Bytes"] = static_cast<double>(bytes);
+    state.counters["Rate"] =
+        ::benchmark::Counter(static_cast<double>(bytes),
+                             ::benchmark::Counter::kIsIterationInvariantRate,
+                             ::benchmark::Counter::kIs1024);
+
+    // Create the "source buffer".
+    data::jagged_vector_buffer<int> source(sizes, host_mr);
+    host_copy.setup(source);
+    // Create the "destination vector".
+    jagged_vector<int> dest = make_jagged_vector(sizes, host_mr);
+    data::jagged_vector_data<int> dest_data = get_data(dest);
+
+    // Perform the copy benchmark.
+    for (auto _ : state) {
+        host_copy(source, dest_data, copy::type::device_to_host);
+    }
+}
+// Set up the benchmark.
+BENCHMARK(jaggedVectorKnownDtoHCopy)->Ranges({{10, 100000}, {50, 5000}});
 
 }  // namespace vecmem::benchmark

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -9,13 +9,16 @@ include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-cuda )
 
 # Set up the benchmark(s) for the CUDA library.
-add_executable(vecmem_benchmark_cuda "benchmark_cuda.cpp")
+add_executable( vecmem_benchmark_cuda
+    "benchmark_cuda.cpp"
+    "benchmark_copy.cpp" )
 
 target_link_libraries(
     vecmem_benchmark_cuda
 
     PRIVATE
     vecmem::cuda
+    vecmem_benchmark_common
     benchmark::benchmark
     benchmark::benchmark_main
 )

--- a/benchmarks/cuda/benchmark_copy.cpp
+++ b/benchmarks/cuda/benchmark_copy.cpp
@@ -1,0 +1,48 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// VecMem include(s).
+#include <vecmem/memory/cuda/managed_memory_resource.hpp>
+#include <vecmem/utils/cuda/copy.hpp>
+
+// Common benchmark include(s).
+#include "../common/make_jagged_vector.hpp"
+
+// Google benchmark include(s).
+#include <benchmark/benchmark.h>
+
+// System include(s).
+#include <vector>
+
+namespace vecmem::cuda::benchmark {
+
+/// The (managed) memory resource to use in the benchmark(s).
+static managed_memory_resource managed_mr;
+/// The copy object to use in the benchmark(s).
+static copy cuda_copy;
+
+/// Function benchmarking the @c vecmem::cuda::copy jagged vector operations
+void jaggedVectorUnknownCopy(::benchmark::State& state) {
+
+    // Create the "source vector".
+    jagged_vector<int> source = vecmem::benchmark::make_jagged_vector(
+        state.range(0), state.range(1), managed_mr);
+    const data::jagged_vector_data<int> source_data = get_data(source);
+    // Create the "destination vector".
+    jagged_vector<int> dest;
+
+    // Perform the copy benchmark.
+    for (auto _ : state) {
+        dest.clear();
+        cuda_copy(source_data, dest);
+    }
+}
+// Set up the benchmark.
+BENCHMARK(jaggedVectorUnknownCopy)->Ranges({{10, 100000}, {50, 5000}});
+
+}  // namespace vecmem::cuda::benchmark

--- a/benchmarks/sycl/CMakeLists.txt
+++ b/benchmarks/sycl/CMakeLists.txt
@@ -1,0 +1,18 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Project include(s).
+include( vecmem-compiler-options-cpp )
+include( vecmem-compiler-options-sycl )
+
+# Set up the benchmark(s) for the SYCL library.
+add_executable( vecmem_benchmark_sycl
+    "benchmark_sycl.cpp"
+    "benchmark_copy.cpp" )
+target_link_libraries( vecmem_benchmark_sycl
+    PRIVATE vecmem::sycl vecmem_benchmark_common
+            benchmark::benchmark benchmark::benchmark_main
+)

--- a/benchmarks/sycl/benchmark_copy.cpp
+++ b/benchmarks/sycl/benchmark_copy.cpp
@@ -7,9 +7,9 @@
  */
 
 // VecMem include(s).
-#include <vecmem/memory/cuda/device_memory_resource.hpp>
-#include <vecmem/memory/host_memory_resource.hpp>
-#include <vecmem/utils/cuda/copy.hpp>
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/memory/sycl/host_memory_resource.hpp>
+#include <vecmem/utils/sycl/copy.hpp>
 
 // Common benchmark include(s).
 #include "../common/make_jagged_sizes.hpp"
@@ -22,14 +22,14 @@
 #include <numeric>
 #include <vector>
 
-namespace vecmem::cuda::benchmark {
+namespace vecmem::sycl::benchmark {
 
 /// The (host) memory resource to use in the benchmark(s).
-static vecmem::host_memory_resource host_mr;
+static host_memory_resource host_mr;
 /// The (device) memory resource to use in the benchmark(s).
 static device_memory_resource device_mr;
 /// The copy object to use in the benchmark(s).
-static copy cuda_copy;
+static copy sycl_copy;
 
 /// Function benchmarking "unknown" host-to-device jagged vector copies
 void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
@@ -54,11 +54,11 @@ void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    cuda_copy.setup(dest);
+    sycl_copy.setup(dest);
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source_data, dest);
+        sycl_copy(source_data, dest);
     }
 }
 // Set up the benchmark.
@@ -87,11 +87,11 @@ void jaggedVectorKnownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    cuda_copy.setup(dest);
+    sycl_copy.setup(dest);
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source_data, dest, copy::type::host_to_device);
+        sycl_copy(source_data, dest, copy::type::host_to_device);
     }
 }
 // Set up the benchmark.
@@ -116,7 +116,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    cuda_copy.setup(source);
+    sycl_copy.setup(source);
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -124,7 +124,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source, dest_data);
+        sycl_copy(source, dest_data);
     }
 }
 // Set up the benchmark.
@@ -149,7 +149,7 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    cuda_copy.setup(source);
+    sycl_copy.setup(source);
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -157,10 +157,10 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source, dest_data, copy::type::device_to_host);
+        sycl_copy(source, dest_data, copy::type::device_to_host);
     }
 }
 // Set up the benchmark.
 BENCHMARK(jaggedVectorKnownDtoHCopy)->Ranges({{10, 100000}, {50, 5000}});
 
-}  // namespace vecmem::cuda::benchmark
+}  // namespace vecmem::sycl::benchmark

--- a/benchmarks/sycl/benchmark_sycl.cpp
+++ b/benchmarks/sycl/benchmark_sycl.cpp
@@ -1,0 +1,41 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// VecMem include(s).
+#include <vecmem/memory/sycl/device_memory_resource.hpp>
+#include <vecmem/memory/sycl/host_memory_resource.hpp>
+#include <vecmem/memory/sycl/shared_memory_resource.hpp>
+
+// Google benchmark include(s).
+#include <benchmark/benchmark.h>
+
+static vecmem::sycl::device_memory_resource device_mr;
+void BenchmarkSYCLDevice(benchmark::State& state) {
+    for (auto _ : state) {
+        void* p = device_mr.allocate(state.range(0));
+        device_mr.deallocate(p, state.range(0));
+    }
+}
+BENCHMARK(BenchmarkSYCLDevice)->RangeMultiplier(2)->Range(1, 2UL << 31);
+
+static vecmem::sycl::host_memory_resource host_mr;
+void BenchmarkSYCLHost(benchmark::State& state) {
+    for (auto _ : state) {
+        void* p = host_mr.allocate(state.range(0));
+        host_mr.deallocate(p, state.range(0));
+    }
+}
+BENCHMARK(BenchmarkSYCLHost)->RangeMultiplier(2)->Range(1, 2UL << 31);
+
+static vecmem::sycl::shared_memory_resource shared_mr;
+void BenchmarkSYCLShared(benchmark::State& state) {
+    for (auto _ : state) {
+        void* p = shared_mr.allocate(state.range(0));
+        shared_mr.deallocate(p, state.range(0));
+    }
+}
+BENCHMARK(BenchmarkSYCLShared)->RangeMultiplier(2)->Range(1, 2UL << 31);

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -189,8 +189,14 @@ private:
                      int value);
     /// Helper function performing the copy of a jagged array/vector
     template <typename TYPE1, typename TYPE2>
-    void copy_views(std::size_t size, const data::vector_view<TYPE1>* from,
-                    data::vector_view<TYPE2>* to, type::copy_type cptype);
+    void copy_views_impl1(std::size_t size,
+                          const data::vector_view<TYPE1>* from,
+                          data::vector_view<TYPE2>* to, type::copy_type cptype);
+    /// Helper function performing the copy of a jagged array/vector
+    template <typename TYPE1, typename TYPE2>
+    void copy_views_impl2(std::size_t size,
+                          const data::vector_view<TYPE1>* from,
+                          data::vector_view<TYPE2>* to, type::copy_type cptype);
     /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(


### PR DESCRIPTION
This is something that I've been pondering about since a while. So I wanted to finally give it a try.

Copying large jagged vectors is becoming more and more of a bottleneck in [traccc](https://github.com/acts-project/traccc) jobs. Just today @konradkusiak97 explained to me that explicitly copying all cells into device memory is a whole lot slower than just constructing the cells in managed/shared memory, and letting the CUDA/SYCL runtime take care of moving the data as appropriate.

The main issue here is that while `vecmem::copy` can recognise how to minimise the number of copy operations for jagged vectors, in practice we never reduce this to much smaller than the size of the "outer vector". This is because as long as the source or the destination of the copy is a `vecmem::jagged_vector`, and we don't use any special memory resource to ensure that the "inner vectors" are allocated in contiguous memory, [std::vector](https://en.cppreference.com/w/cpp/container/vector) will just allocate the "inner vectors" all across the heap.

So... since Host-to-Device and Device-to-Host memory copies are supposed to be a lot slower than Host-to-Host ones, I've been thinking since a long time about teaching `vecmem::copy` how to coalesce fragmented memory into a single block behind the scenes with Host-to-Host memory copies, before executing a single Host-to-Device copy on it. (Note that device memory is practically always contiguous because of how `vecmem::data::jagged_vector_buffer` behaves.)

And this is what I tried out in this PR. :thinking: I updated `vecmem::copy` to do such extra Host-to-Host copies, as long as the user explicitly asks for Host-to-Device or Device-to-Host copies. (To ensure that all this trickery would have a chance of helping with the performance.)

I also added some new benchmarks to test that this would indeed help things. And well, the situation is a bit complicated... :confused:

As one would absolutely expect, copying between two host memory areas with `vecmem::copy::type::host_to_device` is slower than using `vecmem::copy::type::unknown`. Since with that setting more host-to-host memory operations (and some more allocations and de-allocations) are performed. This is most visible for small vector sizes.

```
[bash][atspot01]:build > ./bin/vecmem_benchmark_core --benchmark_filter="jaggedVector"
2022-05-30T16:53:20+02:00
Running ./bin/vecmem_benchmark_core
Run on (16 X 5000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.43, 1.28, 1.70
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
jaggedVectorUnknownCopy/10/50             76.2 ns         76.2 ns      8150422
jaggedVectorUnknownCopy/64/50              365 ns          365 ns      1952915
jaggedVectorUnknownCopy/512/50            3230 ns         3229 ns       215752
jaggedVectorUnknownCopy/4096/50          37696 ns        37695 ns        18529
jaggedVectorUnknownCopy/32768/50        332415 ns       332395 ns         2096
jaggedVectorUnknownCopy/100000/50      1335576 ns      1335493 ns          520
jaggedVectorUnknownCopy/10/64             75.1 ns         75.1 ns      9185072
jaggedVectorUnknownCopy/64/64              358 ns          358 ns      1951232
jaggedVectorUnknownCopy/512/64            3490 ns         3490 ns       199194
jaggedVectorUnknownCopy/4096/64          37010 ns        37009 ns        18921
jaggedVectorUnknownCopy/32768/64        330494 ns       330485 ns         2021
jaggedVectorUnknownCopy/100000/64      1600302 ns      1600214 ns          439
jaggedVectorUnknownCopy/10/512             130 ns          130 ns      5378893
jaggedVectorUnknownCopy/64/512            1745 ns         1745 ns       400055
jaggedVectorUnknownCopy/512/512          21258 ns        21258 ns        33713
jaggedVectorUnknownCopy/4096/512        170972 ns       170974 ns         4062
jaggedVectorUnknownCopy/32768/512      3950898 ns      3950817 ns          168
jaggedVectorUnknownCopy/100000/512    13889953 ns     13889817 ns           47
jaggedVectorUnknownCopy/10/4096           1376 ns         1376 ns       514685
jaggedVectorUnknownCopy/64/4096          16459 ns        16459 ns        43003
jaggedVectorUnknownCopy/512/4096        136361 ns       136359 ns         5065
jaggedVectorUnknownCopy/4096/4096      3679999 ns      3679992 ns          190
jaggedVectorUnknownCopy/32768/4096    32155702 ns     32153877 ns           20
jaggedVectorUnknownCopy/100000/4096  119276776 ns    119268194 ns            5
jaggedVectorUnknownCopy/10/5000           1756 ns         1756 ns       413096
jaggedVectorUnknownCopy/64/5000          20152 ns        20152 ns        34775
jaggedVectorUnknownCopy/512/5000        179190 ns       179189 ns         3974
jaggedVectorUnknownCopy/4096/5000      4570827 ns      4570623 ns          129
jaggedVectorUnknownCopy/32768/5000    40220652 ns     40220168 ns           16
jaggedVectorUnknownCopy/100000/5000  153522586 ns    153519898 ns            4
jaggedVectorHtoDCopy/10/50                 204 ns          204 ns      3410585
jaggedVectorHtoDCopy/64/50                 964 ns          964 ns       725122
jaggedVectorHtoDCopy/512/50               7666 ns         7666 ns        92347
jaggedVectorHtoDCopy/4096/50             81163 ns        81162 ns         8593
jaggedVectorHtoDCopy/32768/50           339737 ns       339727 ns         2061
jaggedVectorHtoDCopy/100000/50         1409513 ns      1409456 ns          518
jaggedVectorHtoDCopy/10/64                 226 ns          226 ns      3053364
jaggedVectorHtoDCopy/64/64                 934 ns          934 ns       735632
jaggedVectorHtoDCopy/512/64               8312 ns         8312 ns        85428
jaggedVectorHtoDCopy/4096/64             82802 ns        82801 ns         8472
jaggedVectorHtoDCopy/32768/64           332541 ns       332535 ns         2095
jaggedVectorHtoDCopy/100000/64         1565558 ns      1565543 ns          443
jaggedVectorHtoDCopy/10/512                390 ns          390 ns      1792472
jaggedVectorHtoDCopy/64/512               3269 ns         3269 ns       214271
jaggedVectorHtoDCopy/512/512             39881 ns        39881 ns        17593
jaggedVectorHtoDCopy/4096/512           165711 ns       165710 ns         4211
jaggedVectorHtoDCopy/32768/512         3903412 ns      3903403 ns          179
jaggedVectorHtoDCopy/100000/512       13729373 ns     13728899 ns           47
jaggedVectorHtoDCopy/10/4096              3138 ns         3138 ns       222912
jaggedVectorHtoDCopy/64/4096             31948 ns        31948 ns        21949
jaggedVectorHtoDCopy/512/4096           134700 ns       134700 ns         5185
jaggedVectorHtoDCopy/4096/4096         3650020 ns      3649875 ns          192
jaggedVectorHtoDCopy/32768/4096       32127366 ns     32127370 ns           20
jaggedVectorHtoDCopy/100000/4096     118959691 ns    118956086 ns            5
jaggedVectorHtoDCopy/10/5000              4030 ns         4030 ns       173493
jaggedVectorHtoDCopy/64/5000             38663 ns        38662 ns        18087
jaggedVectorHtoDCopy/512/5000           167960 ns       167956 ns         4142
jaggedVectorHtoDCopy/4096/5000         4538436 ns      4538367 ns          133
jaggedVectorHtoDCopy/32768/5000       39789349 ns     39787849 ns           15
jaggedVectorHtoDCopy/100000/5000     153751410 ns    153748267 ns            4
[bash][atspot01]:build >
```

So clearly, one should not set up the copies like this for Host-to-Host memory transfers. But this part is quite understandable, and doesn't worry me all too much. What worries me is what I see with CUDA.

```
[bash][atspot01]:build > ./bin/vecmem_benchmark_cuda --benchmark_filter="jaggedVector"
2022-05-30T16:44:17+02:00
Running ./bin/vecmem_benchmark_cuda
Run on (16 X 5000 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 256 KiB (x8)
  L3 Unified 16384 KiB (x1)
Load Average: 0.62, 2.24, 1.80
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
jaggedVectorUnknownCopy/10/50            27878 ns        27878 ns        24415
jaggedVectorUnknownCopy/64/50           195744 ns       195746 ns         3556
jaggedVectorUnknownCopy/512/50         1552115 ns      1552116 ns          444
jaggedVectorUnknownCopy/4096/50       12707777 ns     12707652 ns           56
jaggedVectorUnknownCopy/32768/50     100592377 ns    100592023 ns            6
jaggedVectorUnknownCopy/100000/50    308479796 ns    308474233 ns            2
jaggedVectorUnknownCopy/10/64            28143 ns        28143 ns        24449
jaggedVectorUnknownCopy/64/64           194479 ns       194470 ns         3573
jaggedVectorUnknownCopy/512/64         1569748 ns      1569757 ns          444
jaggedVectorUnknownCopy/4096/64       12563375 ns     12563207 ns           55
jaggedVectorUnknownCopy/32768/64     101416391 ns    101416373 ns            7
jaggedVectorUnknownCopy/100000/64    308194956 ns    308194376 ns            2
jaggedVectorUnknownCopy/10/512           28786 ns        28786 ns        24467
jaggedVectorUnknownCopy/64/512          200589 ns       200587 ns         3483
jaggedVectorUnknownCopy/512/512        1618560 ns      1618545 ns          431
jaggedVectorUnknownCopy/4096/512      13013281 ns     13013178 ns           53
jaggedVectorUnknownCopy/32768/512    104976397 ns    104974524 ns            7
jaggedVectorUnknownCopy/100000/512   321830345 ns    321827896 ns            2
jaggedVectorUnknownCopy/10/4096          33932 ns        33931 ns        19886
jaggedVectorUnknownCopy/64/4096         233242 ns       233240 ns         2954
jaggedVectorUnknownCopy/512/4096       1841365 ns      1841331 ns          377
jaggedVectorUnknownCopy/4096/4096     15831082 ns     15831056 ns           44
jaggedVectorUnknownCopy/32768/4096   128679894 ns    128680013 ns            5
jaggedVectorUnknownCopy/100000/4096  412286737 ns    412274486 ns            2
jaggedVectorUnknownCopy/10/5000          33371 ns        33371 ns        20442
jaggedVectorUnknownCopy/64/5000         237753 ns       237754 ns         2946
jaggedVectorUnknownCopy/512/5000       1912275 ns      1912274 ns          365
jaggedVectorUnknownCopy/4096/5000     16853734 ns     16853577 ns           42
jaggedVectorUnknownCopy/32768/5000   135504362 ns    135500873 ns            5
jaggedVectorUnknownCopy/100000/5000  426574972 ns    426572864 ns            2
jaggedVectorHtoDCopy/10/50                2825 ns         2825 ns       245973
jaggedVectorHtoDCopy/64/50                3452 ns         3452 ns       202218
jaggedVectorHtoDCopy/512/50              10328 ns        10328 ns        67601
jaggedVectorHtoDCopy/4096/50             81881 ns        81881 ns         8518
jaggedVectorHtoDCopy/32768/50           810180 ns       810168 ns          862
jaggedVectorHtoDCopy/100000/50         3269427 ns      3269368 ns          218
jaggedVectorHtoDCopy/10/64                2990 ns         2990 ns       233563
jaggedVectorHtoDCopy/64/64                3678 ns         3678 ns       184873
jaggedVectorHtoDCopy/512/64              11182 ns        11182 ns        61631
jaggedVectorHtoDCopy/4096/64             85399 ns        85398 ns         8206
jaggedVectorHtoDCopy/32768/64         85732162 ns     85731277 ns            8
jaggedVectorHtoDCopy/100000/64       266189329 ns    266182671 ns            3
jaggedVectorHtoDCopy/10/512              27112 ns        27111 ns        25716
jaggedVectorHtoDCopy/64/512              10821 ns        10820 ns        63927
jaggedVectorHtoDCopy/512/512             61234 ns        61233 ns        11355
jaggedVectorHtoDCopy/4096/512           513589 ns       513580 ns         1295
jaggedVectorHtoDCopy/32768/512         8207539 ns      8207297 ns           86
jaggedVectorHtoDCopy/100000/512       26495917 ns     26495517 ns           26
jaggedVectorHtoDCopy/10/4096             32060 ns        32060 ns        21783
jaggedVectorHtoDCopy/64/4096             61420 ns        61418 ns        11080
jaggedVectorHtoDCopy/512/4096          1867751 ns      1867707 ns          377
jaggedVectorHtoDCopy/4096/4096        16125754 ns     16125618 ns           44
jaggedVectorHtoDCopy/32768/4096       60914353 ns     60913380 ns           12
jaggedVectorHtoDCopy/100000/4096     359679694 ns    359675400 ns            2
jaggedVectorHtoDCopy/10/5000             33749 ns        33748 ns        20744
jaggedVectorHtoDCopy/64/5000             74453 ns        74453 ns         9450
jaggedVectorHtoDCopy/512/5000          1974141 ns      1974119 ns          358
jaggedVectorHtoDCopy/4096/5000        17299370 ns     17299307 ns           41
jaggedVectorHtoDCopy/32768/5000       73386436 ns     73382615 ns            9
jaggedVectorHtoDCopy/100000/5000     434445531 ns    434432732 ns            2
[bash][atspot01]:build >
```

For small vector sizes the improvement is >100x. But for large vectors there's practically no improvement. :confused:

It's absolutely possible that there is still a bug in the code, and it doesn't quite perform the number of copies that I would expect from it. (Even though I did check from `vecmem::copy`'s debug outputs that it would report doing a single Host-to-Device memory copy in the `jaggedVectorHtoDCopy` benchmarks.)

Since I've been looking at these numbers for a bit already, I thought I would share it with you guys. What do you think? Should we teach `vecmem::copy` to perform jagged vector copies like this? :thinking:

Pinging @beomki-yeo.