### PR TITLE
Doxygen Documentation Generation, main branch (2023.01.17.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -59,3 +59,28 @@ endif()
 
 # Set up the packaging of the project.
 include( vecmem-packaging )
+
+# Set up Doxygen documentation creation for the project.
+find_package( Doxygen )
+if( DOXYGEN_FOUND )
+   set( DOXYGEN_JAVADOC_AUTOBRIEF TRUE )
+   set( DOXYGEN_USE_MDFILE_AS_MAINPAGE
+      "${CMAKE_CURRENT_SOURCE_DIR}/README.md" )
+   set( DOXYGEN_FULL_PATH_NAMES TRUE )
+   set( DOXYGEN_INLINE_INHERITED_MEMB TRUE )
+   set( DOXYGEN_INHERIT_DOCS TRUE )
+   set( DOXYGEN_EXTRACT_PRIV_VIRTUAL TRUE )
+   set( DOXYGEN_STRIP_FROM_PATH
+      "${CMAKE_CURRENT_SOURCE_DIR}" )
+   set( DOXYGEN_STRIP_FROM_INC_PATH
+      "${CMAKE_CURRENT_SOURCE_DIR}/core/include"
+      "${CMAKE_CURRENT_SOURCE_DIR}/cuda/include"
+      "${CMAKE_CURRENT_SOURCE_DIR}/hip/include"
+      "${CMAKE_CURRENT_SOURCE_DIR}/sycl/include" )
+   set( DOXYGEN_EXCLUDE
+      "${CMAKE_CURRENT_SOURCE_DIR}/tests"
+      "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks" )
+   doxygen_add_docs( vecmem_docs
+      "${CMAKE_CURRENT_SOURCE_DIR}"
+      COMMENT "Generating Doxygen pages" )
+endif()


### PR DESCRIPTION
Taught CMake how to build Doxygen HTML pages for the project. I used the `vecmem_docs` target name for it, so that it would not interfere with a parent project's similar target.

As I said on Mattermost, I'd like to be able to push the generated pages to https://acts-project.github.io/vecmem/. If we can find a way to make that happen...

Right now locally it generates the following, rather spartan looking pages.

![image](https://user-images.githubusercontent.com/30694331/212917650-ae0849e5-4a8f-4dce-9832-b9e7c2c3106f.png)
![image](https://user-images.githubusercontent.com/30694331/212917784-33905217-49c6-4c2c-a642-9201eebbcd97.png)
![image](https://user-images.githubusercontent.com/30694331/212917971-4be000af-513d-416a-a558-dda5b3849c0e.png)

But with a bit of extra work these could be improved upon later on...