### PR TITLE
Jagged Vector View Redesign, main branch (2022.09.30.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -95,18 +95,6 @@ public:
                          memory_resource& resource,
                          memory_resource* host_access_resource = nullptr);
 
-    /// Access the host accessible array describing the inner vectors
-    ///
-    /// This may or may not return the same pointer that
-    /// @c vecmem::data::jagged_vector_view::m_ptr holds. If the buffer is set
-    /// up on top of a "shared" (both host- and device accessible) memory
-    /// resource, then the two will be the same. If not, then
-    /// @c vecmem::data::jagged_vector_view::m_ptr is set up to point at the
-    /// device accessible array, and this function returns a pointer to the
-    /// host accessible one.
-    ///
-    pointer host_ptr() const;
-
 private:
     /// Data object for the @c vecmem::data::vector_view array
     vecmem::unique_alloc_ptr<value_type[]> m_outer_memory;

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,20 +15,8 @@ namespace vecmem {
 
 template <typename T>
 VECMEM_HOST_AND_DEVICE jagged_device_vector<T>::jagged_device_vector(
-    const data::jagged_vector_view<T>& data)
-    : m_size(data.m_size), m_ptr(data.m_ptr) {}
-
-template <typename T>
-template <typename OTHERTYPE,
-          std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> >
-VECMEM_HOST_AND_DEVICE jagged_device_vector<T>::jagged_device_vector(
-    const data::jagged_vector_view<OTHERTYPE>& data)
-    : m_size(data.m_size),
-      // This looks scarier than it really is. We "just" reinterpret a
-      // vecmem::data::vector_view<T> pointer to be seen as
-      // vecmem::data::vector_view<const T> instead.
-      m_ptr(reinterpret_cast<typename data::jagged_vector_view<T>::pointer>(
-          data.m_ptr)) {}
+    data::jagged_vector_view<T> data)
+    : m_size(data.size()), m_ptr(data.ptr()) {}
 
 template <typename T>
 VECMEM_HOST_AND_DEVICE jagged_device_vector<T>::jagged_device_vector(

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -30,7 +30,7 @@ data::jagged_vector_data<TYPE> get_data(jagged_vector<TYPE>& vec,
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] =
+        result.host_ptr()[i] =
             value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
@@ -58,7 +58,7 @@ data::jagged_vector_data<TYPE> get_data(
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] =
+        result.host_ptr()[i] =
             value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
@@ -85,7 +85,7 @@ data::jagged_vector_data<const TYPE> get_data(const jagged_vector<TYPE>& vec,
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] =
+        result.host_ptr()[i] =
             value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 
@@ -114,7 +114,7 @@ data::jagged_vector_data<const TYPE> get_data(
 
     // Fill the result object with information.
     for (std::size_t i = 0; i < size; ++i) {
-        result.m_ptr[i] =
+        result.host_ptr()[i] =
             value_type(static_cast<size_type>(vec[i].size()), vec[i].data());
     }
 

--- a/core/include/vecmem/containers/impl/jagged_vector_data.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_data.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -41,6 +41,7 @@ jagged_vector_data<T>::jagged_vector_data(size_type size, memory_resource& mem)
       m_memory(::allocate_jagged_memory<T>(size, mem)) {
     // Point the base class at the newly allocated memory.
     base_type::m_ptr = m_memory.get();
+    base_type::m_host_ptr = m_memory.get();
 
     /*
      * Construct vecmem::data::vector_view objects in the allocated area.

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,20 +12,82 @@ namespace vecmem {
 namespace data {
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE jagged_vector_view<T>::jagged_vector_view(size_type size,
-                                                                 pointer ptr)
-    : m_size(size), m_ptr(ptr) {}
+VECMEM_HOST_AND_DEVICE jagged_vector_view<T>::jagged_vector_view(
+    size_type size, pointer ptr, pointer host_ptr)
+    : m_size(size),
+      m_ptr(ptr),
+      m_host_ptr(host_ptr != nullptr ? host_ptr : ptr) {}
 
 template <typename T>
 template <typename OTHERTYPE,
           std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> >
 VECMEM_HOST_AND_DEVICE jagged_vector_view<T>::jagged_vector_view(
-    const jagged_vector_view<OTHERTYPE>& parent)
-    : m_size(parent.m_size),
+    jagged_vector_view<OTHERTYPE> parent)
+    : m_size(parent.size()),
       // This looks scarier than it really is. We "just" reinterpret a
       // vecmem::data::vector_view<T> pointer to be seen as
       // vecmem::data::vector_view<const T> instead.
-      m_ptr(reinterpret_cast<pointer>(parent.m_ptr)) {}
+      m_ptr(reinterpret_cast<pointer>(parent.ptr())),
+      m_host_ptr(reinterpret_cast<pointer>(parent.host_ptr())) {}
+
+template <typename T>
+template <typename OTHERTYPE,
+          std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> >
+VECMEM_HOST_AND_DEVICE jagged_vector_view<T>& jagged_vector_view<T>::operator=(
+    jagged_vector_view<OTHERTYPE> rhs) {
+
+    // Avoid self-assignment.
+    if (this == &rhs) {
+        return *this;
+    }
+
+    // Perform the assignment.
+    m_size = rhs.m_size;
+    m_ptr = reinterpret_cast<pointer>(rhs.m_ptr);
+    m_host_ptr = reinterpret_cast<pointer>(rhs.m_host_ptr);
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::size_type
+jagged_vector_view<T>::size() const {
+
+    return m_size;
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::size_type
+jagged_vector_view<T>::capacity() const {
+
+    return m_size;
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::pointer
+jagged_vector_view<T>::ptr() {
+
+    return m_ptr;
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::const_pointer
+jagged_vector_view<T>::ptr() const {
+
+    return m_ptr;
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::pointer
+jagged_vector_view<T>::host_ptr() {
+
+    return m_host_ptr;
+}
+
+template <typename T>
+VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::const_pointer
+jagged_vector_view<T>::host_ptr() const {
+
+    return m_host_ptr;
+}
 
 }  // namespace data
 }  // namespace vecmem

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -78,13 +78,7 @@ public:
      * object.
      */
     VECMEM_HOST_AND_DEVICE
-    jagged_device_vector(const data::jagged_vector_view<T>& data);
-    /// Construct a const jagged device vector from a non-const data object
-    template <
-        typename OTHERTYPE,
-        std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> = true>
-    VECMEM_HOST_AND_DEVICE jagged_device_vector(
-        const data::jagged_vector_view<OTHERTYPE>& data);
+    jagged_device_vector(data::jagged_vector_view<T> data);
 
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -67,11 +67,11 @@ public:
 
     /// Set up the internal state of a vector buffer correctly on a device
     template <typename TYPE>
-    void setup(data::vector_view<TYPE>& data);
+    void setup(data::vector_view<TYPE> data);
 
     /// Set all bytes of the vector to some value
     template <typename TYPE>
-    void memset(data::vector_view<TYPE>& data, int value);
+    void memset(data::vector_view<TYPE> data, int value);
 
     /// Copy a 1-dimensional vector to the specified memory resource
     template <typename TYPE>
@@ -82,7 +82,7 @@ public:
     /// Copy a 1-dimensional vector's data between two existing memory blocks
     template <typename TYPE1, typename TYPE2>
     void operator()(const data::vector_view<TYPE1>& from,
-                    data::vector_view<TYPE2>& to,
+                    data::vector_view<TYPE2> to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a 1-dimensional vector's data into a vector object
@@ -103,15 +103,11 @@ public:
 
     /// Copy the internal state of a jagged vector buffer to the target device
     template <typename TYPE>
-    void setup(data::jagged_vector_buffer<TYPE>& data);
+    void setup(data::jagged_vector_view<TYPE> data);
 
     /// Set all bytes of the jagged vector to some value
     template <typename TYPE>
-    void memset(data::jagged_vector_view<TYPE>& data, int value);
-
-    /// Set all bytes of the jagged vector to some value
-    template <typename TYPE>
-    void memset(data::jagged_vector_buffer<TYPE>& data, int value);
+    void memset(data::jagged_vector_view<TYPE> data, int value);
 
     /// Copy a jagged vector to the specified memory resource
     template <typename TYPE>
@@ -120,46 +116,15 @@ public:
         memory_resource* host_access_resource = nullptr,
         type::copy_type cptype = type::unknown);
 
-    /// Copy a jagged vector to the specified memory resource
-    template <typename TYPE>
-    data::jagged_vector_buffer<std::remove_cv_t<TYPE>> to(
-        const data::jagged_vector_buffer<TYPE>& data, memory_resource& resource,
-        memory_resource* host_access_resource = nullptr,
-        type::copy_type cptype = type::unknown);
-
     /// Copy a jagged vector's data between two existing allocations
     template <typename TYPE1, typename TYPE2>
     void operator()(const data::jagged_vector_view<TYPE1>& from,
-                    data::jagged_vector_view<TYPE2>& to,
-                    type::copy_type cptype = type::unknown);
-
-    /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE1, typename TYPE2>
-    void operator()(const data::jagged_vector_view<TYPE1>& from,
-                    data::jagged_vector_buffer<TYPE2>& to,
-                    type::copy_type cptype = type::unknown);
-
-    /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE1, typename TYPE2>
-    void operator()(const data::jagged_vector_buffer<TYPE1>& from,
-                    data::jagged_vector_view<TYPE2>& to,
-                    type::copy_type cptype = type::unknown);
-
-    /// Copy a jagged vector's data between two existing allocations
-    template <typename TYPE1, typename TYPE2>
-    void operator()(const data::jagged_vector_buffer<TYPE1>& from,
-                    data::jagged_vector_buffer<TYPE2>& to,
+                    data::jagged_vector_view<TYPE2> to,
                     type::copy_type cptype = type::unknown);
 
     /// Copy a jagged vector's data into a vector object
     template <typename TYPE1, typename TYPE2, typename ALLOC1, typename ALLOC2>
     void operator()(const data::jagged_vector_view<TYPE1>& from,
-                    std::vector<std::vector<TYPE2, ALLOC2>, ALLOC1>& to,
-                    type::copy_type cptype = type::unknown);
-
-    /// Copy a jagged vector's data into a vector object
-    template <typename TYPE1, typename TYPE2, typename ALLOC1, typename ALLOC2>
-    void operator()(const data::jagged_vector_buffer<TYPE1>& from,
                     std::vector<std::vector<TYPE2, ALLOC2>, ALLOC1>& to,
                     type::copy_type cptype = type::unknown);
 
@@ -167,11 +132,6 @@ public:
     template <typename TYPE>
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
         const data::jagged_vector_view<TYPE>& data);
-
-    /// Helper function for getting the sizes of a resizable jagged buffer
-    template <typename TYPE>
-    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
-        const data::jagged_vector_buffer<TYPE>& data);
 
     /// @}
 
@@ -183,23 +143,13 @@ protected:
     virtual void do_memset(std::size_t size, void* ptr, int value);
 
 private:
-    /// Helper function implementing @c memset for jagged vectors
-    template <typename TYPE>
-    void memset_impl(std::size_t size, data::vector_view<TYPE>* data,
-                     int value);
     /// Helper function performing the copy of a jagged array/vector
     template <typename TYPE1, typename TYPE2>
-    void copy_views_impl1(std::size_t size,
-                          const data::vector_view<TYPE1>* from,
-                          data::vector_view<TYPE2>* to, type::copy_type cptype);
-    /// Helper function performing the copy of a jagged array/vector
-    template <typename TYPE1, typename TYPE2>
-    void copy_views_impl2(std::size_t size,
-                          const data::vector_view<TYPE1>* from,
-                          data::vector_view<TYPE2>* to, type::copy_type cptype);
+    void copy_views_impl(std::size_t size, const data::vector_view<TYPE1>* from,
+                         data::vector_view<TYPE2>* to, type::copy_type cptype);
     /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
-    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
+    std::vector<typename data::vector_view<TYPE>::size_type> get_sizes_impl(
         const data::vector_view<TYPE>* data, std::size_t size);
 
 };  // class copy

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -107,10 +107,10 @@ TEST_F(core_device_container_test, jagged_vector_buffer) {
                                                          &cresource);
 
     // Test the internal state of the buffer.
-    EXPECT_EQ(device_data1.m_ptr, device_data1.host_ptr());
-    EXPECT_EQ(device_data1.m_size, host_vector.size());
-    EXPECT_NE(device_data2.m_ptr, device_data2.host_ptr());
-    EXPECT_EQ(device_data2.m_size, host_vector.size());
+    EXPECT_EQ(device_data1.ptr(), device_data1.host_ptr());
+    EXPECT_EQ(device_data1.size(), host_vector.size());
+    EXPECT_NE(device_data2.ptr(), device_data2.host_ptr());
+    EXPECT_EQ(device_data2.size(), host_vector.size());
     for (std::size_t i = 0; i < host_vector.size(); ++i) {
         EXPECT_EQ(device_data1.host_ptr()[i].size(), host_vector[i].size());
         EXPECT_EQ(device_data2.host_ptr()[i].size(), host_vector[i].size());

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -150,11 +150,11 @@ __global__ void filterTransformKernel(
 
     // Find the current indices.
     const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= input.m_size) {
+    if (i >= input.size()) {
         return;
     }
     const std::size_t j = blockIdx.y * blockDim.y + threadIdx.y;
-    if (j >= input.m_ptr[i].size()) {
+    if (j >= input.ptr()[i].size()) {
         return;
     }
 
@@ -175,7 +175,7 @@ void filterTransform(vecmem::data::jagged_vector_view<const int> input,
                      vecmem::data::jagged_vector_view<int> output) {
 
     // Launch the kernel.
-    dim3 dimensions(static_cast<unsigned int>(input.m_size), max_vec_size);
+    dim3 dimensions(static_cast<unsigned int>(input.size()), max_vec_size);
     filterTransformKernel<<<1, dimensions>>>(input, output);
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
@@ -188,7 +188,7 @@ __global__ void fillTransformKernel(
 
     // Find the current index.
     const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= vec_data.m_size) {
+    if (i >= vec_data.size()) {
         return;
     }
 
@@ -204,7 +204,7 @@ __global__ void fillTransformKernel(
 void fillTransform(vecmem::data::jagged_vector_view<int> vec) {
 
     // Launch the kernel
-    fillTransformKernel<<<static_cast<unsigned int>(vec.m_size), 1>>>(vec);
+    fillTransformKernel<<<static_cast<unsigned int>(vec.size()), 1>>>(vec);
 
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view_kernels.cu
@@ -23,7 +23,7 @@ __global__ void linearTransformKernel(
 
     // Find the current index.
     const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= input.m_size) {
+    if (i >= input.size()) {
         return;
     }
 
@@ -61,10 +61,10 @@ void linearTransform(const vecmem::data::vector_view<int>& constants,
                      vecmem::data::jagged_vector_view<int>& output) {
 
     // A sanity check.
-    assert(input.m_size == output.m_size);
+    assert(input.size() == output.size());
 
     // Launch the kernel.
-    linearTransformKernel<<<1, static_cast<unsigned int>(input.m_size)>>>(
+    linearTransformKernel<<<1, static_cast<unsigned int>(input.size())>>>(
         constants, input, output);
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -65,7 +65,7 @@ __global__ void linearTransformKernel(
 
     // Find the current index.
     const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    if (i >= input.m_size) {
+    if (i >= input.size()) {
         return;
     }
 
@@ -103,10 +103,10 @@ void linearTransform(vecmem::data::vector_view<const int> constants,
                      vecmem::data::jagged_vector_view<int> output) {
 
     // A sanity check.
-    assert(input.m_size == output.m_size);
+    assert(input.size() == output.size());
 
     // Launch the kernel.
-    hipLaunchKernelGGL(linearTransformKernel, 1, input.m_size, 0, nullptr,
+    hipLaunchKernelGGL(linearTransformKernel, 1, input.size(), 0, nullptr,
                        constants, input, output);
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
@@ -196,11 +196,11 @@ __global__ void filterTransformKernel(
 
     // Find the current indices.
     const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    if (i >= input.m_size) {
+    if (i >= input.size()) {
         return;
     }
     const std::size_t j = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
-    if (j >= input.m_ptr[i].size()) {
+    if (j >= input.ptr()[i].size()) {
         return;
     }
 
@@ -222,7 +222,7 @@ void filterTransform(vecmem::data::jagged_vector_view<const int> input,
 
     // Launch the kernel.
     hipLaunchKernelGGL(filterTransformKernel, 1,
-                       dim3(input.m_size, max_vec_size), 0, nullptr, input,
+                       dim3(input.size(), max_vec_size), 0, nullptr, input,
                        output);
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
@@ -235,7 +235,7 @@ __global__ void fillTransformKernel(
 
     // Find the current index.
     const std::size_t i = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
-    if (i >= vec_data.m_size) {
+    if (i >= vec_data.size()) {
         return;
     }
 
@@ -251,7 +251,7 @@ __global__ void fillTransformKernel(
 void fillTransform(vecmem::data::jagged_vector_view<int> vec) {
 
     // Launch the kernel
-    hipLaunchKernelGGL(fillTransformKernel, vec.m_size, 1, 0, nullptr, vec);
+    hipLaunchKernelGGL(fillTransformKernel, vec.size(), 1, 0, nullptr, vec);
 
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -71,7 +71,7 @@ public:
         : m_constants(constants), m_input(input), m_output(output) {
 
         // A little sanity check.
-        assert(m_input.m_size == m_output.m_size);
+        assert(m_input.size() == m_output.size());
     }
 
     /// Operator executing the functor in a single thread
@@ -79,7 +79,7 @@ public:
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
-        if (i >= m_input.m_size) {
+        if (i >= m_input.size()) {
             return;
         }
 
@@ -121,7 +121,7 @@ public:
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
-        if (i >= m_data.m_size) {
+        if (i >= m_data.size()) {
             return;
         }
 
@@ -161,7 +161,7 @@ public:
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
-        if (i >= m_view.m_size) {
+        if (i >= m_view.size()) {
             return;
         }
 
@@ -195,7 +195,7 @@ TEST_F(sycl_jagged_containers_test, mutate_in_kernel) {
             LinearTransformKernel kernel(const_data, vec_data, vec_data);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(vec_data.m_size), kernel);
+                cl::sycl::range<1>(vec_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
@@ -204,7 +204,7 @@ TEST_F(sycl_jagged_containers_test, mutate_in_kernel) {
             // Create the kernel functor.
             SummationKernel kernel(vec_data);
             // Execute this kernel.
-            h.parallel_for<SummationKernel>(cl::sycl::range<1>(vec_data.m_size),
+            h.parallel_for<SummationKernel>(cl::sycl::range<1>(vec_data.size()),
                                             kernel);
         })
         .wait_and_throw();
@@ -260,7 +260,7 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
                                          output_data_device);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(input_data.m_size), kernel);
+                cl::sycl::range<1>(input_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
@@ -270,7 +270,7 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
             SummationKernel kernel(output_data_device);
             // Execute this kernel.
             h.parallel_for<SummationKernel>(
-                cl::sycl::range<1>(output_data_device.m_size), kernel);
+                cl::sycl::range<1>(output_data_device.size()), kernel);
         })
         .wait_and_throw();
 
@@ -334,7 +334,7 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
                                          output_data_device);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(input_data.m_size), kernel);
+                cl::sycl::range<1>(input_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
@@ -344,7 +344,7 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
             SummationKernel kernel(output_data_device);
             // Execute this kernel.
             h.parallel_for<SummationKernel>(
-                cl::sycl::range<1>(output_data_device.m_size), kernel);
+                cl::sycl::range<1>(output_data_device.size()), kernel);
         })
         .wait_and_throw();
 
@@ -391,15 +391,15 @@ TEST_F(sycl_jagged_containers_test, filter) {
     m_queue
         .submit([&input_data, &output_data_device](cl::sycl::handler& h) {
             h.parallel_for<class FilterKernel>(
-                cl::sycl::range<2>(input_data.m_size, 5),
+                cl::sycl::range<2>(input_data.size(), 5),
                 [input = vecmem::get_data(input_data),
                  output = vecmem::get_data(output_data_device)](
                     cl::sycl::item<2> id) {
                     // Skip invalid indices.
-                    if (id[0] >= input.m_size) {
+                    if (id[0] >= input.size()) {
                         return;
                     }
-                    if (id[1] >= input.m_ptr[id[0]].size()) {
+                    if (id[1] >= input.ptr()[id[0]].size()) {
                         return;
                     }
 
@@ -460,7 +460,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
             // Create the kernel functor.
             FillKernel kernel(managed_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(managed_data.m_size),
+            h.parallel_for<FillKernel>(cl::sycl::range<1>(managed_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -489,7 +489,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
             // Create the kernel functor.
             FillKernel kernel(device_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(device_data.m_size),
+            h.parallel_for<FillKernel>(cl::sycl::range<1>(device_data.size()),
                                        kernel);
         })
         .wait_and_throw();


### PR DESCRIPTION
This is a slightly bigger thing...

It's been really bothering me since a while that in [traccc](https://github.com/acts-project/traccc) we would need to put two different interfaces on algorithms that receive a jagged vector as their input. (Which is most of them.) Like:

https://github.com/acts-project/traccc/blob/main/device/sycl/include/traccc/sycl/seeding/seeding_algorithm.hpp

So far the 3 different jagged vector data types (`vecmem::data::jagged_vector_view`, `vecmem::data::jagged_vector_data`, `vecmem::data::jagged_vector_buffer`) were written to each contain the minimum amount of information possible. This PR breaks with that.

What I did was to move the `host_ptr()` function previously only defined in `vecmem::data::jagged_vector_buffer` all the way down to `vecmem::data::jagged_vector_view`. Meaning that that type received one more pointer member. (Remember that virtual function calls are not a thing for these types...)

At the same time I made `vecmem::data::jagged_vector_view` into a class, so that it would have a consistent interface with `vecmem::data::vector_view`.

These changes allowed me to greatly simplify `vecmem::copy`. Since that too can now just handle all jagged vector views through a single interface. Showcasing a bit what sort of simplification we could achieve in [traccc](https://github.com/acts-project/traccc) as well. :wink:

The updates in the tests are just technicalities, necessitated by the `struct` -> `class` change.