### PR TITLE
SYCL Assert Test Update, main branch (2022.11.10.)

### DIFF
--- a/cmake/vecmem-check-sycl-code-compiles.cmake
+++ b/cmake/vecmem-check-sycl-code-compiles.cmake
@@ -15,7 +15,7 @@ include( CMakeParseArguments )
 function( vecmem_check_sycl_code_compiles _variable )
 
    # Parse the optional function arguments.
-   cmake_parse_arguments( ARG "" "" "COMPILE_DEFINITIONS" ${ARGN} )
+   cmake_parse_arguments( ARG "" "" "COMPILE_DEFINITIONS;CMAKE_FLAGS" ${ARGN} )
 
    # Enable the SYCL language.
    enable_language( SYCL )
@@ -36,7 +36,8 @@ function( vecmem_check_sycl_code_compiles _variable )
    try_compile( ${_variable}
       "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_variable}"
       SOURCES ${ARG_UNPARSED_ARGUMENTS}
-      COMPILE_DEFINITIONS ${ARG_COMPILE_DEFINITIONS} )
+      COMPILE_DEFINITIONS ${ARG_COMPILE_DEFINITIONS}
+      CMAKE_FLAGS ${ARG_CMAKE_FLAGS} )
 
    # Print a result message.
    if( ${_variable} )

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -40,7 +40,8 @@ set_target_properties( vecmem_sycl PROPERTIES
 
 # Check if assertions work out of the box in the build.
 vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_ASSERT
-   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl" )
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl"
+   CMAKE_FLAGS -DCMAKE_BUILD_TYPE:STRING=Debug )
 
 # If not, check if it can be solved as described in:
 #   https://github.com/intel/llvm/issues/3385
@@ -49,7 +50,8 @@ if( NOT VECMEM_HAVE_SYCL_ASSERT )
    # Check if the "CUDA polyfill" can make the test work.
    vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_CUDA_ASSERT_POLYFILL
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/assert_test.sycl"
-      "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/sycl/cuda_assert_polyfill.sycl" )
+      "${CMAKE_CURRENT_SOURCE_DIR}/src/utils/sycl/cuda_assert_polyfill.sycl"
+      CMAKE_FLAGS -DCMAKE_BUILD_TYPE:STRING=Debug )
 
    # If yes, we have to do something a bit elaborate. The "polyfill" code only
    # works correctly when linked into the binary that needs to use assertions.


### PR DESCRIPTION
Made the `assert(...)` failure detection in SYCL code more robust. Making sure that the test code would actually be compiled in Debug mode, so to be sensitive to a wider range of issues than it was to before.

Previously the code was only sensitive to the issue discussed in https://github.com/intel/llvm/issues/3385. With this update it becomes sensitive to https://github.com/intel/llvm/issues/5980 as well. It cannot fix the latter, but at least we get a warning in the CMake configuration that would explain any build failures later on.