### PR TITLE
Atomic Test Improvements, main branch (2023.02.02.)

### DIFF
--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -145,8 +145,27 @@ TEST_F(cuda_containers_test, async_memory) {
     }
 }
 
-/// Test the execution of atomic operations as part of a kernel
-TEST_F(cuda_containers_test, atomic_memory) {
+/// Test the execution of atomic operations in managed memory
+TEST_F(cuda_containers_test, atomic_managed_memory) {
+
+    // The memory resource(s).
+    vecmem::cuda::managed_memory_resource resource;
+
+    // Create a small vector in managed memory.
+    vecmem::vector<int> vec(100, 0, &resource);
+
+    // Give it to the test function.
+    static constexpr unsigned int ITERATIONS = 100;
+    atomicTransform(ITERATIONS, vecmem::get_data(vec));
+
+    // Check the output.
+    for (int value : vec) {
+        EXPECT_EQ(static_cast<unsigned int>(value), 4 * ITERATIONS);
+    }
+}
+
+/// Test the execution of atomic operations in device memory
+TEST_F(cuda_containers_test, atomic_device_memory) {
 
     // The memory resources.
     vecmem::cuda::host_memory_resource host_resource;

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -92,8 +92,27 @@ TEST_F(hip_containers_test, device_memory) {
     }
 }
 
-/// Test the execution of atomic operations as part of a kernel
-TEST_F(hip_containers_test, atomic_memory) {
+/// Test the execution of atomic operations in host/shared memory
+TEST_F(hip_containers_test, atomic_shared_memory) {
+
+    // The memory resource(s).
+    vecmem::hip::host_memory_resource resource;
+
+    // Create a small vector in host/managed memory.
+    vecmem::vector<int> vec(100, 0, &resource);
+
+    // Give it to the test function.
+    static constexpr unsigned int ITERATIONS = 100;
+    atomicTransform(ITERATIONS, vecmem::get_data(vec));
+
+    // Check the output.
+    for (int value : vec) {
+        EXPECT_EQ(static_cast<unsigned int>(value), 4 * ITERATIONS);
+    }
+}
+
+/// Test the execution of atomic operations in device memory
+TEST_F(hip_containers_test, atomic_device_memory) {
 
     // The host/device memory resources.
     vecmem::hip::host_memory_resource host_resource;

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -172,8 +172,8 @@ TEST_F(sycl_containers_test, device_memory) {
     }
 }
 
-/// Test atomic access in a simple kernel
-TEST_F(sycl_containers_test, atomic_memory) {
+/// Test atomic access to shared memory
+TEST_F(sycl_containers_test, atomic_shared_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
     cl::sycl::queue queue;
@@ -190,7 +190,7 @@ TEST_F(sycl_containers_test, atomic_memory) {
     // Do very basic atomic modifications on the buffer.
     queue
         .submit([&buffer](cl::sycl::handler& h) {
-            h.parallel_for<class AtomicTests>(
+            h.parallel_for<class AtomicSharedTests>(
                 cl::sycl::range<1>(buffer.size() * ITERATIONS),
                 [buffer = vecmem::get_data(buffer)](cl::sycl::item<1> id) {
                     // Check if anything needs to be done.
@@ -223,6 +223,73 @@ TEST_F(sycl_containers_test, atomic_memory) {
 
     // Check the output.
     for (int value : buffer) {
+        EXPECT_EQ(value, ITERATIONS * 4);
+    }
+}
+
+/// Test atomic access to device memory
+TEST_F(sycl_containers_test, atomic_device_memory) {
+
+    // Create the SYCL queue that we'll be using in the test.
+    cl::sycl::queue queue;
+
+    // The memory resources.
+    vecmem::sycl::host_memory_resource host_resource(&queue);
+    vecmem::sycl::device_memory_resource device_resource(&queue);
+
+    // Helper object for performing memory copies.
+    vecmem::sycl::async_copy copy(&queue);
+
+    // Allocate memory on the host, and set initial values in it.
+    vecmem::vector<int> host_vector(100, 0, &host_resource);
+
+    // Set up a device buffer with the data.
+    auto device_buffer =
+        copy.to(vecmem::get_data(host_vector), device_resource);
+
+    // Number of iterations performed on a single buffer element.
+    static constexpr int ITERATIONS = 100;
+
+    // Do very basic atomic modifications on the buffer.
+    queue
+        .submit([&device_buffer](cl::sycl::handler& h) {
+            h.parallel_for<class AtomicDeviceTests>(
+                cl::sycl::range<1>(device_buffer.size() * ITERATIONS),
+                [buffer =
+                     vecmem::get_data(device_buffer)](cl::sycl::item<1> id) {
+                    // Check if anything needs to be done.
+                    const std::size_t i = id[0];
+                    if (i >= buffer.size() * ITERATIONS) {
+                        return;
+                    }
+
+                    // Index/pointer to modify.
+                    const std::size_t index = i % buffer.size();
+                    int* ptr = buffer.ptr() + index;
+
+                    // Do some simple stuff with it using vecmem::atomic.
+                    vecmem::atomic<int> a(ptr);
+                    a.fetch_add(4);
+                    a.fetch_sub(2);
+                    a.fetch_and(0xffffffff);
+                    a.fetch_or(0x00000000);
+
+                    // Do the same simple stuff with it using
+                    // vecmem::atomic_ref.
+                    vecmem::device_atomic_ref<int> a2(*ptr);
+                    a2.fetch_add(4);
+                    a2.fetch_sub(2);
+                    a2.fetch_and(0xffffffff);
+                    a2.fetch_or(0x00000000);
+                });
+        })
+        .wait_and_throw();
+
+    // Copy the data back to the host.
+    copy(device_buffer, vecmem::get_data(host_vector))->wait();
+
+    // Check the output.
+    for (int value : host_vector) {
         EXPECT_EQ(value, ITERATIONS * 4);
     }
 }


### PR DESCRIPTION
Switched to separately testing atomic operations in device and managed/shared memory.

This is because of https://github.com/intel/llvm/issues/7252, which identified certain atomic operations not working with the HIP backend of Intel's LLVM compiler. But only when using shared memory.

This also gave me an opportunity to harmonize the tests between our 3 language backends. Because while the SYCL tests were only using shared memory so far, the CUDA and HIP tests were only using device memory. Now they all test both.