### PR TITLE
Asynchronous Copies, main branch (2022.12.13.)

### DIFF
--- a/core/include/vecmem/utils/abstract_event.hpp
+++ b/core/include/vecmem/utils/abstract_event.hpp
@@ -1,0 +1,32 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem {
+
+/// Interface that language specific "events" need to implement
+///
+/// "Events" provide a way to have synchronization points in a program's
+/// execution flow. Asynchronous memory operations in different languages
+/// provide ways of explicitly waiting for the completion of certain operations.
+/// This abstract interface is used in this project to provide a uniform
+/// interface to language specific "event" objects that would provide such
+/// synchronization points.
+///
+struct abstract_event {
+
+    /// Virtual destructor to make vtable happy
+    virtual ~abstract_event() {}
+
+    /// Function that would block the current thread until the event is
+    /// complete
+    virtual void wait() = 0;
+
+};  // struct abstract_event
+
+}  // namespace vecmem

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -23,11 +23,11 @@
 namespace vecmem {
 
 template <typename TYPE>
-void copy::setup(data::vector_view<TYPE> data) {
+copy::event_type copy::setup(data::vector_view<TYPE> data) {
 
     // Check if anything needs to be done.
     if ((data.size_ptr() == nullptr) || (data.capacity() == 0)) {
-        return;
+        return vecmem::copy::create_event();
     }
 
     // Initialize the "size variable" correctly on the buffer.
@@ -37,20 +37,26 @@ void copy::setup(data::vector_view<TYPE> data) {
                      "Prepared a device vector buffer of capacity %u "
                      "for use on a device (ptr: %p)",
                      data.capacity(), static_cast<void*>(data.size_ptr()));
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE>
-void copy::memset(data::vector_view<TYPE> data, int value) {
+copy::event_type copy::memset(data::vector_view<TYPE> data, int value) {
 
     // Check if anything needs to be done.
     if (data.capacity() == 0) {
-        return;
+        return vecmem::copy::create_event();
     }
 
     // Call memset with the correct arguments.
     do_memset(data.capacity() * sizeof(TYPE), data.ptr(), value);
     VECMEM_DEBUG_MSG(2, "Set %u vector elements to %i at ptr: %p",
                      data.capacity(), value, static_cast<void*>(data.ptr()));
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE>
@@ -61,17 +67,20 @@ data::vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     // Set up the result buffer.
     data::vector_buffer<std::remove_cv_t<TYPE>> result(
         data.capacity(), get_size(data), resource);
-    setup(result);
+    setup(result)->wait();
 
-    // Copy the payload of the vector.
-    this->operator()(data, result, cptype);
+    // Copy the payload of the vector. Explicitly waiting for the copy to finish
+    // before returning the buffer.
+    operator()(data, result, cptype)->wait();
+
+    // Return the buffer.
     return result;
 }
 
 template <typename TYPE1, typename TYPE2>
-void copy::operator()(const data::vector_view<TYPE1>& from_view,
-                      data::vector_view<TYPE2> to_view,
-                      type::copy_type cptype) {
+copy::event_type copy::operator()(const data::vector_view<TYPE1>& from_view,
+                                  data::vector_view<TYPE2> to_view,
+                                  type::copy_type cptype) {
 
     // The input and output types are allowed to be different, but only by
     // const-ness.
@@ -101,12 +110,15 @@ void copy::operator()(const data::vector_view<TYPE1>& from_view,
     // Copy the payload.
     assert(size == get_size(to_view));
     do_copy(size * sizeof(TYPE1), from_view.ptr(), to_view.ptr(), cptype);
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE1, typename TYPE2, typename ALLOC>
-void copy::operator()(const data::vector_view<TYPE1>& from_view,
-                      std::vector<TYPE2, ALLOC>& to_vec,
-                      type::copy_type cptype) {
+copy::event_type copy::operator()(const data::vector_view<TYPE1>& from_view,
+                                  std::vector<TYPE2, ALLOC>& to_vec,
+                                  type::copy_type cptype) {
 
     // The input and output types are allowed to be different, but only by
     // const-ness.
@@ -122,6 +134,9 @@ void copy::operator()(const data::vector_view<TYPE1>& from_view,
     to_vec.resize(size);
     // Perform the memory copy.
     do_copy(size * sizeof(TYPE1), from_view.ptr(), to_vec.data(), cptype);
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE>
@@ -139,16 +154,21 @@ typename data::vector_view<TYPE>::size_type copy::get_size(
     do_copy(sizeof(typename data::vector_view<TYPE>::size_type),
             data.size_ptr(), &result, type::unknown);
 
+    // Wait for the copy operation to finish. With some backends
+    // (khm... SYCL... khm...) copies can be asynchronous even into
+    // non-pinned host memory.
+    create_event()->wait();
+
     // Return what we got.
     return result;
 }
 
 template <typename TYPE>
-void copy::setup(data::jagged_vector_view<TYPE> data) {
+copy::event_type copy::setup(data::jagged_vector_view<TYPE> data) {
 
     // Check if anything needs to be done.
     if (data.size() == 0) {
-        return;
+        return vecmem::copy::create_event();
     }
 
     // "Set up" the inner vector descriptors, using the host-accessible data.
@@ -161,7 +181,7 @@ void copy::setup(data::jagged_vector_view<TYPE> data) {
 
     // Check if anything else needs to be done.
     if (data.ptr() == data.host_ptr()) {
-        return;
+        return create_event();
     }
 
     // Copy the description of the inner vectors of the buffer.
@@ -174,15 +194,21 @@ void copy::setup(data::jagged_vector_view<TYPE> data) {
                      "Prepared a jagged device vector buffer of size %lu "
                      "for use on a device",
                      data.size());
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE>
-void copy::memset(data::jagged_vector_view<TYPE> data, int value) {
+copy::event_type copy::memset(data::jagged_vector_view<TYPE> data, int value) {
 
     // Use a very naive/expensive implementation.
     for (std::size_t i = 0; i < data.size(); ++i) {
         this->memset(data.host_ptr()[i], value);
     }
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE>
@@ -196,19 +222,20 @@ data::jagged_vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     assert(result.size() == data.size());
 
     // Copy the description of the "inner vectors" if necessary.
-    setup(result);
+    setup(result)->wait();
 
-    // Copy the payload of the inner vectors.
-    this->operator()(data, result, cptype);
+    // Copy the payload of the inner vectors. Explicitly waiting for the copy to
+    // finish before returning the buffer.
+    operator()(data, result, cptype)->wait();
 
     // Return the newly created object.
     return result;
 }
 
 template <typename TYPE1, typename TYPE2>
-void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
-                      data::jagged_vector_view<TYPE2> to_view,
-                      type::copy_type cptype) {
+copy::event_type copy::operator()(
+    const data::jagged_vector_view<TYPE1>& from_view,
+    data::jagged_vector_view<TYPE2> to_view, type::copy_type cptype) {
 
     // The input and output types are allowed to be different, but only by
     // const-ness.
@@ -227,7 +254,7 @@ void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
     // Check if anything needs to be done.
     const std::size_t size = from_view.size();
     if (size == 0) {
-        return;
+        return vecmem::copy::create_event();
     }
 
     // Calculate the contiguous-ness of the memory allocations.
@@ -268,12 +295,16 @@ void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
         copy_views_impl(sizes, from_view.host_ptr(), to_view.host_ptr(),
                         cptype);
     }
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE1, typename TYPE2, typename ALLOC1, typename ALLOC2>
-void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
-                      std::vector<std::vector<TYPE2, ALLOC2>, ALLOC1>& to_vec,
-                      type::copy_type cptype) {
+copy::event_type copy::operator()(
+    const data::jagged_vector_view<TYPE1>& from_view,
+    std::vector<std::vector<TYPE2, ALLOC2>, ALLOC1>& to_vec,
+    type::copy_type cptype) {
 
     // The input and output types are allowed to be different, but only by
     // const-ness.
@@ -284,14 +315,14 @@ void copy::operator()(const data::jagged_vector_view<TYPE1>& from_view,
     // Resize the output object to the correct size.
     to_vec.resize(from_view.size());
     const auto sizes = get_sizes(from_view);
+    assert(sizes.size() == to_vec.size());
     for (typename data::jagged_vector_view<TYPE1>::size_type i = 0;
          i < from_view.size(); ++i) {
         to_vec[i].resize(sizes[i]);
     }
 
     // Perform the memory copy.
-    auto helper = vecmem::get_data(to_vec);
-    this->operator()(from_view, helper, cptype);
+    return operator()(from_view, vecmem::get_data(to_vec), cptype);
 }
 
 template <typename TYPE>
@@ -303,13 +334,13 @@ std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes(
 }
 
 template <typename TYPE>
-void copy::set_sizes(
+copy::event_type copy::set_sizes(
     const std::vector<typename data::vector_view<TYPE>::size_type>& sizes,
     data::jagged_vector_view<TYPE> data) {
 
     // Finish early if possible.
     if ((sizes.size() == 0) && (data.size() == 0)) {
-        return;
+        return vecmem::copy::create_event();
     }
     // Make sure that the sizes match up.
     if (sizes.size() != data.size()) {
@@ -334,12 +365,15 @@ void copy::set_sizes(
     }
     // If no copy is necessary, we're done.
     if (perform_copy == false) {
-        return;
+        return vecmem::copy::create_event();
     }
     // Perform the copy with some internal knowledge of how resizable jagged
     // vector buffers work.
     do_copy(sizeof(typename data::vector_view<TYPE>::size_type) * sizes.size(),
             sizes.data(), data.host_ptr()->size_ptr(), type::unknown);
+
+    // Return a new event.
+    return create_event();
 }
 
 template <typename TYPE1, typename TYPE2>
@@ -454,6 +488,10 @@ std::vector<typename data::vector_view<TYPE>::size_type> copy::get_sizes_impl(
             do_copy(sizeof(typename data::vector_view<TYPE>::size_type) *
                         (size - i),
                     data[i].size_ptr(), result.data() + i, type::unknown);
+            // Wait for the copy operation to finish. With some backends
+            // (khm... SYCL... khm...) copies can be asynchronous even into
+            // non-pinned host memory.
+            create_event()->wait();
             // At this point the result vector should have been set up
             // correctly.
             return result;

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -14,6 +14,13 @@
 // System include(s).
 #include <cstring>
 
+namespace {
+/// Empty/no-op implementation for @c vecmem::abstract_event
+struct noop_event : public vecmem::abstract_event {
+    virtual void wait() override {}
+};  // struct noop_event
+}  // namespace
+
 namespace vecmem {
 
 void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
@@ -37,6 +44,12 @@ void copy::do_memset(std::size_t size, void* ptr, int value) {
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(2, "Set %lu bytes to %i at %p with POSIX memset", size,
                      value, ptr);
+}
+
+copy::event_type copy::create_event() {
+
+    // Make a no-op event.
+    return std::make_unique<noop_event>();
 }
 
 }  // namespace vecmem

--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -36,6 +36,8 @@ protected:
                          type::copy_type cptype) override;
     /// Fill a memory area using CUDA asynchronously
     virtual void do_memset(std::size_t size, void* ptr, int value) override;
+    /// Create an event for synchronization
+    virtual event_type create_event() override;
 
 private:
     /// The stream that the copies are performed on

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -26,6 +26,8 @@ vecmem_add_library( vecmem_sycl sycl
    # Utilities.
    "include/vecmem/utils/sycl/copy.hpp"
    "src/utils/sycl/copy.sycl"
+   "include/vecmem/utils/sycl/async_copy.hpp"
+   "src/utils/sycl/async_copy.sycl"
    "include/vecmem/utils/sycl/queue_wrapper.hpp"
    "src/utils/sycl/queue_wrapper.sycl"
    "src/utils/sycl/get_queue.hpp"

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -1,0 +1,58 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/utils/copy.hpp"
+#include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
+
+// System include(s).
+#include <memory>
+
+namespace vecmem::sycl {
+namespace details {
+/// Object holding on to internal data for @c vecmem::sycl::async_copy
+struct async_copy_data;
+}  // namespace details
+
+/// Specialisation of @c vecmem::copy for SYCL
+///
+/// Unlike @c vecmem::cuda::copy and @c vecmem::hip::copy, this object does
+/// have a state. As USM memory operations in SYCL happen through a
+/// @c cl::sycl::queue object. So this object needs to point to a valid
+/// queue object itself.
+///
+/// Different to @c vecmem::sycl::copy, this type performs operations
+/// asynchronously, requiring users to introduce synchronisation points
+/// explicitly into their code as needed.
+///
+class VECMEM_SYCL_EXPORT async_copy : public vecmem::copy {
+
+public:
+    /// Constructor on top of a user-provided queue
+    async_copy(const queue_wrapper& queue = {});
+    /// Destructor
+    ~async_copy();
+
+protected:
+    /// Perform a memory copy using SYCL
+    virtual void do_copy(std::size_t size, const void* from, void* to,
+                         type::copy_type cptype) override;
+    /// Fill a memory area using SYCL
+    virtual void do_memset(std::size_t size, void* ptr, int value) override;
+    /// Create an event for synchronization
+    virtual event_type create_event() override;
+
+private:
+    /// Internal data for the object
+    std::unique_ptr<details::async_copy_data> m_data;
+
+};  // class async_copy
+
+}  // namespace vecmem::sycl

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -1,0 +1,115 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2022 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+// VecMem include(s).
+#include "get_queue.hpp"
+#include "vecmem/utils/debug.hpp"
+#include "vecmem/utils/sycl/async_copy.hpp"
+
+// System include(s).
+#include <vector>
+
+namespace {
+
+/// SYCL specific implementation of the abstract event interface
+struct sycl_event : public vecmem::abstract_event {
+
+    /// Constructor with a SYCL event
+    sycl_event(const std::vector<::sycl::event>& events) : m_events(events) {}
+
+    /// Synchronize on the underlying SYCL event
+    virtual void wait() override { ::sycl::event::wait_and_throw(m_events); }
+
+    /// The managed SYCL event
+    std::vector<::sycl::event> m_events;
+
+};  // struct sycl_event
+
+}  // namespace
+
+namespace vecmem::sycl {
+namespace details {
+
+struct async_copy_data {
+    queue_wrapper m_queue;
+    std::vector<::sycl::event> m_events;
+};
+
+}  // namespace details
+
+async_copy::async_copy(const queue_wrapper& queue)
+    : m_data(new details::async_copy_data{queue, {}}) {}
+
+async_copy::~async_copy() {}
+
+void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
+                         type::copy_type) {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory copy");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
+
+    // Perform the copy.
+    m_data->m_events.push_back(
+        details::get_queue(m_data->m_queue).memcpy(to_ptr, from_ptr, size));
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(1, "Performed memory copy of %lu bytes from %p to %p",
+                     size, from_ptr, to_ptr);
+}
+
+void async_copy::do_memset(std::size_t size, void* ptr, int value) {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory filling");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(ptr != nullptr);
+
+    // Perform the operation.
+#if defined(VECMEM_HAVE_SYCL_MEMSET)
+    m_data->m_events.push_back(
+        details::get_queue(m_data->m_queue).memset(ptr, value, size));
+#else
+    // We can not perform this operation asynchronously, since the data used
+    // in the copy only exists as long as this function is executing. So we
+    // don't record this event, but rather wait it out right here.
+    const std::vector<int> dummy(size / sizeof(int) + 1, value);
+    details::get_queue(m_data->m_queue)
+        .memcpy(ptr, dummy.data(), size)
+        .wait_and_throw();
+#endif  // VECMEM_HAVE_SYCL_MEMSET
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(2, "Set %lu bytes to %i at %p with SYCL", size, value,
+                     ptr);
+}
+
+copy::event_type async_copy::create_event() {
+
+    // Construct an event object out of all of the events collected.
+    auto result = std::make_unique<::sycl_event>(m_data->m_events);
+    // Forget about the events in this object.
+    m_data->m_events.clear();
+    // Return the event object.
+    return result;
+}
+
+}  // namespace vecmem::sycl

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -20,6 +20,7 @@
 #include "vecmem/memory/sycl/device_memory_resource.hpp"
 #include "vecmem/memory/sycl/host_memory_resource.hpp"
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
+#include "vecmem/utils/sycl/async_copy.hpp"
 #include "vecmem/utils/sycl/copy.hpp"
 
 // GoogleTest include(s).
@@ -48,34 +49,35 @@ TEST_F(sycl_containers_test, shared_memory) {
     constants[1] = 3;
 
     // Perform a linear transformation using the vecmem vector helper types.
-    queue.submit([&constants, &inputvec, &outputvec](cl::sycl::handler& h) {
-        // Run the kernel.
-        h.parallel_for<class LinearTransform1>(
-            cl::sycl::range<1>(inputvec.size()),
-            [constants = vecmem::get_data(constants),
-             input = vecmem::get_data(inputvec),
-             output = vecmem::get_data(outputvec)](cl::sycl::id<1> id) {
-                // Skip invalid indices.
-                const std::size_t i = id[0];
-                if (i >= input.size()) {
+    queue
+        .submit([&constants, &inputvec, &outputvec](cl::sycl::handler& h) {
+            // Run the kernel.
+            h.parallel_for<class LinearTransform1>(
+                cl::sycl::range<1>(inputvec.size()),
+                [constants = vecmem::get_data(constants),
+                 input = vecmem::get_data(inputvec),
+                 output = vecmem::get_data(outputvec)](cl::sycl::id<1> id) {
+                    // Skip invalid indices.
+                    const std::size_t i = id[0];
+                    if (i >= input.size()) {
+                        return;
+                    }
+
+                    // Create the helper containers.
+                    const vecmem::const_device_array<int, 2> constantarray1(
+                        constants);
+                    const vecmem::static_array<int, 2> constantarray2 = {
+                        constantarray1[0], constantarray1[1]};
+                    const vecmem::const_device_vector<int> inputvec(input);
+                    vecmem::device_vector<int> outputvec(output);
+
+                    // Perform the linear transformation.
+                    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) +
+                                      vecmem::get<1>(constantarray2);
                     return;
-                }
-
-                // Create the helper containers.
-                const vecmem::const_device_array<int, 2> constantarray1(
-                    constants);
-                const vecmem::static_array<int, 2> constantarray2 = {
-                    constantarray1[0], constantarray1[1]};
-                const vecmem::const_device_vector<int> inputvec(input);
-                vecmem::device_vector<int> outputvec(output);
-
-                // Perform the linear transformation.
-                outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) +
-                                  vecmem::get<1>(constantarray2);
-                return;
-            });
-    });
-    queue.wait_and_throw();
+                });
+        })
+        .wait_and_throw();
 
     // Check the output.
     EXPECT_EQ(inputvec.size(), outputvec.size());
@@ -96,7 +98,7 @@ TEST_F(sycl_containers_test, device_memory) {
     vecmem::sycl::device_memory_resource device_resource(&queue);
 
     // Helper object for performing memory copies.
-    vecmem::sycl::copy copy(&queue);
+    vecmem::sycl::async_copy copy(&queue);
 
     // Create an input and an output vector in host memory.
     vecmem::vector<int> inputvec({1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
@@ -108,6 +110,7 @@ TEST_F(sycl_containers_test, device_memory) {
     auto outputvechost = vecmem::get_data(outputvec);
     vecmem::data::vector_buffer<int> outputvecdevice(outputvec.size(),
                                                      device_resource);
+    copy.setup(outputvecdevice)->wait();
 
     // Create the array that is used in the linear transformation.
     vecmem::array<int, 2> constants(host_resource);
@@ -121,34 +124,39 @@ TEST_F(sycl_containers_test, device_memory) {
     auto input_data = copy.to(vecmem::get_data(inputvec), device_resource);
 
     // Perform a linear transformation using the vecmem vector helper types.
-    queue.submit([&const_data, &input_data,
-                  &outputvecdevice](cl::sycl::handler& h) {
-        // Run the kernel.
-        h.parallel_for<class LinearTransform2>(
-            cl::sycl::range<1>(input_data.size()),
-            [constants = vecmem::get_data(const_data),
-             input = vecmem::get_data(input_data),
-             output = vecmem::get_data(outputvecdevice)](cl::sycl::id<1> id) {
-                // Skip invalid indices.
-                const std::size_t i = id[0];
-                if (i >= input.size()) {
+    queue
+        .submit([&const_data, &input_data,
+                 &outputvecdevice](cl::sycl::handler& h) {
+            // Run the kernel.
+            h.parallel_for<class LinearTransform2>(
+                cl::sycl::range<1>(input_data.size()),
+                [constants = vecmem::get_data(const_data),
+                 input = vecmem::get_data(input_data),
+                 output =
+                     vecmem::get_data(outputvecdevice)](cl::sycl::id<1> id) {
+                    // Skip invalid indices.
+                    const std::size_t i = id[0];
+                    if (i >= input.size()) {
+                        return;
+                    }
+
+                    // Create the helper containers.
+                    const vecmem::const_device_array<int, 2> constantarray(
+                        constants);
+                    const vecmem::const_device_vector<int> inputvec(input);
+                    vecmem::device_vector<int> outputvec(output);
+
+                    // Perform the linear transformation.
+                    outputvec.at(i) = inputvec.at(i) * constantarray.at(0) +
+                                      constantarray.at(1);
                     return;
-                }
+                });
+        })
+        .wait_and_throw();
 
-                // Create the helper containers.
-                const vecmem::const_device_array<int, 2> constantarray(
-                    constants);
-                const vecmem::const_device_vector<int> inputvec(input);
-                vecmem::device_vector<int> outputvec(output);
-
-                // Perform the linear transformation.
-                outputvec.at(i) =
-                    inputvec.at(i) * constantarray.at(0) + constantarray.at(1);
-                return;
-            });
-    });
-    queue.wait_and_throw();
-    copy(outputvecdevice, outputvechost);
+    // Copy the data back to the host, and explicitly wait for the copy
+    // operation to finish.
+    copy(outputvecdevice, outputvechost)->wait();
 
     // Check the output.
     EXPECT_EQ(inputvec.size(), outputvec.size());
@@ -174,36 +182,38 @@ TEST_F(sycl_containers_test, atomic_memory) {
     static constexpr int ITERATIONS = 100;
 
     // Do very basic atomic modifications on the buffer.
-    queue.submit([&buffer](cl::sycl::handler& h) {
-        h.parallel_for<class AtomicTests>(
-            cl::sycl::range<1>(buffer.size() * ITERATIONS),
-            [buffer = vecmem::get_data(buffer)](cl::sycl::item<1> id) {
-                // Check if anything needs to be done.
-                const std::size_t i = id[0];
-                if (i >= buffer.size() * ITERATIONS) {
-                    return;
-                }
+    queue
+        .submit([&buffer](cl::sycl::handler& h) {
+            h.parallel_for<class AtomicTests>(
+                cl::sycl::range<1>(buffer.size() * ITERATIONS),
+                [buffer = vecmem::get_data(buffer)](cl::sycl::item<1> id) {
+                    // Check if anything needs to be done.
+                    const std::size_t i = id[0];
+                    if (i >= buffer.size() * ITERATIONS) {
+                        return;
+                    }
 
-                // Index/pointer to modify.
-                const std::size_t index = i % buffer.size();
-                int* ptr = buffer.ptr() + index;
+                    // Index/pointer to modify.
+                    const std::size_t index = i % buffer.size();
+                    int* ptr = buffer.ptr() + index;
 
-                // Do some simple stuff with it using vecmem::atomic.
-                vecmem::atomic<int> a(ptr);
-                a.fetch_add(4);
-                a.fetch_sub(2);
-                a.fetch_and(0xffffffff);
-                a.fetch_or(0x00000000);
+                    // Do some simple stuff with it using vecmem::atomic.
+                    vecmem::atomic<int> a(ptr);
+                    a.fetch_add(4);
+                    a.fetch_sub(2);
+                    a.fetch_and(0xffffffff);
+                    a.fetch_or(0x00000000);
 
-                // Do the same simple stuff with it using vecmem::atomic_ref.
-                vecmem::device_atomic_ref<int> a2(*ptr);
-                a2.fetch_add(4);
-                a2.fetch_sub(2);
-                a2.fetch_and(0xffffffff);
-                a2.fetch_or(0x00000000);
-            });
-    });
-    queue.wait_and_throw();
+                    // Do the same simple stuff with it using
+                    // vecmem::atomic_ref.
+                    vecmem::device_atomic_ref<int> a2(*ptr);
+                    a2.fetch_add(4);
+                    a2.fetch_sub(2);
+                    a2.fetch_and(0xffffffff);
+                    a2.fetch_or(0x00000000);
+                });
+        })
+        .wait_and_throw();
 
     // Check the output.
     for (int value : buffer) {
@@ -237,29 +247,31 @@ TEST_F(sycl_containers_test, extendable_memory) {
     copy.setup(output_buffer);
 
     // Run a kernel that filters the elements of the input vector.
-    queue.submit([&input, &output_buffer](cl::sycl::handler& h) {
-        h.parallel_for<class FilterTests>(
-            cl::sycl::range<1>(input.size()),
-            [input = vecmem::get_data(input),
-             output = vecmem::get_data(output_buffer)](cl::sycl::item<1> id) {
-                // Check if anything needs to be done.
-                const std::size_t i = id[0];
-                if (i >= input.size()) {
-                    return;
-                }
+    queue
+        .submit([&input, &output_buffer](cl::sycl::handler& h) {
+            h.parallel_for<class FilterTests>(
+                cl::sycl::range<1>(input.size()),
+                [input = vecmem::get_data(input),
+                 output =
+                     vecmem::get_data(output_buffer)](cl::sycl::item<1> id) {
+                    // Check if anything needs to be done.
+                    const std::size_t i = id[0];
+                    if (i >= input.size()) {
+                        return;
+                    }
 
-                // Set up the vector objects.
-                const vecmem::const_device_vector<int> inputvec(input);
-                vecmem::device_vector<int> outputvec(output);
+                    // Set up the vector objects.
+                    const vecmem::const_device_vector<int> inputvec(input);
+                    vecmem::device_vector<int> outputvec(output);
 
-                // Add this thread's element, if it passes the selection.
-                const int element = inputvec.at(i);
-                if (element > 10) {
-                    outputvec.push_back(element);
-                }
-            });
-    });
-    queue.wait_and_throw();
+                    // Add this thread's element, if it passes the selection.
+                    const int element = inputvec.at(i);
+                    if (element > 10) {
+                        outputvec.push_back(element);
+                    }
+                });
+        })
+        .wait_and_throw();
 
     // Copy the output into the host's memory.
     vecmem::vector<int> output(&host_resource);

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -20,6 +20,7 @@
 #include "vecmem/memory/sycl/device_memory_resource.hpp"
 #include "vecmem/memory/sycl/host_memory_resource.hpp"
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
+#include "vecmem/utils/sycl/async_copy.hpp"
 #include "vecmem/utils/sycl/copy.hpp"
 
 // GoogleTest include(s).
@@ -300,7 +301,7 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
 TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
 
     // Helper object for performing memory copies.
-    vecmem::sycl::copy copy(&m_queue);
+    vecmem::sycl::async_copy copy(&m_queue);
 
     // Make the input data contiguous in memory.
     vecmem::sycl::host_memory_resource host_resource(&m_queue);
@@ -322,7 +323,7 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
     vecmem::sycl::device_memory_resource device_resource(&m_queue);
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         output_data_host, device_resource, &m_mem);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Run the linear transformation.
     m_queue
@@ -349,7 +350,8 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
 
     // Copy the data back to the host.
     copy(output_data_device, output_data_host,
-         vecmem::copy::type::device_to_host);
+         vecmem::copy::type::device_to_host)
+        ->wait();
 
     // Check the results.
     EXPECT_EQ(output[0][0], 214);
@@ -374,13 +376,13 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
 TEST_F(sycl_jagged_containers_test, filter) {
 
     // Helper object for performing memory copies.
-    vecmem::sycl::copy copy(&m_queue);
+    vecmem::sycl::async_copy copy(&m_queue);
 
     // Create the output data on the device.
     vecmem::sycl::device_memory_resource device_resource(&m_queue);
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         {0, 0, 0, 0, 0, 0}, {10, 10, 10, 10, 10, 10}, device_resource, &m_mem);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Create the view/data objects of the jagged vector outside of the
     // submission.
@@ -418,7 +420,7 @@ TEST_F(sycl_jagged_containers_test, filter) {
 
     // Copy the filtered output back into the host's memory.
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data_device, output);
+    copy(output_data_device, output)->wait();
 
     // Check the output. Note that the order of elements in the "inner vectors"
     // is not fixed. And for the single-element and empty vectors I just decided


### PR DESCRIPTION
As I mentioned at the last parallelization meeting, the current implementation we have for jagged vector copies does not allow for asynchronous copies. I had to re-think the code a bit to allow proper asynchronous operations in [traccc](https://github.com/acts-project/traccc).

First off I removed the "hidden" optimisation from the jagged vector copy operator. It will no longer create a "host buffer" itself to minimise the H<->D memory copies. Instead the users must do this explicitly themselves. Like:

```c++
vecmem::copy host_copy;
vecmem::cuda::host_memory_resource cuda_host_mr;
vecmem::cuda::copy cuda_copy;
vecmem::jagged_vector<Foo> host_vec = ...;
auto host_buffer = host_copy.to(vecmem::get_data(host_vec, cuda_host_mr);
vecmem::data::jagged_vector_buffer<Foo> device_buffer{...};
cuda_copy(host_buffer, device_buffer);
```

I agree, it seems like a fair amount of additional code. :frowning: We'll have to see how we could optimise things a bit more later on. But in such a setup it is possible to perform the H<->D copy asynchronously. (It is now up to the user to make sure that the copy source and target would be alive for long enough.)

And to test that, I updated `vecmem::copy` to now provide an "asynchronous interface". One that would be backwards compatible with the interface that we had already. So that clients that are not interested in asynchronous operations would be able to forego asynchronous operations.

Updated `vecmem::cuda::async_copy` and introduced `vecmem::sycl::async_copy` to implement this new asynchronous interface.

To test the asynchronous implementation a little, I also updated some of the SYCL unit tests to use `vecmem::sycl::async_copy` and include explicit  synchronisation points in the right places.

There are some things about this implementation that I'm still not crazy about, but I wanted to get some feedback on this style of code organisation finally.