### PR TITLE
hipSYCL Support, main branch (2022.11.04.)

### DIFF
--- a/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
+++ b/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
@@ -27,6 +27,12 @@ if( NOT "$ENV{SYCLCXX}" STREQUAL "" )
    execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}" "--version"
       OUTPUT_VARIABLE _syclVersionOutput
       RESULT_VARIABLE _syclVersionResult )
+   if( NOT ${_syclVersionResult} EQUAL 0 )
+      execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}"
+                               "--hipsycl-version"
+         OUTPUT_VARIABLE _syclVersionOutput
+         RESULT_VARIABLE _syclVersionResult )
+   endif()
    if( ${_syclVersionResult} EQUAL 0 )
       if( "${_syclVersionOutput}" MATCHES "ComputeCpp" )
          set( CMAKE_SYCL_COMPILER_ID "ComputeCpp" CACHE STRING
@@ -34,15 +40,19 @@ if( NOT "$ENV{SYCLCXX}" STREQUAL "" )
          set( _syclVersionRegex "([0-9\.]+) Device Compiler" )
       elseif( "${_syclVersionOutput}" MATCHES "oneAPI" )
          set( CMAKE_SYCL_COMPILER_ID "IntelLLVM" CACHE STRING
-         "Identifier for the SYCL compiler in use" )
+            "Identifier for the SYCL compiler in use" )
          set( _syclVersionRegex "DPC\\\+\\\+.*Compiler ([0-9\.]+)" )
       elseif( "${_syclVersionOutput}" MATCHES "intel/llvm" )
          set( CMAKE_SYCL_COMPILER_ID "IntelLLVM" CACHE STRING
-         "Identifier for the SYCL compiler in use" )
+            "Identifier for the SYCL compiler in use" )
          set( _syclVersionRegex "clang version ([0-9\.]+)" )
+      elseif( "${_syclVersionOutput}" MATCHES "hipSYCL" )
+         set( CMAKE_SYCL_COMPILER_ID "hipSYCL" CACHE STRING
+            "Identifier for the SYCL compiler in use" )
+         set( _syclVersionRegex "hipSYCL version: ([0-9\.]+)" )
       else()
          set( CMAKE_SYCL_COMPILER_ID "Unknown" CACHE STRING
-         "Identifier for the SYCL compiler in use" )
+            "Identifier for the SYCL compiler in use" )
          set( _syclVersionRegex "[a-zA-Z]+ version ([0-9\.]+)" )
       endif()
       string( REPLACE "\n" ";" _syclVersionOutputList "${_syclVersionOutput}" )

--- a/cmake/sycl/CMakeSYCLInformation.cmake
+++ b/cmake/sycl/CMakeSYCLInformation.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2022 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -14,7 +14,7 @@ include( Platform/${CMAKE_EFFECTIVE_SYSTEM_NAME}-${CMAKE_SYCL_COMPILER_ID}-SYCL
 # Set up how SYCL object file compilation should go.
 if( NOT DEFINED CMAKE_SYCL_COMPILE_OBJECT )
    set( CMAKE_SYCL_COMPILE_OBJECT
-      "<CMAKE_SYCL_COMPILER> -x c++ <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>" )
+      "<CMAKE_SYCL_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>" )
 endif()
 
 # Set up how shared library building should go.

--- a/cmake/sycl/Platform/Linux-hipSYCL-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-hipSYCL-SYCL.cmake
@@ -1,0 +1,17 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2022 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Use the standard GNU compiler options for ComputeCpp.
+include( Platform/Linux-GNU )
+__linux_compiler_gnu( SYCL )
+
+# Set an archive (static library) creation command explicitly for this platform.
+set( CMAKE_SYCL_CREATE_STATIC_LIBRARY
+   "<CMAKE_AR> qc <TARGET> <LINK_FLAGS> <OBJECTS>" )
+
+# Set the flags controlling the C++ standard used by the SYCL compiler.
+set( CMAKE_SYCL17_STANDARD_COMPILE_OPTION "-std=c++17" )
+set( CMAKE_SYCL17_EXTENSION_COMPILE_OPTION "-std=c++17" )


### PR DESCRIPTION
Added explicit support for building the project with [hipSYCL](https://github.com/illuhad/hipSYCL).

With the latest hipSYCL tag ([0.9.3](https://github.com/illuhad/hipSYCL/releases/tag/v0.9.3)) I was able to build all of the SYCL tests of our project for both an AMD and NVIDIA backend, and even run all of the tests successfully.

There is one outstanding issue still about our project's strict warning settings generating a metric ton of warnings from the hipSYCL headers, but I need to follow up with the hipSYCL developer(s) separately about that.

P.S. Yes, if this keeps on working, we should teach the CI how to test the build with hipSYCL. :wink: