### PR TITLE
Fix false-positive missing return statement warning

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -229,3 +229,68 @@ if( VECMEM_HAVE_BUILTIN_CLZL )
       PRIVATE VECMEM_HAVE_BUILTIN_CLZL
    )
 endif()
+
+# Test whether we have unreachability builtins.
+check_cxx_source_compiles( "
+   int main() {
+      return 0;
+      __builtin_unreachable();
+   }
+   " VECMEM_CXX_HAVE_BUILTIN_UNREACHABLE )
+if( VECMEM_CXX_HAVE_BUILTIN_UNREACHABLE )
+   target_compile_definitions(
+      vecmem_core
+      PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:VECMEM_HAVE_BUILTIN_UNREACHABLE>
+   )
+endif()
+
+check_cxx_source_compiles( "
+   int main() {
+      return 0;
+      __assume(0);
+   }
+   " VECMEM_CXX_HAVE_ASSUME )
+if( VECMEM_CXX_HAVE_ASSUME )
+   target_compile_definitions(
+      vecmem_core
+      PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:VECMEM_HAVE_ASSUME>
+   )
+endif()
+
+if ( VECMEM_BUILD_CUDA_LIBRARY )
+   enable_language( CUDA )
+
+   cmake_check_source_compiles(
+      CUDA
+      "
+      int main() {
+         return 0;
+         __builtin_unreachable();
+      }
+      " VECMEM_CUDA_HAVE_BUILTIN_UNREACHABLE )
+   if( VECMEM_CUDA_HAVE_BUILTIN_UNREACHABLE )
+      target_compile_definitions(
+         vecmem_core
+         PRIVATE
+         $<$<COMPILE_LANGUAGE:CUDA>:VECMEM_HAVE_BUILTIN_UNREACHABLE>
+      )
+   endif()
+
+   cmake_check_source_compiles(
+      CUDA
+      "
+      int main() {
+         return 0;
+         __assume(0);
+      }
+      " VECMEM_CUDA_HAVE_ASSUME )
+   if( VECMEM_CUDA_HAVE_ASSUME )
+      target_compile_definitions(
+         vecmem_core
+         PRIVATE
+         $<$<COMPILE_LANGUAGE:CUDA>:VECMEM_HAVE_ASSUME>
+      )
+   endif()
+endif()

--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -122,6 +122,12 @@ aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps... ps) {
          */
         return std::make_tuple<std::add_pointer_t<T>>(std::move(beg));
     }
+
+    #if defined(VECMEM_HAVE_BUILTIN_UNREACHABLE)
+    __builtin_unreachable();
+    #elif defined(VECMEM_HAVE_ASSUME)
+    __assume(0);
+    #endif
 }
 
 template <typename... Ts, typename... Ps>


### PR DESCRIPTION
As it stands `aligned_multiple_placement_helper` can, under some circumstances, produce false-positive warnings about missing return statements because its execution path checker has a bug. This commit fixes this warning by adding an explicit annotation to the end of the function marking it as unreachable.