### PR TITLE
Fix missing include in `unique_alloc_deleter.hpp`

### DIFF
--- a/core/include/vecmem/memory/details/unique_alloc_deleter.hpp
+++ b/core/include/vecmem/memory/details/unique_alloc_deleter.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <type_traits>
 
 #include "vecmem/memory/memory_resource.hpp"


### PR DESCRIPTION
This commit fixes a missing inclusion in the `unique_alloc_deleter.hpp` file, which had not previously manifested itself because the include (`cassert`) was being caught by another header file.