### PR TITLE
Aligned Host Memory Allocations, main branch (2022.07.14.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -86,6 +86,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/memory/details/unique_alloc_deleter.hpp"
    "include/vecmem/memory/details/unique_obj_deleter.hpp"
    "include/vecmem/memory/unique_ptr.hpp"
+   "include/vecmem/memory/details/is_aligned.hpp"
+   "src/memory/details/is_aligned.cpp"
    # Utilities.
    "include/vecmem/utils/copy.hpp"
    "include/vecmem/utils/impl/copy.ipp"
@@ -228,4 +230,14 @@ if( VECMEM_HAVE_BUILTIN_CLZL )
       vecmem_core
       PRIVATE VECMEM_HAVE_BUILTIN_CLZL
    )
+endif()
+
+# Check if std::aligned_alloc is available. With MSVC (at the time of writing)
+# it is not.
+include( CheckCXXSymbolExists )
+check_cxx_symbol_exists( "std::aligned_alloc" "cstdlib"
+   VECMEM_HAVE_STD_ALIGNED_ALLOC )
+if( VECMEM_HAVE_STD_ALIGNED_ALLOC )
+   target_compile_definitions( vecmem_core
+      PRIVATE VECMEM_HAVE_STD_ALIGNED_ALLOC )
 endif()

--- a/core/include/vecmem/memory/details/is_aligned.hpp
+++ b/core/include/vecmem/memory/details/is_aligned.hpp
@@ -1,0 +1,32 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/utils/types.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem {
+namespace details {
+
+/// Helper function checking if a given pointer has a given alignment
+///
+/// It is used for debugging/validation by some parts of the code, it is
+/// not meant to be used by clients of the library directly.
+///
+/// @param ptr The pointer that is to be checked
+/// @param alignment The alignment that the pointer should be checked for
+/// @return @c true if the pointer has the queried alignment, @c false otherwise
+///
+VECMEM_HOST
+bool VECMEM_CORE_EXPORT is_aligned(void* ptr, std::size_t alignment);
+
+}  // namespace details
+}  // namespace vecmem

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -1,7 +1,7 @@
 /**
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,11 +15,11 @@
 namespace vecmem {
 
 /**
- * @brief Memory resource which wraps the malloc standard library call.
+ * @brief Memory resource which wraps standard library memory allocation calls.
  *
  * This is probably the simplest memory resource you can possibly write. It
- * is a terminal resource which does nothing but wrap malloc and free. It
- * is state-free (on the relevant levels of abstraction).
+ * is a terminal resource which does nothing but wrap @c std::aligned_alloc and
+ * @c std::free. It is state-free (on the relevant levels of abstraction).
  */
 class VECMEM_CORE_EXPORT host_memory_resource final
     : public details::memory_resource_base {
@@ -29,9 +29,10 @@ private:
     /// @{
 
     /// Allocate standard host memory
-    virtual void* do_allocate(std::size_t, std::size_t) override;
+    virtual void* do_allocate(std::size_t size, std::size_t alignment) override;
     /// De-allocate a block of previously allocated memory
-    virtual void do_deallocate(void* p, std::size_t, std::size_t) override;
+    virtual void do_deallocate(void* p, std::size_t size,
+                               std::size_t alignment) override;
     /// Compares @c *this for equality with @c other
     virtual bool do_is_equal(
         const memory_resource& other) const noexcept override;

--- a/core/src/memory/details/is_aligned.cpp
+++ b/core/src/memory/details/is_aligned.cpp
@@ -1,0 +1,31 @@
+/**
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/memory/details/is_aligned.hpp"
+
+// System include(s).
+#include <memory>
+
+namespace vecmem {
+namespace details {
+
+VECMEM_HOST
+bool is_aligned(void* ptr, std::size_t alignment) {
+
+    // Use std::align to see if the pointer needs to be modified to be aligned
+    // to the requested value. Just use a dummy "size" and "space" parameter
+    // for the call.
+    const std::size_t size = 2 * alignment;
+    std::size_t space = 4 * alignment;
+    void* ptr_copy = ptr;
+    return (std::align(alignment, size, ptr_copy, space) == ptr);
+}
+
+}  // namespace details
+}  // namespace vecmem

--- a/core/src/memory/host_memory_resource.cpp
+++ b/core/src/memory/host_memory_resource.cpp
@@ -1,7 +1,7 @@
 /**
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,21 +12,68 @@
 #include "vecmem/utils/debug.hpp"
 
 // System include(s).
+#include <algorithm>
+#include <cassert>
 #include <cstdlib>
+#include <memory>
 
 namespace vecmem {
 
-void *host_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
+void *host_memory_resource::do_allocate(std::size_t bytes,
+                                        std::size_t alignment) {
 
-    void *ptr = std::malloc(bytes);
-    VECMEM_DEBUG_MSG(4, "Allocated %lu bytes at %p", bytes, ptr);
+#ifdef VECMEM_HAVE_STD_ALIGNED_ALLOC
+    // Rely on std::aligned_alloc to give us properly aligned memory.
+    // Note that std::aligned_alloc has a number of quirks about the parameters
+    // that it would accept. Hence the tweaking of the alignment and size
+    // values.
+    const std::size_t align = std::max(alignment, alignof(std::max_align_t));
+    const std::size_t size = bytes + (align - (bytes % align));
+    void *ptr = std::aligned_alloc(align, size);
+#else
+    // Ask for enough memory that will allow us to be able to align the
+    // the returned pointer for sure, **and** be able to store the
+    // pointer to the beginning of the unaligned memory blob before
+    // the aligned pointer.
+    std::size_t alloc_bytes = bytes + alignment + sizeof(void *) - 1;
+    void *unaligned_ptr = std::malloc(alloc_bytes);
+    // Make a pointer that has space "before it" for the
+    // pointer to the beginning of the unaligned space.
+    void *ptr = static_cast<char *>(unaligned_ptr) + sizeof(void *);
+    // The bytes available for alignment are a little less than what we
+    // allocated.
+    std::size_t align_bytes = alloc_bytes - sizeof(void *);
+    // Perform the alignment.
+    if (std::align(alignment, bytes, ptr, align_bytes) == nullptr) {
+        // The alignment was meant to succeed. If it didn't, we messed
+        // something up in the code. :-/
+        return nullptr;
+    }
+    // Store the unaligned pointer's value just before the aligned
+    // pointer for later use.
+    *(reinterpret_cast<void **>(static_cast<char *>(ptr) - sizeof(void *))) =
+        unaligned_ptr;
+#endif  // VECMEM_HAVE_STD_ALIGNED_ALLOC
+    VECMEM_DEBUG_MSG(4,
+                     "Allocated %lu bytes of (%lu aligned) host memory at %p",
+                     bytes, alignment, ptr);
     return ptr;
 }
 
-void host_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+void host_memory_resource::do_deallocate(void *ptr, std::size_t, std::size_t) {
 
-    VECMEM_DEBUG_MSG(4, "De-allocating memory at %p", p);
-    std::free(p);
+    VECMEM_DEBUG_MSG(4, "De-allocating host memory at %p", ptr);
+
+#ifdef VECMEM_HAVE_STD_ALIGNED_ALLOC
+    // We can directly de-allocate the memory that was given to us by
+    // std::aligned_alloc earlier.
+    std::free(ptr);
+#else
+    // Construct the (unaligned) pointer that we need to free.
+    void *unaligned_ptr =
+        *(reinterpret_cast<void **>(static_cast<char *>(ptr) - sizeof(void *)));
+    std::free(unaligned_ptr);
+#endif  // VECMEM_HAVE_STD_ALIGNED_ALLOC
 }
 
 bool host_memory_resource::do_is_equal(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -25,6 +25,8 @@ endif()
 add_library( vecmem_testing_common STATIC
    "common/memory_resource_name_gen.hpp"
    "common/memory_resource_name_gen.cpp"
+   "common/memory_resource_test_alignment.hpp"
+   "common/memory_resource_test_alignment.ipp"
    "common/memory_resource_test_basic.hpp"
    "common/memory_resource_test_basic.ipp"
    "common/memory_resource_test_host_accessible.hpp"

--- a/tests/common/memory_resource_test_alignment.hpp
+++ b/tests/common/memory_resource_test_alignment.hpp
@@ -1,0 +1,25 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+/// Test case for the alignment used in memory resources
+///
+/// The test should make sure that aligned requests are fulfilled
+/// correctly.
+///
+class memory_resource_test_alignment
+    : public testing::TestWithParam<vecmem::memory_resource*> {};
+
+// Include the implementation.
+#include "memory_resource_test_alignment.ipp"

--- a/tests/common/memory_resource_test_alignment.ipp
+++ b/tests/common/memory_resource_test_alignment.ipp
@@ -1,0 +1,38 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/memory/details/is_aligned.hpp"
+
+// System include(s).
+#include <cmath>
+
+/// Basic aligned memory allocation tests
+TEST_P(memory_resource_test_alignment, basics) {
+
+    // Get the memory resource to be used.
+    vecmem::memory_resource* resource = GetParam();
+
+    // Perform alignments for a set of different sizes.
+    for (std::size_t size = 1000; size < 100000; size += 1000) {
+        // And for a set of different alignments.
+        static constexpr std::size_t max_alignment = 0x1 << 16;
+        for (std::size_t alignment = 1; alignment <= max_alignment;
+             alignment *= 2) {
+            // Perform the allocation.
+            void* ptr = resource->allocate(size, alignment);
+            // Check that it succeeded.
+            EXPECT_NE(ptr, nullptr);
+            EXPECT_TRUE(vecmem::details::is_aligned(ptr, alignment));
+            // Free the memory.
+            resource->deallocate(ptr, size, alignment);
+        }
+    }
+}

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -1,12 +1,13 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // Local include(s).
 #include "../common/memory_resource_name_gen.hpp"
+#include "../common/memory_resource_test_alignment.hpp"
 #include "../common/memory_resource_test_basic.hpp"
 #include "../common/memory_resource_test_host_accessible.hpp"
 #include "../common/memory_resource_test_stress.hpp"
@@ -53,6 +54,22 @@ static vecmem::debug_memory_resource debug_host_resource(host_resource);
 static vecmem::debug_memory_resource debug_binary_resource(binary_resource);
 static vecmem::debug_memory_resource debug_arena_resource(arena_resource);
 
+// Set up the test name generating helper object.
+static vecmem::testing::memory_resource_name_gen name_gen(
+    {{&host_resource, "host_resource"},
+     {&binary_resource, "binary_resource"},
+     {&contiguous_resource, "contiguous_resource"},
+     {&arena_resource, "arena_resource"},
+     {&instrumenting_resource, "instrumenting_resource"},
+     {&identity_resource, "identity_resource"},
+     {&conditional_resource, "conditional_resource"},
+     {&coalescing_resource_1, "coalescing_resource_1"},
+     {&coalescing_resource_2, "coalescing_resource_2"},
+     {&choice_resource, "choice_resource"},
+     {&debug_host_resource, "debug_host_resource"},
+     {&debug_binary_resource, "debug_binary_resource"},
+     {&debug_arena_resource, "debug_arena_resource"}});
+
 // Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_basic,
@@ -62,22 +79,8 @@ INSTANTIATE_TEST_SUITE_P(
                     &coalescing_resource_2, &choice_resource,
                     &debug_host_resource, &debug_binary_resource,
                     &debug_arena_resource),
-    vecmem::testing::memory_resource_name_gen(
-        {{&host_resource, "host_resource"},
-         {&binary_resource, "binary_resource"},
-         {&contiguous_resource, "contiguous_resource"},
-         {&arena_resource, "arena_resource"},
-         {&instrumenting_resource, "instrumenting_resource"},
-         {&identity_resource, "identity_resource"},
-         {&conditional_resource, "conditional_resource"},
-         {&coalescing_resource_1, "coalescing_resource_1"},
-         {&coalescing_resource_2, "coalescing_resource_2"},
-         {&choice_resource, "choice_resource"},
-         {&debug_host_resource, "debug_host_resource"},
-         {&debug_binary_resource, "debug_binary_resource"},
-         {&debug_arena_resource, "debug_arena_resource"}}));
+    name_gen);
 
-// Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_host_accessible,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
@@ -86,39 +89,22 @@ INSTANTIATE_TEST_SUITE_P(
                     &coalescing_resource_2, &choice_resource,
                     &debug_host_resource, &debug_binary_resource,
                     &debug_arena_resource),
-    vecmem::testing::memory_resource_name_gen(
-        {{&host_resource, "host_resource"},
-         {&binary_resource, "binary_resource"},
-         {&contiguous_resource, "contiguous_resource"},
-         {&arena_resource, "arena_resource"},
-         {&instrumenting_resource, "instrumenting_resource"},
-         {&identity_resource, "identity_resource"},
-         {&conditional_resource, "conditional_resource"},
-         {&coalescing_resource_1, "coalescing_resource_1"},
-         {&coalescing_resource_2, "coalescing_resource_2"},
-         {&choice_resource, "choice_resource"},
-         {&debug_host_resource, "debug_host_resource"},
-         {&debug_binary_resource, "debug_binary_resource"},
-         {&debug_arena_resource, "debug_arena_resource"}}));
+    name_gen);
 
 INSTANTIATE_TEST_SUITE_P(
-    core_memory_resource_stress_tests, memory_resource_test_stress,
+    core_memory_resource_tests, memory_resource_test_stress,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
                     &instrumenting_resource, &identity_resource,
                     &conditional_resource, &coalescing_resource_1,
                     &coalescing_resource_2, &choice_resource,
                     &debug_host_resource, &debug_binary_resource,
                     &debug_arena_resource),
-    vecmem::testing::memory_resource_name_gen(
-        {{&host_resource, "host_resource"},
-         {&binary_resource, "binary_resource"},
-         {&arena_resource, "arena_resource"},
-         {&instrumenting_resource, "instrumenting_resource"},
-         {&identity_resource, "identity_resource"},
-         {&conditional_resource, "conditional_resource"},
-         {&coalescing_resource_1, "coalescing_resource_1"},
-         {&coalescing_resource_2, "coalescing_resource_2"},
-         {&choice_resource, "choice_resource"},
-         {&debug_host_resource, "debug_host_resource"},
-         {&debug_binary_resource, "debug_binary_resource"},
-         {&debug_arena_resource, "debug_arena_resource"}}));
+    name_gen);
+
+INSTANTIATE_TEST_SUITE_P(
+    core_memory_resource_tests, memory_resource_test_alignment,
+    testing::Values(&host_resource, &instrumenting_resource, &identity_resource,
+                    &conditional_resource, &coalescing_resource_1,
+                    &coalescing_resource_2, &choice_resource,
+                    &debug_host_resource),
+    name_gen);


### PR DESCRIPTION
Switched `vecmem::host_memory_resource` to using [std::aligned_alloc](https://en.cppreference.com/w/cpp/memory/c/aligned_alloc). This is a follow-up from #191, providing yet another component for #183.

At the same time updated the documentation and debug messages of the code a little.