### PR TITLE
Warning Fixes, main branch (2023.02.02.)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -22,6 +22,9 @@ if(VECMEM_SETUP_GOOGLEBENCHMARK)
       add_subdirectory(googlebenchmark)
    endif()
 endif()
+
+# Project include(s).
+include( vecmem-compiler-options-cpp )
 
 # Build a common, helper library.
 add_library( vecmem_benchmark_common STATIC

--- a/benchmarks/common/make_jagged_sizes.cpp
+++ b/benchmarks/common/make_jagged_sizes.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,7 +20,8 @@ std::vector<std::size_t> make_jagged_sizes(std::size_t outerSize,
 
     // Set up a simple random number generator for the inner vector sizes.
     std::default_random_engine eng;
-    eng.seed(outerSize + maxInnerSize);
+    eng.seed(static_cast<std::default_random_engine::result_type>(
+        outerSize + maxInnerSize));
     std::uniform_int_distribution<std::size_t> gen(0, maxInnerSize);
 
     // Generate the result vector.

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,9 +26,9 @@ namespace {
 
 /// "Complex" type used in the bulk of the tests
 struct TestType1 {
-    TestType1(int a = 0, long b = 123) : m_a(a), m_b(b) {}
+    TestType1(int a = 0, long b = 123l) : m_a(a), m_b(b) {}
     int m_a;
-    int m_b;
+    long m_b;
 };  // struct TestType1
 
 /// Helper operator for comparing two @c TestType1 objects

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -58,7 +58,9 @@ TEST_F(sycl_containers_test, shared_memory) {
                  input = vecmem::get_data(inputvec),
                  output = vecmem::get_data(outputvec)](cl::sycl::id<1> id) {
                     // Skip invalid indices.
-                    const std::size_t i = id[0];
+                    const vecmem::device_vector<int>::size_type i =
+                        static_cast<vecmem::device_vector<int>::size_type>(
+                            id[0]);
                     if (i >= input.size()) {
                         return;
                     }
@@ -108,8 +110,10 @@ TEST_F(sycl_containers_test, device_memory) {
 
     // Allocate a device memory block for the output container.
     auto outputvechost = vecmem::get_data(outputvec);
-    vecmem::data::vector_buffer<int> outputvecdevice(outputvec.size(),
-                                                     device_resource);
+    vecmem::data::vector_buffer<int> outputvecdevice(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(
+            outputvec.size()),
+        device_resource);
     copy.setup(outputvecdevice)->wait();
 
     // Create the array that is used in the linear transformation.
@@ -135,7 +139,9 @@ TEST_F(sycl_containers_test, device_memory) {
                  output =
                      vecmem::get_data(outputvecdevice)](cl::sycl::id<1> id) {
                     // Skip invalid indices.
-                    const std::size_t i = id[0];
+                    const vecmem::device_vector<int>::size_type i =
+                        static_cast<vecmem::device_vector<int>::size_type>(
+                            id[0]);
                     if (i >= input.size()) {
                         return;
                     }
@@ -242,8 +248,9 @@ TEST_F(sycl_containers_test, extendable_memory) {
     }
 
     // Create a buffer that will hold the filtered elements of the input vector.
-    vecmem::data::vector_buffer<int> output_buffer(input.size(), 0,
-                                                   device_resource);
+    vecmem::data::vector_buffer<int> output_buffer(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
+        0, device_resource);
     copy.setup(output_buffer);
 
     // Run a kernel that filters the elements of the input vector.
@@ -255,7 +262,9 @@ TEST_F(sycl_containers_test, extendable_memory) {
                  output =
                      vecmem::get_data(output_buffer)](cl::sycl::item<1> id) {
                     // Check if anything needs to be done.
-                    const std::size_t i = id[0];
+                    const vecmem::device_vector<int>::size_type i =
+                        static_cast<vecmem::device_vector<int>::size_type>(
+                            id[0]);
                     if (i >= input.size()) {
                         return;
                     }
@@ -325,7 +334,10 @@ TEST_F(sycl_containers_test, array_memory) {
                         data[0], data[1], data[2], data[3]};
 
                     // Perform the transformation.
-                    vec[id[0]][id[1]] *= 2;
+                    vec[static_cast<vecmem::static_array<
+                        vecmem::device_vector<int>, 4>::size_type>(id[0])]
+                       [static_cast<vecmem::device_vector<int>::size_type>(
+                           id[1])] *= 2;
                 });
         })
         .wait_and_throw();

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -93,7 +93,8 @@ public:
 
         // Perform the requested linear transformation on all elements of a
         // given "internal vector".
-        for (std::size_t j = 0; j < input[i].size(); ++j) {
+        for (vecmem::device_vector<const int>::size_type j = 0;
+             j < input[i].size(); ++j) {
             output[i][j] = input[i][j] * constants[0] + constants[1];
         }
     }
@@ -410,7 +411,10 @@ TEST_F(sycl_jagged_containers_test, filter) {
                     vecmem::jagged_device_vector<int> outputvec(output);
 
                     // Keep just the odd elements.
-                    const int value = inputvec[id[0]][id[1]];
+                    const int value = inputvec[static_cast<
+                        vecmem::jagged_device_vector<const int>::size_type>(
+                        id[0])][static_cast<vecmem::device_vector<const int>::
+                                                size_type>(id[1])];
                     if ((value % 2) != 0) {
                         outputvec.at(id[0]).push_back(value);
                     }


### PR DESCRIPTION
Silenced the 64->32 bit value conversion warnings. These are triggered in Clang by `-Wshorten-64-to-32`, which is a default in the latest AppleClang versions. Which is now used in the GitHub CI.