### PR TITLE
Add additional benchmarks for buddy allocator

### DIFF
--- a/benchmarks/core/benchmark_core.cpp
+++ b/benchmarks/core/benchmark_core.cpp
@@ -6,6 +6,7 @@
  */
 
 // VecMem include(s).
+#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/host_memory_resource.hpp>
 
 // Google benchmark include(s).
@@ -22,3 +23,16 @@ void BenchmarkHost(benchmark::State& state) {
 }
 
 BENCHMARK(BenchmarkHost)->RangeMultiplier(2)->Range(1, 2UL << 31);
+
+void BenchmarkBinaryPage(benchmark::State& state) {
+    std::size_t size = state.range(0);
+
+    vecmem::binary_page_memory_resource mr(host_mr);
+
+    for (auto _ : state) {
+        void* p = mr.allocate(size);
+        mr.deallocate(p, size);
+    }
+}
+
+BENCHMARK(BenchmarkBinaryPage)->RangeMultiplier(2)->Range(1, 2UL << 31);

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(
     vecmem_benchmark_cuda
 
     PRIVATE
+    vecmem::core
     vecmem::cuda
     vecmem_benchmark_common
     benchmark::benchmark

--- a/benchmarks/cuda/benchmark_cuda.cpp
+++ b/benchmarks/cuda/benchmark_cuda.cpp
@@ -6,12 +6,15 @@
  */
 
 // VecMem include(s).
+#include <vecmem/memory/binary_page_memory_resource.hpp>
 #include <vecmem/memory/cuda/device_memory_resource.hpp>
 #include <vecmem/memory/cuda/host_memory_resource.hpp>
 #include <vecmem/memory/cuda/managed_memory_resource.hpp>
 
 // Google benchmark include(s).
 #include <benchmark/benchmark.h>
+
+#include <vector>
 
 static vecmem::cuda::device_memory_resource device_mr;
 void BenchmarkCudaDevice(benchmark::State& state) {
@@ -22,6 +25,43 @@ void BenchmarkCudaDevice(benchmark::State& state) {
 }
 BENCHMARK(BenchmarkCudaDevice)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
+void BenchmarkCudaDeviceBinaryPage(benchmark::State& state) {
+    std::size_t size = state.range(0);
+
+    vecmem::binary_page_memory_resource mr(device_mr);
+
+    for (auto _ : state) {
+        void* p = mr.allocate(size);
+        mr.deallocate(p, size);
+    }
+}
+BENCHMARK(BenchmarkCudaDeviceBinaryPage)
+    ->RangeMultiplier(2)
+    ->Range(1, 2UL << 31);
+
+void BenchmarkCudaDeviceBinaryPageMultiple(benchmark::State& state) {
+    std::size_t size = state.range(0);
+    std::size_t nallocs = state.range(1);
+
+    std::vector<void*> allocs;
+
+    allocs.reserve(nallocs);
+
+    for (auto _ : state) {
+        vecmem::binary_page_memory_resource mr(device_mr);
+        for (std::size_t i = 0; i < nallocs; ++i) {
+            allocs[i] = mr.allocate(size);
+        }
+
+        for (std::size_t i = 0; i < nallocs; ++i) {
+            mr.deallocate(allocs[i], size);
+        }
+    }
+}
+BENCHMARK(BenchmarkCudaDeviceBinaryPageMultiple)
+    ->RangeMultiplier(2)
+    ->Ranges({{1, 2UL << 21}, {1, 1024}});
+
 static vecmem::cuda::host_memory_resource host_mr;
 void BenchmarkCudaPinned(benchmark::State& state) {
     for (auto _ : state) {
@@ -31,6 +71,20 @@ void BenchmarkCudaPinned(benchmark::State& state) {
 }
 BENCHMARK(BenchmarkCudaPinned)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
+void BenchmarkCudaPinnedBinaryPage(benchmark::State& state) {
+    std::size_t size = state.range(0);
+
+    vecmem::binary_page_memory_resource mr(host_mr);
+
+    for (auto _ : state) {
+        void* p = mr.allocate(size);
+        mr.deallocate(p, size);
+    }
+}
+BENCHMARK(BenchmarkCudaPinnedBinaryPage)
+    ->RangeMultiplier(2)
+    ->Range(1, 2UL << 31);
+
 static vecmem::cuda::managed_memory_resource managed_mr;
 void BenchmarkCudaManaged(benchmark::State& state) {
     for (auto _ : state) {
@@ -39,3 +93,17 @@ void BenchmarkCudaManaged(benchmark::State& state) {
     }
 }
 BENCHMARK(BenchmarkCudaManaged)->RangeMultiplier(2)->Range(1, 2UL << 31);
+
+void BenchmarkCudaManagedBinaryPage(benchmark::State& state) {
+    std::size_t size = state.range(0);
+
+    vecmem::binary_page_memory_resource mr(managed_mr);
+
+    for (auto _ : state) {
+        void* p = mr.allocate(size);
+        mr.deallocate(p, size);
+    }
+}
+BENCHMARK(BenchmarkCudaManagedBinaryPage)
+    ->RangeMultiplier(2)
+    ->Range(1, 2UL << 31);


### PR DESCRIPTION
This commit adds more benchmarks to our benchmarking suite, in particular those designed to benchmark the buddy allocator. These are the benchmarks I have used to debug #182.