### PR TITLE
CUDA(+GCC) False Warning Fix, main branch (2022.07.13.)

### DIFF
--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -122,6 +122,13 @@ aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps... ps) {
          */
         return std::make_tuple<std::add_pointer_t<T>>(std::move(beg));
     }
+#ifdef __GNUC__
+    // Certain combinations of CUDA + GCC generate a warning here, thinking
+    // that the code may reach this point in the function. So for just GCC,
+    // let's add some help here. Telling it that this part of the function is
+    // not (meant to be) reachable.
+    __builtin_unreachable();
+#endif  // __GNUC__
 }
 
 template <typename... Ts, typename... Ps>

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -53,7 +53,17 @@ vecmem_add_test( cuda
 if( "${CUDAToolkit_VERSION}" VERSION_GREATER_EQUAL "11.0" )
    vecmem_add_test( cuda_cxx17
       "test_cuda_memory_resources.cu"
-      LINK_LIBRARIES vecmem::cuda vecmem_testing_cuda_main vecmem_testing_common )
+      "test_cuda_containers.cu" "test_cuda_containers_kernels.cuh"
+      "test_cuda_containers_kernels.cu"
+      "test_cuda_jagged_vector_view.cu"
+      "test_cuda_jagged_vector_view_kernels.cu"
+      "test_cuda_jagged_vector_view_kernels.cuh"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.hpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_error_handling.cpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.hpp"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../../cuda/src/utils/cuda_wrappers.cpp"
+      LINK_LIBRARIES vecmem::core vecmem::cuda vecmem_testing_cuda_main
+                     vecmem_testing_common )
    set_target_properties( vecmem_test_cuda_cxx17 PROPERTIES
       CUDA_STANDARD 17 )
 endif()

--- a/tests/cuda/test_cuda_containers.cu
+++ b/tests/cuda/test_cuda_containers.cu
@@ -1,0 +1,9 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "test_cuda_containers.cpp"

--- a/tests/cuda/test_cuda_jagged_vector_view.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view.cu
@@ -1,0 +1,9 @@
+/** VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "test_cuda_jagged_vector_view.cpp"


### PR DESCRIPTION
This is a simplified version of #189. One that doesn't try to be as general with its build configuration, but at the same does test explicitly whether the fix would work as it should.

This change is meant to fix the following types of (false) warnings that currently show up in the build [traccc](https://github.com/acts-project/traccc) with GCC 11.2 + CUDA 11.4:

```
/afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/vecmem-src/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp(125): warning: missing return statement at end of non-void function "vecmem::details::aligned_multiple_placement_helper<T,Ts...,P,Ps...>(void *, std::size_t, P, Ps...) [with T=traccc::internal_spacepoint<traccc::spacepoint>, Ts=<>, P=std::size_t, Ps=<>]"
          detected during:
            instantiation of "std::tuple<std::add_pointer_t<T>, std::add_pointer_t<Ts>...> vecmem::details::aligned_multiple_placement_helper<T,Ts...,P,Ps...>(void *, std::size_t, P, Ps...) [with T=traccc::internal_spacepoint<traccc::spacepoint>, Ts=<>, P=std::size_t, Ps=<>]" 
(117): here                                                                                              
            instantiation of "std::tuple<std::add_pointer_t<T>, std::add_pointer_t<Ts>...> vecmem::details::aligned_multiple_placement_helper<T,Ts...,P,Ps...>(void *, std::size_t, P, Ps...) [with T=unsigned int, Ts=<traccc::internal_spacepoint<traccc::spacepoint>>, P=std::size_t, Ps=<std::size_t>]" 
(216): here                                                                                              
            instantiation of "std::tuple<vecmem::unique_alloc_ptr<char []>, std::add_pointer_t<Ts>...> vecmem::details::aligned_multiple_placement<Ts...,Ps...>(vecmem::memory_resource &, Ps...) [with Ts=<unsigned int, traccc::internal_spacepoint<traccc::spacepoint>>, Ps=<std::size_t, std::size_t>]" 
/afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/vecmem-src/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp(118): here                                                                           
            instantiation of "vecmem::data::jagged_vector_buffer<TYPE>::jagged_vector_buffer(const std::vector<std::size_t, std::allocator<std::size_t>> &, const std::vector<std::size_t, std::allocator<std::size_t>> &, vecmem::memory_resource &, vecmem::memory_resource *) [with TYPE=traccc::internal_spacepoint<traccc::spacepoint>]" 
/afs/cern.ch/user/k/krasznaa/work/traccc/build/_deps/detray-src/core/include/detray/grids/grid2.hpp(548): here                                                                                                    
            instantiation of "detray::grid2_buffer<grid2_t>::grid2_buffer(const detray::grid2_buffer<grid2_t>::axis_p0_type &, const detray::grid2_buffer<grid2_t>::axis_p1_type &, grid2_t::populator_type::buffer_size_type, grid2_t::populator_type::buffer_size_type, vecmem::memory_resource &, vecmem::memory_resource *) [with grid2_t=traccc::sp_grid]" 
/afs/cern.ch/user/k/krasznaa/work/traccc/traccc/device/cuda/src/seeding/spacepoint_binning.cu(82): here
```