### PR TITLE
Aligned SYCL Memory Allocations, main branch (2022.07.14.)

### DIFF
--- a/sycl/src/memory/sycl/device_memory_resource.sycl
+++ b/sycl/src/memory/sycl/device_memory_resource.sycl
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,19 +15,22 @@
 
 namespace vecmem::sycl {
 
-void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
+void* device_memory_resource::do_allocate(std::size_t nbytes,
+                                          std::size_t alignment) {
 
     // Allocate the memory.
-    void* result = cl::sycl::malloc_device(nbytes, details::get_queue(m_queue));
+    void* result = cl::sycl::aligned_alloc_device(alignment, nbytes,
+                                                  details::get_queue(m_queue));
 
     // Let the user know what's happening.
-    VECMEM_DEBUG_MSG(5, "Allocated %ld bytes of device memory on \"%s\" at %p",
-                     nbytes,
-                     details::get_queue(m_queue)
-                         .get_device()
-                         .get_info<cl::sycl::info::device::name>()
-                         .c_str(),
-                     result);
+    VECMEM_DEBUG_MSG(
+        5, "Allocated %ld bytes of (%ld aligned) device memory on \"%s\" at %p",
+        nbytes, alignment,
+        details::get_queue(m_queue)
+            .get_device()
+            .get_info<cl::sycl::info::device::name>()
+            .c_str(),
+        result);
 
     // Return the allocated block's pointer.
     return result;

--- a/sycl/src/memory/sycl/host_memory_resource.sycl
+++ b/sycl/src/memory/sycl/host_memory_resource.sycl
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,14 +15,17 @@
 
 namespace vecmem::sycl {
 
-void* host_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
+void* host_memory_resource::do_allocate(std::size_t nbytes,
+                                        std::size_t alignment) {
 
     // Allocate the memory.
-    void* result = cl::sycl::malloc_host(nbytes, details::get_queue(m_queue));
+    void* result = cl::sycl::aligned_alloc_host(alignment, nbytes,
+                                                details::get_queue(m_queue));
 
     // Let the user know what's happening.
-    VECMEM_DEBUG_MSG(5, "Allocated %ld bytes of host memory at %p", nbytes,
-                     result);
+    VECMEM_DEBUG_MSG(5,
+                     "Allocated %ld bytes of (%ld aligned) host memory at %p",
+                     nbytes, alignment, result);
 
     // Return the allocated block's pointer.
     return result;

--- a/sycl/src/memory/sycl/shared_memory_resource.sycl
+++ b/sycl/src/memory/sycl/shared_memory_resource.sycl
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,19 +15,22 @@
 
 namespace vecmem::sycl {
 
-void* shared_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
+void* shared_memory_resource::do_allocate(std::size_t nbytes,
+                                          std::size_t alignment) {
 
     // Allocate the memory.
-    void* result = cl::sycl::malloc_shared(nbytes, details::get_queue(m_queue));
+    void* result = cl::sycl::aligned_alloc_shared(alignment, nbytes,
+                                                  details::get_queue(m_queue));
 
     // Let the user know what's happening.
-    VECMEM_DEBUG_MSG(5, "Allocated %ld bytes of shared memory on \"%s\" at %p",
-                     nbytes,
-                     details::get_queue(m_queue)
-                         .get_device()
-                         .get_info<cl::sycl::info::device::name>()
-                         .c_str(),
-                     result);
+    VECMEM_DEBUG_MSG(
+        5, "Allocated %ld bytes of (%ld aligned) shared memory on \"%s\" at %p",
+        nbytes, alignment,
+        details::get_queue(m_queue)
+            .get_device()
+            .get_info<cl::sycl::info::device::name>()
+            .c_str(),
+        result);
 
     // Return the allocated block's pointer.
     return result;


### PR DESCRIPTION
Switched to using aligned memory allocations in the SYCL memory resources.

While in practice it should not make a difference for our current code, since SYCL provides a version of its memory allocation functions with custom alignments, we should use those instead of the generic allocation functions.

Note that these functions are part of the [SYCL2020](https://www.khronos.org/registry/SYCL/specs/sycl-2020/pdf/sycl-2020.pdf) standard. But that is already required in our code for un-aligned allocations anyway. (At one point we'll need to teach the build system to require the support for SYCL2020 during the configuration...)

This is probably the simplest part of implementing #183. Note that CUDA and HIP do not provide support for custom alignment values in their memory allocation functions. But since in practice all memory allocations are `0x400` aligned in CUDA, that should not cause any actual problems any time soon...