### PR TITLE
Jagged Vector Copy Update, main branch (2022.10.24.)

### DIFF
--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -11,6 +11,7 @@
 #include "vecmem/containers/details/aligned_multiple_placement.hpp"
 
 // System include(s).
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <memory>
@@ -25,10 +26,8 @@ std::vector<std::size_t> get_sizes(
     const vecmem::data::jagged_vector_view<TYPE>& jvv) {
 
     std::vector<std::size_t> result(jvv.size());
-    for (typename vecmem::data::jagged_vector_view<TYPE>::size_type i = 0;
-         i < jvv.size(); ++i) {
-        result[i] = jvv.host_ptr()[i].size();
-    }
+    std::transform(jvv.host_ptr(), jvv.host_ptr() + jvv.size(), result.begin(),
+                   [](const auto& vv) { return vv.size(); });
     return result;
 }
 

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -155,10 +155,20 @@ private:
         const std::vector<typename data::vector_view<TYPE1>::size_type>& sizes,
         const data::vector_view<TYPE1>* from, data::vector_view<TYPE2>* to,
         type::copy_type cptype);
+    /// Helper function performing the copy of a jagged array/vector
+    template <typename TYPE1, typename TYPE2>
+    void copy_views_contiguous_impl(
+        const std::vector<typename data::vector_view<TYPE1>::size_type>& sizes,
+        const data::vector_view<TYPE1>* from, data::vector_view<TYPE2>* to,
+        type::copy_type cptype);
     /// Helper function for getting the sizes of a jagged vector/buffer
     template <typename TYPE>
     std::vector<typename data::vector_view<TYPE>::size_type> get_sizes_impl(
         const data::vector_view<TYPE>* data, std::size_t size);
+    /// Check if a vector of views occupy a contiguous block of memory
+    template <typename TYPE>
+    static bool is_contiguous(const data::vector_view<TYPE>* data,
+                              std::size_t size);
 
 };  // class copy
 

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -295,7 +295,8 @@ TEST_F(core_copy_test, jagged_vector_buffer) {
     }
 
     // Make a copy of it into a buffer.
-    auto copy_data = m_copy.to(source_data, m_resource);
+    auto copy_data = m_copy.to(source_data, m_resource, nullptr,
+                               vecmem::copy::type::host_to_device);
     // Check the copy.
     vecmem::jagged_device_vector<int> copy_data_vec(copy_data);
     EXPECT_EQ(source_data_vec.size(), copy_data_vec.size());
@@ -316,7 +317,7 @@ TEST_F(core_copy_test, jagged_vector_buffer) {
 
     // Make a copy into a host vector.
     vecmem::jagged_vector<int> copy_vec(&m_resource);
-    m_copy(source_data, copy_vec);
+    m_copy(source_data, copy_vec, vecmem::copy::type::device_to_host);
     // Check the copy.
     EXPECT_EQ(reference.size(), copy_vec.size());
     auto reference_itr = reference.begin();
@@ -369,7 +370,8 @@ TEST_F(core_copy_test, resizable_jagged_vector_buffer) {
     }
 
     // Make a copy of it into a buffer.
-    auto copy_data = m_copy.to(source_data, m_resource);
+    auto copy_data = m_copy.to(source_data, m_resource, nullptr,
+                               vecmem::copy::type::host_to_device);
     // Check the copy.
     vecmem::jagged_device_vector<int> copy_data_vec(copy_data);
     EXPECT_EQ(source_data_vec.size(), copy_data_vec.size());
@@ -390,7 +392,7 @@ TEST_F(core_copy_test, resizable_jagged_vector_buffer) {
 
     // Make a copy into a host vector.
     vecmem::jagged_vector<int> copy_vec(&m_resource);
-    m_copy(source_data, copy_vec);
+    m_copy(source_data, copy_vec, vecmem::copy::type::device_to_host);
     // Check the copy.
     EXPECT_EQ(reference.size(), copy_vec.size());
     auto reference_itr = reference.begin();


### PR DESCRIPTION
This is meant to conclude the updates on jagged vector copies for now. (Right now I don't have more ideas on how to make things better. :stuck_out_tongue:)

In order to reduce the chances of mistakenly trying to perform a single memory copy over multiple memory allocations, the jagged vector copy now only tries to be "optimal" if all of the elements of the jagged vector are contiguous in memory. Since the chances of this happening by chance are very-very low.

Finally updated the unit tests to explicitly test the optimised copies using (just) host memory (for now).

Also made a tiny improvement/change in the implementation of `vecmem::data::jagged_vector_buffer`, making use of a standard algorithm instead of using a hand-written for-loop. (This latter one is something I bumped into a while ago, I just never committed it.)