### PR TITLE
oneAPI 2023.0.0 Windows Fix, main branch (2023.02.22.)

### DIFF
--- a/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
+++ b/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -26,6 +26,7 @@ if( NOT "$ENV{SYCLCXX}" STREQUAL "" )
    # Determine the type and version of the SYCL compiler.
    execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}" "--version"
       OUTPUT_VARIABLE _syclVersionOutput
+      ERROR_VARIABLE _syclVersionError
       RESULT_VARIABLE _syclVersionResult )
    if( NOT ${_syclVersionResult} EQUAL 0 )
       execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}"

--- a/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,12 +15,17 @@ __windows_compiler_intel( SYCL )
 string( REPLACE "<SOURCE>" "/Tp <SOURCE>" CMAKE_SYCL_COMPILE_OBJECT
    "${CMAKE_SYCL_COMPILE_OBJECT}" )
 
+# Use the (basic) flags set up for compilation, during linking as well.
+set( CMAKE_SYCL_LINK_FLAGS "${CMAKE_SYCL_FLAGS}" )
+
 # Tweak the linker commands to use the DPC++ executable for linking, and to
 # pass the arguments to the linker correctly.
 foreach( linker_command "CMAKE_SYCL_CREATE_SHARED_LIBRARY"
    "CMAKE_SYCL_CREATE_SHARED_MODULE" "CMAKE_SYCL_LINK_EXECUTABLE" )
 
-   # Replace the VS linker with DPC++.
+   # Replace the VS linker with DPC++. (Note that this does not do
+   # anything with modern CMake versions anymore. As those use
+   # <CMAKE_SYCL_COMPILER> in the link command out of the box.)
    string( REPLACE "<CMAKE_LINKER>" "\"${CMAKE_SYCL_HOST_LINKER}\""
       ${linker_command} "${${linker_command}}" )
 


### PR DESCRIPTION
The `dpcpp(-cl)` executables have been deprecated by Intel some time ago in oneAPI. One is instead meant to use "`icpx -fsycl`" (on Linux) and "`icx-cl.exe -fsycl`" (on Windows).

This update makes sure that the "`-fsycl`" flag is correctly propagated to the link commands. Plus it also silences printout from "`icx-cl.exe --version`" that is sent to stderr by that command.

Some additional notes:
  - The way to set the `SYCLCXX` environment variable on Windows gave me some headaches. One is supposed to do the following:

```
set SYCLCXX=icx-cl -fsycl
```

Yes, without any type of quotes whatsoever! 😕

  - Just like on Linux, CUDA can't use oneAPI 2023.0.0 as a host compiler at the moment. So one should not set the `CC` or `CXX` (or `CUDAHOSTCXX`) environment variables to point at oneAPI 2023 if CUDA is also used in the project. (Only using oneAPI to build the `.sycl` source files, and MSVC for everything else, does allow for a successful linking of everything at least.)