### PR TITLE
Copy and Assignment Fixes, main branch (2022.11.14.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -53,6 +53,9 @@ public:
 
     /// @}
 
+    /// Default constructor
+    jagged_vector_buffer();
+
     /// Constructor from an existing @c vecmem::data::jagged_vector_view
     ///
     /// @param other The existing @c vecmem::data::jagged_vector_view object
@@ -94,6 +97,12 @@ public:
                          const std::vector<std::size_t>& capacities,
                          memory_resource& resource,
                          memory_resource* host_access_resource = nullptr);
+
+    /// Move constructor
+    jagged_vector_buffer(jagged_vector_buffer&&) = default;
+
+    /// Move assignment
+    jagged_vector_buffer& operator=(jagged_vector_buffer&&) = default;
 
 private:
     /// Data object for the @c vecmem::data::vector_view array

--- a/core/include/vecmem/containers/data/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_data.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -37,6 +37,8 @@ public:
     /// Use the base class's @c value_type
     typedef typename base_type::value_type value_type;
 
+    /// Default constructor
+    jagged_vector_data();
     /**
      * @brief Construct jagged vector data from raw information
      *
@@ -47,6 +49,11 @@ public:
      * @param[in] mem The memory resource to manage the internal state
      */
     jagged_vector_data(size_type size, memory_resource& mem);
+    /// Move constructor
+    jagged_vector_data(jagged_vector_data&&) = default;
+
+    /// Move assignment
+    jagged_vector_data& operator=(jagged_vector_data&&) = default;
 
 private:
     /// Data object owning the allocated memory

--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -76,14 +76,33 @@ public:
         typename OTHERTYPE,
         std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> = true>
     VECMEM_HOST_AND_DEVICE jagged_vector_view(
-        jagged_vector_view<OTHERTYPE> parent);
+        const jagged_vector_view<OTHERTYPE>& parent);
 
     /// Assignment operator from a "slightly different" object
     template <
         typename OTHERTYPE,
         std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> = true>
     VECMEM_HOST_AND_DEVICE jagged_vector_view& operator=(
-        jagged_vector_view<OTHERTYPE> rhs);
+        const jagged_vector_view<OTHERTYPE>& rhs);
+
+    /// Equality check. Two objects are only equal if they point at the same
+    /// memory.
+    template <
+        typename OTHERTYPE,
+        std::enable_if_t<std::is_same<std::remove_cv_t<T>,
+                                      std::remove_cv_t<OTHERTYPE> >::value,
+                         bool> = true>
+    VECMEM_HOST_AND_DEVICE bool operator==(
+        const jagged_vector_view<OTHERTYPE>& rhs) const;
+
+    /// Inequality check. Simply based on @c operator==.
+    template <
+        typename OTHERTYPE,
+        std::enable_if_t<std::is_same<std::remove_cv_t<T>,
+                                      std::remove_cv_t<OTHERTYPE> >::value,
+                         bool> = true>
+    VECMEM_HOST_AND_DEVICE bool operator!=(
+        const jagged_vector_view<OTHERTYPE>& rhs) const;
 
     /// Get the "outer" size of the jagged vector
     VECMEM_HOST_AND_DEVICE

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -1,6 +1,6 @@
 /** VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,11 +47,18 @@ public:
 
     /// @}
 
+    /// Default constructor
+    vector_buffer();
     /// Constant size data constructor
     vector_buffer(size_type size, memory_resource& resource);
     /// Resizable data constructor
     vector_buffer(size_type capacity, size_type size,
                   memory_resource& resource);
+    /// Move constructor
+    vector_buffer(vector_buffer&&) = default;
+
+    /// Move assignment
+    vector_buffer& operator=(vector_buffer&&) = default;
 
 private:
     /// Data object owning the allocated memory

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -67,6 +67,35 @@ public:
                                bool> = true>
     VECMEM_HOST_AND_DEVICE vector_view(const vector_view<OTHERTYPE>& parent);
 
+    /// Copy from a "slightly different" @c vecmem::details::vector_view object
+    ///
+    /// See the copy constructor for more details.
+    ///
+    template <typename OTHERTYPE,
+              std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE vector_view& operator=(
+        const vector_view<OTHERTYPE>& rhs);
+
+    /// Equality check. Two objects are only equal if they point at the same
+    /// memory.
+    template <
+        typename OTHERTYPE,
+        std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                      std::remove_cv_t<OTHERTYPE> >::value,
+                         bool> = true>
+    VECMEM_HOST_AND_DEVICE bool operator==(
+        const vector_view<OTHERTYPE>& rhs) const;
+
+    /// Inequality check. Simply based on @c operator==.
+    template <
+        typename OTHERTYPE,
+        std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                      std::remove_cv_t<OTHERTYPE> >::value,
+                         bool> = true>
+    VECMEM_HOST_AND_DEVICE bool operator!=(
+        const vector_view<OTHERTYPE>& rhs) const;
+
     /// Get the size of the vector
     VECMEM_HOST_AND_DEVICE
     size_type size() const;

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -52,6 +52,13 @@ allocate_jagged_buffer_outer_memory(
 namespace vecmem {
 namespace data {
 
+/// A custom implementation for the default constructor is necessary because
+/// @c vecmem::data::jagged_vector_view does not set its members to anything
+/// explicitly in its default constructor. (In order to be trivially default
+/// constructible.) So here we need to be explicit.
+template <typename TYPE>
+jagged_vector_buffer<TYPE>::jagged_vector_buffer() : base_type(0, nullptr) {}
+
 template <typename TYPE>
 template <typename OTHERTYPE,
           std::enable_if_t<std::is_convertible<TYPE, OTHERTYPE>::value, bool> >

--- a/core/include/vecmem/containers/impl/jagged_vector_data.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_data.ipp
@@ -35,6 +35,14 @@ allocate_jagged_memory(
 namespace vecmem {
 namespace data {
 
+/// A custom implementation for the default constructor is necessary because
+/// @c vecmem::data::jagged_vector_view does not set its members to anything
+/// explicitly in its default constructor. (In order to be trivially default
+/// constructible.) So here we need to be explicit.
+template <typename T>
+jagged_vector_data<T>::jagged_vector_data()
+    : base_type(static_cast<size_type>(0), nullptr) {}
+
 template <typename T>
 jagged_vector_data<T>::jagged_vector_data(size_type size, memory_resource& mem)
     : base_type(size, nullptr),

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -22,29 +22,61 @@ template <typename T>
 template <typename OTHERTYPE,
           std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> >
 VECMEM_HOST_AND_DEVICE jagged_vector_view<T>::jagged_vector_view(
-    jagged_vector_view<OTHERTYPE> parent)
+    const jagged_vector_view<OTHERTYPE>& parent)
     : m_size(parent.size()),
       // This looks scarier than it really is. We "just" reinterpret a
       // vecmem::data::vector_view<T> pointer to be seen as
       // vecmem::data::vector_view<const T> instead.
-      m_ptr(reinterpret_cast<pointer>(parent.ptr())),
-      m_host_ptr(reinterpret_cast<pointer>(parent.host_ptr())) {}
+      m_ptr(reinterpret_cast<pointer>(
+          const_cast<typename jagged_vector_view<OTHERTYPE>::pointer>(
+              parent.ptr()))),
+      m_host_ptr(reinterpret_cast<pointer>(
+          const_cast<typename jagged_vector_view<OTHERTYPE>::pointer>(
+              parent.host_ptr()))) {}
 
 template <typename T>
 template <typename OTHERTYPE,
           std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> >
 VECMEM_HOST_AND_DEVICE jagged_vector_view<T>& jagged_vector_view<T>::operator=(
-    jagged_vector_view<OTHERTYPE> rhs) {
+    const jagged_vector_view<OTHERTYPE>& rhs) {
 
-    // Avoid self-assignment.
-    if (this == &rhs) {
-        return *this;
-    }
+    // Self-assignment is not dangerous for this type. But putting in
+    // extra checks into the code would not be great.
+    m_size = rhs.size();
+    m_ptr = reinterpret_cast<pointer>(
+        const_cast<typename jagged_vector_view<OTHERTYPE>::pointer>(rhs.ptr()));
+    m_host_ptr = reinterpret_cast<pointer>(
+        const_cast<typename jagged_vector_view<OTHERTYPE>::pointer>(
+            rhs.host_ptr()));
 
-    // Perform the assignment.
-    m_size = rhs.m_size;
-    m_ptr = reinterpret_cast<pointer>(rhs.m_ptr);
-    m_host_ptr = reinterpret_cast<pointer>(rhs.m_host_ptr);
+    // Return this (updated) object.
+    return *this;
+}
+
+template <typename T>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_same<std::remove_cv_t<T>,
+                                        std::remove_cv_t<OTHERTYPE> >::value,
+                           bool> >
+VECMEM_HOST_AND_DEVICE bool jagged_vector_view<T>::operator==(
+    const jagged_vector_view<OTHERTYPE>& rhs) const {
+
+    return ((m_size == rhs.size()) &&
+            (static_cast<const void*>(m_ptr) ==
+             static_cast<const void*>(rhs.ptr())) &&
+            (static_cast<const void*>(m_host_ptr) ==
+             static_cast<const void*>(rhs.host_ptr())));
+}
+
+template <typename T>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_same<std::remove_cv_t<T>,
+                                        std::remove_cv_t<OTHERTYPE> >::value,
+                           bool> >
+VECMEM_HOST_AND_DEVICE bool jagged_vector_view<T>::operator!=(
+    const jagged_vector_view<OTHERTYPE>& rhs) const {
+
+    return !(*this == rhs);
 }
 
 template <typename T>

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -16,6 +16,14 @@
 namespace vecmem {
 namespace data {
 
+/// A custom implementation for the default constructor is necessary because
+/// @c vecmem::data::vector_view does not set its members to anything
+/// explicitly in its default constructor. (In order to be trivially default
+/// constructible.) So here we need to be explicit.
+template <typename TYPE>
+vector_buffer<TYPE>::vector_buffer()
+    : base_type(static_cast<size_type>(0), nullptr) {}
+
 template <typename TYPE>
 vector_buffer<TYPE>::vector_buffer(size_type size, memory_resource& resource)
     : vector_buffer(size, size, resource) {}

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -33,6 +33,45 @@ VECMEM_HOST_AND_DEVICE vector_view<TYPE>::vector_view(
       m_ptr(parent.ptr()) {}
 
 template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value, bool> >
+VECMEM_HOST_AND_DEVICE vector_view<TYPE>& vector_view<TYPE>::operator=(
+    const vector_view<OTHERTYPE>& rhs) {
+
+    // Self-assignment is not dangerous for this type. But putting in
+    // extra checks into the code would not be great.
+    m_capacity = rhs.capacity();
+    m_size = rhs.size_ptr();
+    m_ptr = rhs.ptr();
+
+    // Return this (updated) object.
+    return *this;
+}
+
+template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                        std::remove_cv_t<OTHERTYPE> >::value,
+                           bool> >
+VECMEM_HOST_AND_DEVICE bool vector_view<TYPE>::operator==(
+    const vector_view<OTHERTYPE>& rhs) const {
+
+    return ((m_capacity == rhs.capacity()) && (m_size == rhs.size_ptr()) &&
+            (m_ptr == rhs.ptr()));
+}
+
+template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                        std::remove_cv_t<OTHERTYPE> >::value,
+                           bool> >
+VECMEM_HOST_AND_DEVICE bool vector_view<TYPE>::operator!=(
+    const vector_view<OTHERTYPE>& rhs) const {
+
+    return !(*this == rhs);
+}
+
+template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size() const -> size_type {
 
     return (m_size == nullptr ? m_capacity : *m_size);


### PR DESCRIPTION
As @guilhermeAlmeida1 found in https://github.com/acts-project/traccc/pull/271, the "data owning" types couldn't be default-constructed so far. Which there can be a legitimate use case for. (As shown in that PR.)

While adding those default constructors I noticed that copy constructors and assignment operators on the "view types" were also a bit all over the place. So I now tried to clean those up a bit as well.

Also added compatison operators for the view types.

Finally, added some extra tests at the end to make sure that all of this would work as intended.