### PR TITLE
Resizable Jagged Vector Copies, main branch (2022.10.17.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -133,6 +133,12 @@ public:
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes(
         const data::jagged_vector_view<TYPE>& data);
 
+    /// Helper function for setting the sizes of a resizable jagged vector
+    template <typename TYPE>
+    void set_sizes(
+        const std::vector<typename data::vector_view<TYPE>::size_type>& sizes,
+        data::jagged_vector_view<TYPE> data);
+
     /// @}
 
 protected:
@@ -145,8 +151,10 @@ protected:
 private:
     /// Helper function performing the copy of a jagged array/vector
     template <typename TYPE1, typename TYPE2>
-    void copy_views_impl(std::size_t size, const data::vector_view<TYPE1>* from,
-                         data::vector_view<TYPE2>* to, type::copy_type cptype);
+    void copy_views_impl(
+        const std::vector<typename data::vector_view<TYPE1>::size_type>& sizes,
+        const data::vector_view<TYPE1>* from, data::vector_view<TYPE2>* to,
+        type::copy_type cptype);
     /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes_impl(


### PR DESCRIPTION
Continuing with hunting down bugs found by @guilhermeAlmeida1, I now made copies from resizable jagged vectors possible.

The previously implemented code broke down if the source of the copy was a resizable `jagged_vector_buffer`, which was not filled with data completely. Which is exactly what happens during "doublet counting" in [traccc](https://github.com/acts-project/traccc). The good thing is that the assertions in the code were correct. They did catch this logic error. But only when building the code in "Debug" mode. :stuck_out_tongue:

In the updated setup the copies generally use the vector capacities instead of the sizes, in order to have a chance for optimised copies out of resizable `jagged_vector_buffer`-s.

At the same time I introduced the `vecmem::copy::set_sizes(...)` function for conveniently setting the sizes of a jagged vector (buffer). Which can come in handy when it's the target container that is resizable, and not the source one. (Though this latter operation I didn't really test yet.) And I also plan to use this new function to finally resolve #95 in the non-too-distant future.

@guilhermeAlmeida1, please check if this branch works correctly with your code. I will still need to add some meaningful unit tests to this PR before I would push it in. Since unfortunately the copies are woefully under-tested in this repository right now. :frowning: