### PR TITLE
GitHub Doxygen Pages, main branch (2023.01.17.)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,52 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2023 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Name for this "action".
+name: GitHub Pages
+
+# Perform the deployment on every push to the main branch, or
+# on explicit requests.
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment.
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Job building and deploying the Doxygen documentation for the project
+  # to GitHub Pages.
+  build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Build Doxygen
+        run: |
+          sudo apt-get install -y cmake doxygen
+          cmake -S ${{ github.workspace }} -B build
+          cmake --build build --target vecmem_docs
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'build/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ if( DOXYGEN_FOUND )
       "${CMAKE_CURRENT_SOURCE_DIR}/sycl/include" )
    set( DOXYGEN_EXCLUDE
       "${CMAKE_CURRENT_SOURCE_DIR}/tests"
-      "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks" )
+      "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks"
+      "${CMAKE_CURRENT_SOURCE_DIR}/build" )
    doxygen_add_docs( vecmem_docs
       "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Generating Doxygen pages" )


### PR DESCRIPTION
Added an action for deploying [Doxygen](https://doxygen.nl/) documentation for the project under: https://acts-project.github.io/vecmem/.

That page was already created while experimenting with this branch, so everyone can have a look already. :smile: