### PR TITLE
CI Update, main branch (2022.11.07.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -76,7 +76,7 @@ jobs:
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda:v11"
             OPTIONS:
           - NAME: "CUDA"
-            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v13"
+            CONTAINER: "ghcr.io/acts-project/ubuntu2004_cuda:v32"
             OPTIONS:
           - NAME: "HIP"
             CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm:v11"
@@ -84,16 +84,20 @@ jobs:
           - NAME: "SYCL"
             CONTAINER: "ghcr.io/acts-project/ubuntu2004_oneapi:v20"
             OPTIONS:
-          - NAME: "SYCL"
-            CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v20"
-            OPTIONS: -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
         include:
           - BUILD:
               TYPE: "Release"
               MSG_LVL: 0
             PLATFORM:
               NAME: "SYCL"
-              CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v20"
+              CONTAINER: "ghcr.io/acts-project/ubuntu1804_cuda_oneapi:v32"
+              OPTIONS: -DVECMEM_BUILD_CUDA_LIBRARY=FALSE
+          - BUILD:
+              TYPE: "Release"
+              MSG_LVL: 0
+            PLATFORM:
+              NAME: "SYCL"
+              CONTAINER: "ghcr.io/acts-project/ubuntu1804_rocm_oneapi:v32"
               OPTIONS: -DVECMEM_BUILD_HIP_LIBRARY=FALSE
 
     # The system to run on.


### PR DESCRIPTION
Disabled the Debug build for the CUDA backend with Intel's compiler. See https://github.com/intel/llvm/issues/5980 for some details on that. (I investigated today a bit. I didn't find any trivial changes in our code that would get rid of the linking error.)

At the same time updated to the latest versions of the [ubuntu1804_cuda_oneapi](https://github.com/acts-project/machines/pkgs/container/ubuntu1804_cuda_oneapi), [ubuntu1804_rocm_oneapi](https://github.com/acts-project/machines/pkgs/container/ubuntu1804_rocm_oneapi) and [ubuntu2004_cuda](https://github.com/acts-project/machines/pkgs/container/ubuntu2004_cuda) images.

This is a replacement for #205. Note that this will need an update in the GitHub project, to adjust the list of required tests in the CI.