### PR TITLE
Public Header Tests, main branch (2023.03.03.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project( vecmem VERSION 0.24.0 LANGUAGES CXX )
 
 # Standard CMake include(s).
 include( GNUInstallDirs )
+include( CTest )
 
 # Explicitly set the output directory for the binaries. Such that if this
 # project is included by another project, the main project's configuration would
@@ -25,7 +26,8 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
    "Directory for the built static libraries" )
 
 # Flags controlling the meta-build system.
-option( VECMEM_USE_SYSTEM_LIBS "Use system libraries be default" FALSE )
+option( VECMEM_USE_SYSTEM_LIBS "Use system libraries by default" FALSE )
+option( VECMEM_BUILD_TESTING "Build the unit tests of VecMem" TRUE )
 
 # Include the VecMem CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )
@@ -45,8 +47,6 @@ if( VECMEM_BUILD_SYCL_LIBRARY )
 endif()
 
 # Set up the test(s).
-option( VECMEM_BUILD_TESTING "Build the unit tests of VecMem" ON )
-include( CTest )
 if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
   add_subdirectory( tests )
 endif()

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -67,6 +67,44 @@ function( vecmem_add_library fullname basename )
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" )
 
 endfunction( vecmem_add_library )
+
+# Helper function testing the VecMem public headers.
+#
+# It can be used to test that public headers would include everything
+# that they need to work, and that the CMake library targets would take
+# care of declaring all of their dependencies correctly for the public
+# headers to work.
+#
+# Usage: vecmem_test_public_headers( vecmem_core include/header1.hpp ... )
+#
+function( vecmem_test_public_headers library )
+
+   # All arguments are treated as header file names.
+   foreach( _headerName ${ARGN} )
+
+      # Make the header filename into a "string".
+      string( REPLACE "/" "_" _headerNormName "${_headerName}" )
+      string( REPLACE "." "_" _headerNormName "${_headerNormName}" )
+
+      # Write a small source file that would test that the public
+      # header can be used as-is.
+      set( _testFileName
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/test_${_headerNormName}.cpp" )
+      file( WRITE "${_testFileName}"
+         "#include \"${_headerName}\"\n"
+         "int main() { return 0; }" )
+
+      # Set up an executable that would build it. But hide it, don't put it
+      # into ${CMAKE_BINARY_DIR}/bin.
+      add_executable( "test_${_headerNormName}" "${_testFileName}" )
+      target_link_libraries( "test_${_headerNormName}" PRIVATE ${library} )
+      set_target_properties( "test_${_headerNormName}" PROPERTIES
+         RUNTIME_OUTPUT_DIRECTORY
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}" )
+
+   endforeach()
+
+endfunction( vecmem_test_public_headers )
 
 # Helper function for setting up the VecMem tests.
 #

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -240,4 +240,12 @@ check_cxx_symbol_exists( "std::aligned_alloc" "cstdlib"
 if( VECMEM_HAVE_STD_ALIGNED_ALLOC )
    target_compile_definitions( vecmem_core
       PRIVATE VECMEM_HAVE_STD_ALIGNED_ALLOC )
+endif()
+
+# Test the public headers of vecmem::core.
+if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
+   file( GLOB_RECURSE vecmem_core_public_headers
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "include/*/*.hpp" )
+   vecmem_test_public_headers( vecmem_core ${vecmem_core_public_headers} )
 endif()

--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,7 @@
 #include "vecmem/utils/type_traits.hpp"
 
 // Standard library headers
+#include <algorithm>
 #include <tuple>
 #include <type_traits>
 

--- a/core/include/vecmem/memory/details/unique_obj_deleter.hpp
+++ b/core/include/vecmem/memory/details/unique_obj_deleter.hpp
@@ -1,13 +1,17 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+
+// System include(s).
 #include <cassert>
 #include <type_traits>
 

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -47,3 +47,11 @@ target_link_libraries( vecmem_cuda
 set_target_properties( vecmem_cuda PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden"
    CUDA_VISIBILITY_PRESET "hidden" )
+
+# Test the public headers of vecmem::cuda.
+if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
+   file( GLOB_RECURSE vecmem_cuda_public_headers
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "include/*/*.hpp" )
+   vecmem_test_public_headers( vecmem_cuda ${vecmem_cuda_public_headers} )
+endif()

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -39,3 +39,11 @@ target_link_libraries( vecmem_hip
 set_target_properties( vecmem_hip PROPERTIES
    CXX_VISIBILITY_PRESET "hidden"
    HIP_VISIBILITY_PRESET "hidden" )
+
+# Test the public headers of vecmem::hip.
+if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
+   file( GLOB_RECURSE vecmem_hip_public_headers
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "include/*/*.hpp" )
+   vecmem_test_public_headers( vecmem_hip ${vecmem_hip_public_headers} )
+endif()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -82,4 +82,12 @@ vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_MEMSET
    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/memset_test.sycl" )
 if( VECMEM_HAVE_SYCL_MEMSET )
    target_compile_definitions( vecmem_sycl PRIVATE VECMEM_HAVE_SYCL_MEMSET )
+endif()
+
+# Test the public headers of vecmem::sycl.
+if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
+   file( GLOB_RECURSE vecmem_sycl_public_headers
+      RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/include"
+      "include/*/*.hpp" )
+   vecmem_test_public_headers( vecmem_sycl ${vecmem_sycl_public_headers} )
 endif()


### PR DESCRIPTION
While working on https://github.com/acts-project/traccc/pull/328 I had to find the [Detray](https://github.com/acts-project/detray)'s headers are in a bit of a disrepair at the moment.. :frowning:

So I decided that we should put some rigorous tests into our projects that would make sure that at a very basic level the public headers of libraries would be possible to use "out of the box". Starting with this project. (And then I plan to open very similar PRs into all our other projects as well.)

Technically some of the headers that these tests pick up are not strictly "public headers". But in the end any header that's visible to the users should be possible to include by itself. (At least currently we don't have any shenanigans in this project that would prevent us from doing this.)

As you can see, the tests did find one missing include even in this project. :wink: