### PR TITLE
CI Update, main branch (2022.11.04.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -76,7 +76,7 @@ jobs:
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda:v11"
             OPTIONS:
           - NAME: "CUDA"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v32"
             OPTIONS:
           - NAME: "HIP"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm:v11"
@@ -85,7 +85,7 @@ jobs:
             CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v20"
             OPTIONS:
           - NAME: "SYCL"
-            CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v20"
+            CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v32"
             OPTIONS: -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
         include:
           - BUILD:
@@ -93,7 +93,7 @@ jobs:
               MSG_LVL: 0
             PLATFORM:
               NAME: "SYCL"
-              CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v20"
+              CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v32"
               OPTIONS: -DVECMEM_BUILD_HIP_LIBRARY=FALSE
 
     # The system to run on.


### PR DESCRIPTION
Upgraded to [CUDA 11.6.2](https://developer.nvidia.com/cuda-11-6-2-download-archive) (https://github.com/acts-project/machines/pull/72) and [intel/llvm 2022-06](https://github.com/intel/llvm/releases/tag/2022-06) (https://github.com/acts-project/machines/pull/73).

The first one will help with upgrading to even newer versions of the Intel compiler on top of Ubuntu 20.04, and the latter will hopefully put a stop to all of the CI failures that have been plaguing us in the last few weeks.