### PR TITLE
Add alignment support to contiguous resource

### DIFF
--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -44,19 +44,19 @@ TEST_F(core_contiguous_memory_resource_test, allocations) {
     vecmem::vector<int> vec1(VECTOR_SIZE, &m_resource);
 
     vecmem::vector<char> vec2(VECTOR_SIZE, &m_resource);
-    EXPECT_EQ(static_cast<void*>(&*(vec2.begin())),
+    EXPECT_GE(static_cast<void*>(&*(vec2.begin())),
               static_cast<void*>(&*(vec1.end())));
 
     vecmem::vector<double> vec3(VECTOR_SIZE, &m_resource);
-    EXPECT_EQ(static_cast<void*>(&*(vec3.begin())),
+    EXPECT_GE(static_cast<void*>(&*(vec3.begin())),
               static_cast<void*>(&*(vec2.end())));
 
     vecmem::vector<float> vec4(VECTOR_SIZE, &m_resource);
-    EXPECT_EQ(static_cast<void*>(&*(vec4.begin())),
+    EXPECT_GE(static_cast<void*>(&*(vec4.begin())),
               static_cast<void*>(&*(vec3.end())));
 
     vecmem::vector<int> vec5(VECTOR_SIZE, &m_resource);
-    EXPECT_EQ(static_cast<void*>(&*(vec5.begin())),
+    EXPECT_GE(static_cast<void*>(&*(vec5.begin())),
               static_cast<void*>(&*(vec4.end())));
 
 #endif  // MSVC debug build...


### PR DESCRIPTION
Previously, the contiguous memory resource ignored its allocation parameter, which lead to errors - in particular issue #180. This commit reworks the internal allocation strategy to use `std::align`, ensuring that memory is properly aligned.

This also breaks (in a valid way) some of the tests, which are adapted to support the new behaviour.

Closes #180.