### PR TITLE
SYCL Memory Resource Exceptions, main branch (2022.09.14.)

### DIFF
--- a/sycl/src/memory/sycl/device_memory_resource.sycl
+++ b/sycl/src/memory/sycl/device_memory_resource.sycl
@@ -22,6 +22,11 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
     void* result = cl::sycl::aligned_alloc_device(alignment, nbytes,
                                                   details::get_queue(m_queue));
 
+    // Check that the allocation succeeded.
+    if (result == nullptr) {
+        throw std::bad_alloc();
+    }
+
     // Let the user know what's happening.
     VECMEM_DEBUG_MSG(
         5, "Allocated %ld bytes of (%ld aligned) device memory on \"%s\" at %p",

--- a/sycl/src/memory/sycl/host_memory_resource.sycl
+++ b/sycl/src/memory/sycl/host_memory_resource.sycl
@@ -22,6 +22,11 @@ void* host_memory_resource::do_allocate(std::size_t nbytes,
     void* result = cl::sycl::aligned_alloc_host(alignment, nbytes,
                                                 details::get_queue(m_queue));
 
+    // Check that the allocation succeeded.
+    if (result == nullptr) {
+        throw std::bad_alloc();
+    }
+
     // Let the user know what's happening.
     VECMEM_DEBUG_MSG(5,
                      "Allocated %ld bytes of (%ld aligned) host memory at %p",

--- a/sycl/src/memory/sycl/shared_memory_resource.sycl
+++ b/sycl/src/memory/sycl/shared_memory_resource.sycl
@@ -22,6 +22,11 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
     void* result = cl::sycl::aligned_alloc_shared(alignment, nbytes,
                                                   details::get_queue(m_queue));
 
+    // Check that the allocation succeeded.
+    if (result == nullptr) {
+        throw std::bad_alloc();
+    }
+
     // Let the user know what's happening.
     VECMEM_DEBUG_MSG(
         5, "Allocated %ld bytes of (%ld aligned) shared memory on \"%s\" at %p",


### PR DESCRIPTION
Made the SYCL memory resources throw an exception in case of a failure. This came from extended discussions with @stephenswat during the review of #192. Where we concluded that:
  - The SYCL memory allocator functions do throw ("SYCL specific") exceptions themselves if they are asked for some impossible allocation, but for a seemingly good request that can't be fulfilled because of not enough memory, they can return `nullptr`;
  - According to the C\+\+ standard memory resources should not silently return `nullptr`, they should rather throw an exception when the allocation failed.

So I tried to make our code follow the standard a bit more closely.

Note that the CUDA and HIP memory allocator functions always return an error code if there was any problem with the memory allocation. For which the VecMem error checking code throws `std::runtime_error`. Which we decided would be "good enough" for those memory resources.