### PR TITLE
Doxygen Namespace Fixes, main branch (2023.01.17.)

### DIFF
--- a/benchmarks/core/benchmark_core.cpp
+++ b/benchmarks/core/benchmark_core.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/benchmarks/cuda/benchmark_cuda.cpp
+++ b/benchmarks/cuda/benchmark_cuda.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/benchmarks/sycl/benchmark_sycl.cpp
+++ b/benchmarks/sycl/benchmark_sycl.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/core/cmake/atomic_ref_test.sycl
+++ b/core/cmake/atomic_ref_test.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2022 CERN for the benefit of the ACTS project
  *

--- a/core/cmake/ext_oneapi_printf_test.sycl
+++ b/core/cmake/ext_oneapi_printf_test.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/cmake/oneapi_printf_test.sycl
+++ b/core/cmake/oneapi_printf_test.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/const_device_array.hpp
+++ b/core/include/vecmem/containers/const_device_array.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/const_device_vector.hpp
+++ b/core/include/vecmem/containers/const_device_vector.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -15,6 +15,13 @@
 #include <type_traits>
 
 namespace vecmem {
+
+/// @brief Namespace holding "data types"
+///
+/// These are types that either own, or only provide a view of data owned by
+/// some other component. They are used for "non-interactive" data management
+/// in the code.
+///
 namespace data {
 
 /// Class holding data about a 1 dimensional vector/array

--- a/core/include/vecmem/containers/details/reverse_iterator.hpp
+++ b/core/include/vecmem/containers/details/reverse_iterator.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/details/static_array_traits.hpp
+++ b/core/include/vecmem/containers/details/static_array_traits.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/details/static_vector_traits.hpp
+++ b/core/include/vecmem/containers/details/static_vector_traits.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -10,6 +10,12 @@
 #include <cstddef>
 
 namespace vecmem {
+
+/// @brief Namespace for types that should not be used directly by clients
+///
+/// These would be classes/functions/types that are needed by the public
+/// interface of classes/functions outside of this namespace.
+///
 namespace details {
 
 /// Helper type for an array in a static_vector with a given type and size

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/array.ipp
+++ b/core/include/vecmem/containers/impl/array.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/device_array.ipp
+++ b/core/include/vecmem/containers/impl/device_array.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/reverse_iterator.ipp
+++ b/core/include/vecmem/containers/impl/reverse_iterator.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/static_array.ipp
+++ b/core/include/vecmem/containers/impl/static_array.ipp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/containers/impl/static_vector.ipp
+++ b/core/include/vecmem/containers/impl/static_vector.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/vector.ipp
+++ b/core/include/vecmem/containers/impl/vector.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/static_array.hpp
+++ b/core/include/vecmem/containers/static_array.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/containers/vector.hpp
+++ b/core/include/vecmem/containers/vector.hpp
@@ -1,6 +1,6 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,13 @@
 // System include(s).
 #include <vector>
 
+/// @brief Main namespace for the vecmem classes/functions
+///
+/// Public classes and functions that are not language/backend specific, are
+/// generally placed in this namespace.
+///
+/// @see @c vecmem::data
+///
 namespace vecmem {
 /**
  * @brief Alias type for vectors with our polymorphic allocator

--- a/core/include/vecmem/memory/binary_page_memory_resource.hpp
+++ b/core/include/vecmem/memory/binary_page_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/choice_memory_resource.hpp
+++ b/core/include/vecmem/memory/choice_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/coalescing_memory_resource.hpp
+++ b/core/include/vecmem/memory/coalescing_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/conditional_memory_resource.hpp
+++ b/core/include/vecmem/memory/conditional_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/contiguous_memory_resource.hpp
+++ b/core/include/vecmem/memory/contiguous_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/debug_memory_resource.hpp
+++ b/core/include/vecmem/memory/debug_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/details/is_aligned.hpp
+++ b/core/include/vecmem/memory/details/is_aligned.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2022 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/details/memory_resource_base.hpp
+++ b/core/include/vecmem/memory/details/memory_resource_base.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/memory/host_memory_resource.hpp
+++ b/core/include/vecmem/memory/host_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/identity_memory_resource.hpp
+++ b/core/include/vecmem/memory/identity_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/instrumenting_memory_resource.hpp
+++ b/core/include/vecmem/memory/instrumenting_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/memory/memory_resource.hpp
+++ b/core/include/vecmem/memory/memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/memory/polymorphic_allocator.hpp
+++ b/core/include/vecmem/memory/polymorphic_allocator.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/memory/terminal_memory_resource.hpp
+++ b/core/include/vecmem/memory/terminal_memory_resource.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/utils/memory_monitor.hpp
+++ b/core/include/vecmem/utils/memory_monitor.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/include/vecmem/utils/types.hpp
+++ b/core/include/vecmem/utils/types.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/src/memory/binary_page_memory_resource.cpp
+++ b/core/src/memory/binary_page_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/binary_page_memory_resource_impl.cpp
+++ b/core/src/memory/binary_page_memory_resource_impl.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project

--- a/core/src/memory/binary_page_memory_resource_impl.hpp
+++ b/core/src/memory/binary_page_memory_resource_impl.hpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/choice_memory_resource.cpp
+++ b/core/src/memory/choice_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/coalescing_memory_resource.cpp
+++ b/core/src/memory/coalescing_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/conditional_memory_resource.cpp
+++ b/core/src/memory/conditional_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/contiguous_memory_resource.cpp
+++ b/core/src/memory/contiguous_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/debug_memory_resource.cpp
+++ b/core/src/memory/debug_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/default_resource_polyfill.cpp
+++ b/core/src/memory/default_resource_polyfill.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/src/memory/details/is_aligned.cpp
+++ b/core/src/memory/details/is_aligned.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2022 CERN for the benefit of the ACTS project

--- a/core/src/memory/details/memory_resource_base.cpp
+++ b/core/src/memory/details/memory_resource_base.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/core/src/memory/host_memory_resource.cpp
+++ b/core/src/memory/host_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project

--- a/core/src/memory/identity_memory_resource.cpp
+++ b/core/src/memory/identity_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/instrumenting_memory_resource.cpp
+++ b/core/src/memory/instrumenting_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/memory/terminal_memory_resource.cpp
+++ b/core/src/memory/terminal_memory_resource.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/core/src/utils/memory_monitor.cpp
+++ b/core/src/utils/memory_monitor.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
+++ b/cuda/include/vecmem/memory/cuda/device_memory_resource.hpp
@@ -12,6 +12,7 @@
 #include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_cuda_export.hpp"
 
+/// @brief Namespace holding types that work on/with CUDA
 namespace vecmem::cuda {
 
 /**

--- a/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
+++ b/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -16,7 +16,7 @@
 namespace vecmem {
 namespace cuda {
 
-// Forward declaration(s).
+/// @brief Namespace for types that should not be used directly by clients
 namespace details {
 class opaque_stream;
 }

--- a/cuda/src/utils/cuda_error_handling.cpp
+++ b/cuda/src/utils/cuda_error_handling.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/cuda/src/utils/cuda_error_handling.hpp
+++ b/cuda/src/utils/cuda_error_handling.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/cuda/src/utils/opaque_stream.cpp
+++ b/cuda/src/utils/opaque_stream.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/cuda/src/utils/opaque_stream.hpp
+++ b/cuda/src/utils/opaque_stream.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/cuda/src/utils/stream_wrapper.cpp
+++ b/cuda/src/utils/stream_wrapper.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -10,6 +10,7 @@
 #include "vecmem/memory/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_hip_export.hpp"
 
+/// @brief Namespace holding types that work on/with ROCm/HIP
 namespace vecmem::hip {
 
 /// Memory resource for a specific HIP device

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/hip/src/memory/hip/device_memory_resource.cpp
+++ b/hip/src/memory/hip/device_memory_resource.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/hip/src/memory/hip/host_memory_resource.cpp
+++ b/hip/src/memory/hip/host_memory_resource.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/hip/src/utils/get_device.cpp
+++ b/hip/src/utils/get_device.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -13,6 +13,7 @@
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
 
+/// @brief Namespace for types that should not be used directly by clients
 namespace vecmem::hip::details {
 
 int get_device() {

--- a/hip/src/utils/get_device.hpp
+++ b/hip/src/utils/get_device.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/hip/src/utils/hip_error_handling.cpp
+++ b/hip/src/utils/hip_error_handling.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/hip/src/utils/hip_error_handling.hpp
+++ b/hip/src/utils/hip_error_handling.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/hip/src/utils/run_on_device.hpp
+++ b/hip/src/utils/run_on_device.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/hip/src/utils/select_device.hpp
+++ b/hip/src/utils/select_device.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/cmake/assert_test.sycl
+++ b/sycl/cmake/assert_test.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/cmake/memset_test.sycl
+++ b/sycl/cmake/memset_test.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *
@@ -11,6 +11,7 @@
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
+/// @brief Namespace for types that should not be used directly by clients
 namespace vecmem::sycl::details {
 
 /// SYCL memory resource base class

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *
@@ -10,6 +10,7 @@
 #include "vecmem/memory/sycl/details/memory_resource_base.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
+/// @brief Namespace holding types that work on/with oneAPI/SYCL
 namespace vecmem::sycl {
 
 /// Memory resource for a specific SYCL device

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/memory/sycl/details/memory_resource_base.sycl
+++ b/sycl/src/memory/sycl/details/memory_resource_base.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/memory/sycl/device_memory_resource.sycl
+++ b/sycl/src/memory/sycl/device_memory_resource.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/memory/sycl/host_memory_resource.sycl
+++ b/sycl/src/memory/sycl/host_memory_resource.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/memory/sycl/shared_memory_resource.sycl
+++ b/sycl/src/memory/sycl/shared_memory_resource.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
+++ b/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/utils/sycl/get_queue.hpp
+++ b/sycl/src/utils/sycl/get_queue.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/utils/sycl/get_queue.sycl
+++ b/sycl/src/utils/sycl/get_queue.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/utils/sycl/opaque_queue.hpp
+++ b/sycl/src/utils/sycl/opaque_queue.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/sycl/src/utils/sycl/queue_wrapper.sycl
+++ b/sycl/src/utils/sycl/queue_wrapper.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/common/memory_resource_name_gen.cpp
+++ b/tests/common/memory_resource_name_gen.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/common/memory_resource_name_gen.hpp
+++ b/tests/common/memory_resource_name_gen.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_array.cpp
+++ b/tests/core/test_core_array.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_contiguous_memory_resource.cpp
+++ b/tests/core/test_core_contiguous_memory_resource.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_default_resource.cpp
+++ b/tests/core/test_core_default_resource.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_static_array.cpp
+++ b/tests/core/test_core_static_array.cpp
@@ -1,4 +1,4 @@
-/**
+/*
  * VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/core/test_core_vector.cpp
+++ b/tests/core/test_core_vector.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_containers.cu
+++ b/tests/cuda/test_cuda_containers.cu
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2022 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_jagged_vector_view.cu
+++ b/tests/cuda/test_cuda_jagged_vector_view.cu
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2022 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_memory_resources.cpp
+++ b/tests/cuda/test_cuda_memory_resources.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/cuda/test_cuda_memory_resources.cu
+++ b/tests/cuda/test_cuda_memory_resources.cu
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/hip/test_hip_containers_kernels.hpp
+++ b/tests/hip/test_hip_containers_kernels.hpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/hip/test_hip_memory_resources.cpp
+++ b/tests/hip/test_hip_memory_resources.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021-2022 CERN for the benefit of the ACTS project
  *

--- a/tests/sycl/test_sycl_memory_resources.cpp
+++ b/tests/sycl/test_sycl_memory_resources.cpp
@@ -1,4 +1,4 @@
-/** VecMem project, part of the ACTS project (R&D line)
+/* VecMem project, part of the ACTS project (R&D line)
  *
  * (c) 2021 CERN for the benefit of the ACTS project
  *


### PR DESCRIPTION
Fixed the Doxygen documentation for all used namespaces.

Had to remove the `/**` formalism from the file headers, as these were confusing Doxygen. :frowning:  Making it think that those blocks were documenting the first thing (usually a namespace) defined in the file.

At the same time added explicit documentation for all of the namespaces used in the project.