### PR TITLE
CMake 3.24 Compatibility, main branch (2022.09.14.)

### DIFF
--- a/benchmarks/googlebenchmark/CMakeLists.txt
+++ b/benchmarks/googlebenchmark/CMakeLists.txt
@@ -8,6 +8,11 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
 # Tell the user what's happening.
 message( STATUS "Building Google Benchmark as part of the VecMem project" )
 

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -1,12 +1,17 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # CMake include(s).
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
 
 # Tell the user what's happening.
 message( STATUS "Building GoogleTest as part of the VecMem project" )


### PR DESCRIPTION
Explicitly set the [CMP0135 policy](https://cmake.org/cmake/help/latest/policy/CMP0135.html). This is necessary to silence the following warning with CMake >=3.24 coming from [FetchContent](https://cmake.org/cmake/help/latest/module/FetchContent.html)/[ExternalProject](https://cmake.org/cmake/help/latest/module/ExternalProject.html):

```
CMake Warning (dev) at /atlas/software/cmake/3.24.1/x86_64-ubuntu2004-gcc9-opt/share/cmake-3.24/Modules/FetchContent.cmake:1264 (message):                                                                        
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is                              
  not set.  The policy's OLD behavior will be used.  When using a URL                                    
  download, the timestamps of extracted files should preferably be that of                               
  the time of extraction, otherwise code that depends on the extracted                                   
  contents might not be rebuilt if the URL changes.  The OLD behavior                                    
  preserves the timestamps from the archive instead, but this is usually not                             
  what you want.  Update your project to the NEW behavior or specify the                                 
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this                                   
  robustness issue.                                                                                      
Call Stack (most recent call first):                                                                     
  tests/googletest/CMakeLists.txt:15 (FetchContent_Declare)                                              
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Of course this is exactly the same thing as https://github.com/acts-project/detray/pull/299.