### PR TITLE
(Resizable) Vector Buffer Update, main branch (2023.03.17.)

### DIFF
--- a/core/include/vecmem/containers/data/buffer_type.hpp
+++ b/core/include/vecmem/containers/data/buffer_type.hpp
@@ -1,0 +1,21 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem {
+namespace data {
+
+/// @brief "Overall type" for a buffer object
+enum class buffer_type {
+
+    fixed_size = 0,  ///< The buffer has a fixed number of elements
+    resizable = 1    ///< The buffer is resizable/expandable
+
+};  // enum class buffer_type
+
+}  // namespace data
+}  // namespace vecmem

--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/containers/data/buffer_type.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/memory/unique_ptr.hpp"
@@ -64,47 +65,34 @@ public:
     ///        be host accessible.
     /// @param host_access_resource An optional host accessible memory
     ///        resource. Needed if @c resource is not host accessible.
+    /// @param type The type (resizable or not) of the buffer
+    ///
     template <typename OTHERTYPE,
               std::enable_if_t<std::is_convertible<TYPE, OTHERTYPE>::value,
                                bool> = true>
     jagged_vector_buffer(const jagged_vector_view<OTHERTYPE>& other,
                          memory_resource& resource,
-                         memory_resource* host_access_resource = nullptr);
+                         memory_resource* host_access_resource = nullptr,
+                         buffer_type type = buffer_type::fixed_size);
 
     /// Constructor from a vector of ("inner vector") sizes
     ///
-    /// @param sizes Simple vector holding the sizes of the "inner vectors"
-    ///        for the jagged vector buffer.
-    /// @param resource The device accessible memory resource, which may also
-    ///        be host accessible.
-    /// @param host_access_resource An optional host accessible memory
-    ///        resource. Needed if @c resource is not host accessible.
-    template <typename SIZE_TYPE = std::size_t,
-              std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
-                                   std::is_unsigned<SIZE_TYPE>::value,
-                               bool> = true>
-    jagged_vector_buffer(const std::vector<SIZE_TYPE>& sizes,
-                         memory_resource& resource,
-                         memory_resource* host_access_resource = nullptr);
-
-    /// Constructor from a vector of ("inner vector") sizes and capacities
-    ///
-    /// @param sizes Simple vector holding the sizes of the "inner vectors"
-    ///        for the jagged vector buffer.
-    /// @param capacities Simple vector holding the capacities of the
+    /// @param capacities Simple vector holding the capacities/sizes of the
     ///        "inner vectors" for the jagged vector buffer.
     /// @param resource The device accessible memory resource, which may also
     ///        be host accessible.
     /// @param host_access_resource An optional host accessible memory
     ///        resource. Needed if @c resource is not host accessible.
+    /// @param type The type (resizable or not) of the buffer
+    ///
     template <typename SIZE_TYPE = std::size_t,
               std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
                                    std::is_unsigned<SIZE_TYPE>::value,
                                bool> = true>
-    jagged_vector_buffer(const std::vector<SIZE_TYPE>& sizes,
-                         const std::vector<SIZE_TYPE>& capacities,
+    jagged_vector_buffer(const std::vector<SIZE_TYPE>& capacities,
                          memory_resource& resource,
-                         memory_resource* host_access_resource = nullptr);
+                         memory_resource* host_access_resource = nullptr,
+                         buffer_type type = buffer_type::fixed_size);
 
     /// Move constructor
     jagged_vector_buffer(jagged_vector_buffer&&) = default;

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -1,12 +1,13 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
 
 // Local include(s).
+#include "vecmem/containers/data/buffer_type.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/memory/unique_ptr.hpp"
@@ -49,11 +50,9 @@ public:
 
     /// Default constructor
     vector_buffer();
-    /// Constant size data constructor
-    vector_buffer(size_type size, memory_resource& resource);
-    /// Resizable data constructor
-    vector_buffer(size_type capacity, size_type size,
-                  memory_resource& resource);
+    /// Standard constructor
+    vector_buffer(size_type capacity, memory_resource& resource,
+                  buffer_type type = buffer_type::fixed_size);
     /// Move constructor
     vector_buffer(vector_buffer&&) = default;
 

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,16 +25,9 @@ vector_buffer<TYPE>::vector_buffer()
     : base_type(static_cast<size_type>(0), nullptr) {}
 
 template <typename TYPE>
-vector_buffer<TYPE>::vector_buffer(size_type size, memory_resource& resource)
-    : vector_buffer(size, size, resource) {}
-
-template <typename TYPE>
-vector_buffer<TYPE>::vector_buffer(size_type capacity, size_type size,
-                                   memory_resource& resource)
+vector_buffer<TYPE>::vector_buffer(size_type capacity,
+                                   memory_resource& resource, buffer_type type)
     : base_type(capacity, nullptr, nullptr) {
-
-    // A sanity check.
-    assert(capacity >= size);
 
     // Exit early for null-capacity buffers.
     if (capacity == 0) {
@@ -44,7 +37,7 @@ vector_buffer<TYPE>::vector_buffer(size_type capacity, size_type size,
     std::tie(m_memory, base_type::m_size, base_type::m_ptr) =
         details::aligned_multiple_placement<std::remove_pointer_t<size_pointer>,
                                             std::remove_pointer_t<pointer>>(
-            resource, size == capacity ? 0 : 1, capacity);
+            resource, type == buffer_type::fixed_size ? 0 : 1, capacity);
 }
 
 }  // namespace data

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -65,8 +65,8 @@ data::vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     type::copy_type cptype) const {
 
     // Set up the result buffer.
-    data::vector_buffer<std::remove_cv_t<TYPE>> result(
-        data.capacity(), get_size(data), resource);
+    data::vector_buffer<std::remove_cv_t<TYPE>> result(get_size(data),
+                                                       resource);
     setup(result)->wait();
 
     // Copy the payload of the vector. Explicitly waiting for the copy to finish

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -145,7 +145,8 @@ TEST_F(core_copy_test, resizable_vector_buffer) {
     using vecmem_size_type = vecmem::device_vector<int>::size_type;
     const vecmem_size_type capacity =
         static_cast<vecmem_size_type>(reference.size() + 5);
-    vecmem::data::vector_buffer<int> source_data(capacity, 0, m_resource);
+    vecmem::data::vector_buffer<int> source_data(
+        capacity, m_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(source_data);
     // Fill it with data.
     vecmem::device_vector<int> source_data_vec(source_data);

--- a/tests/core/test_core_copy.cpp
+++ b/tests/core/test_core_copy.cpp
@@ -355,7 +355,7 @@ TEST_F(core_copy_test, resizable_jagged_vector_buffer) {
     std::transform(reference.begin(), reference.end(), capacities.begin(),
                    [](const auto& vec) { return vec.size() + 5; });
     vecmem::data::jagged_vector_buffer<int> source_data(
-        std::vector<std::size_t>(capacities.size(), 0), capacities, m_resource);
+        capacities, m_resource, nullptr, vecmem::data::buffer_type::resizable);
     m_copy.setup(source_data);
     // Fill it with data.
     vecmem::jagged_device_vector<int> source_data_vec(source_data);

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -223,9 +223,8 @@ TEST_F(core_device_container_test, resizable_jagged_vector_buffer) {
 
     // Create a buffer with some sufficiently varied capacities.
     vecmem::data::jagged_vector_buffer<int> jagged_buffer(
-        std::vector<std::size_t>(10, 0),
         std::vector<std::size_t>({0, 16, 10, 15, 8, 3, 0, 0, 55, 2}),
-        m_resource);
+        m_resource, nullptr, vecmem::data::buffer_type::resizable);
     m_copy.setup(jagged_buffer);
 
     // Create a device vector on top of the buffer.
@@ -317,9 +316,8 @@ TEST_F(core_device_container_test, conversions) {
 
     // Create a dummy jagged vector buffer.
     vecmem::data::jagged_vector_buffer<int> buffer2d1(
-        std::vector<std::size_t>(10, 0),
         std::vector<std::size_t>({0, 16, 10, 15, 8, 3, 0, 0, 55, 2}),
-        m_resource);
+        m_resource, nullptr, vecmem::data::buffer_type::resizable);
     m_copy.setup(buffer2d1);
 
     // Check that some conversions compile and work correctly.

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -144,8 +144,7 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
     // Create a resizable buffer from that data.
     static constexpr buffer_size_type BUFFER_SIZE = 100;
     vecmem::data::vector_buffer<int> resizable_buffer(
-        BUFFER_SIZE, static_cast<buffer_size_type>(host_vector.size()),
-        m_resource);
+        BUFFER_SIZE, m_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(resizable_buffer);
     EXPECT_EQ(resizable_buffer.capacity(), BUFFER_SIZE);
     m_copy(vecmem::get_data(host_vector), resizable_buffer);
@@ -285,7 +284,8 @@ TEST_F(core_device_container_test, resizable_jagged_vector_buffer) {
 TEST_F(core_device_container_test, conversions) {
 
     // Create a dummy vector buffer.
-    vecmem::data::vector_buffer<int> buffer1d1{10, 0, m_resource};
+    vecmem::data::vector_buffer<int> buffer1d1{
+        10, m_resource, vecmem::data::buffer_type::resizable};
     m_copy.setup(buffer1d1);
 
     // Check that some conversions compile and work correctly.

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -137,7 +137,8 @@ TEST_F(core_jagged_vector_view_test, filter) {
 
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
-        {0, 0, 0, 0, 0, 0}, {10, 10, 10, 10, 10, 10}, m_mem);
+        {10, 10, 10, 10, 10, 10}, m_mem, nullptr,
+        vecmem::data::buffer_type::resizable);
     copy.setup(output_data);
 
     // Fill the jagged vector buffer with just the odd elements.

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -273,7 +273,8 @@ TEST_F(cuda_containers_test, large_buffer) {
 
     // Test a (2D) jagged vector.
     vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
-        {0, 0, 0}, {3, 3, 3}, managed_resource);
+        {3, 3, 3}, managed_resource, nullptr,
+        vecmem::data::buffer_type::resizable);
     m_copy.setup(buffer2);
     largeBufferTransform(buffer2);
     EXPECT_EQ(m_copy.get_sizes(buffer2), std::vector<unsigned int>({0, 1u, 0}));

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -207,7 +207,7 @@ TEST_F(cuda_containers_test, extendable_memory) {
     // Create a buffer that will hold the filtered elements of the input vector.
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
-        0, device_resource);
+        device_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(output_buffer);
 
     // Run the filtering kernel.
@@ -265,7 +265,8 @@ TEST_F(cuda_containers_test, large_buffer) {
     vecmem::cuda::managed_memory_resource managed_resource;
 
     // Test a (1D) vector.
-    vecmem::data::vector_buffer<unsigned long> buffer1(3, 0, managed_resource);
+    vecmem::data::vector_buffer<unsigned long> buffer1(
+        3, managed_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(buffer1);
     largeBufferTransform(buffer1);
     EXPECT_EQ(m_copy.get_size(buffer1), 1u);

--- a/tests/cuda/test_cuda_jagged_vector_view.cpp
+++ b/tests/cuda/test_cuda_jagged_vector_view.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -168,7 +168,8 @@ TEST_F(cuda_jagged_vector_view_test, filter) {
     // Create the output data on the device.
     vecmem::cuda::device_memory_resource device_resource;
     vecmem::data::jagged_vector_buffer<int> output_data_device(
-        {0, 0, 0, 0, 0, 0}, {10, 10, 10, 10, 10, 10}, device_resource, &m_mem);
+        {10, 10, 10, 10, 10, 10}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(output_data_device);
 
     // Run the filtering.
@@ -207,7 +208,8 @@ TEST_F(cuda_jagged_vector_view_test, zero_capacity) {
 
     // Create the jagged vector buffer in managed memory.
     vecmem::data::jagged_vector_buffer<int> managed_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, m_mem);
+        {0, 1, 200, 1, 100, 2}, m_mem, nullptr,
+        vecmem::data::buffer_type::resizable);
     copy.setup(managed_data);
 
     // Run the vector filling.
@@ -228,7 +230,8 @@ TEST_F(cuda_jagged_vector_view_test, zero_capacity) {
 
     // Create the jagged vector buffer in device memory.
     vecmem::data::jagged_vector_buffer<int> device_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, device_resource, &m_mem);
+        {0, 1, 200, 1, 100, 2}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(device_data);
 
     // Run the vector filling.

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -155,7 +155,7 @@ TEST_F(hip_containers_test, extendable_memory) {
     // Create a buffer that will hold the filtered elements of the input vector.
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
-        0, device_resource);
+        device_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(output_buffer);
 
     // Run the filtering kernel.

--- a/tests/hip/test_hip_jagged_containers.cpp
+++ b/tests/hip/test_hip_jagged_containers.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -182,7 +182,8 @@ TEST_F(hip_jagged_containers_test, filter) {
     // Create the output data on the device.
     vecmem::hip::device_memory_resource device_resource;
     vecmem::data::jagged_vector_buffer<int> output_data_device(
-        {0, 0, 0, 0, 0, 0}, {10, 10, 10, 10, 10, 10}, device_resource, &m_mem);
+        {10, 10, 10, 10, 10, 10}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(output_data_device);
 
     // Run the filtering.
@@ -221,7 +222,8 @@ TEST_F(hip_jagged_containers_test, zero_capacity) {
 
     // Create the jagged vector buffer in managed memory.
     vecmem::data::jagged_vector_buffer<int> managed_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, m_mem);
+        {0, 1, 200, 1, 100, 2}, m_mem, nullptr,
+        vecmem::data::buffer_type::resizable);
     copy.setup(managed_data);
 
     // Run the vector filling.
@@ -242,7 +244,8 @@ TEST_F(hip_jagged_containers_test, zero_capacity) {
 
     // Create the jagged vector buffer in device memory.
     vecmem::data::jagged_vector_buffer<int> device_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, device_resource, &m_mem);
+        {0, 1, 200, 1, 100, 2}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(device_data);
 
     // Run the vector filling.

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -317,7 +317,7 @@ TEST_F(sycl_containers_test, extendable_memory) {
     // Create a buffer that will hold the filtered elements of the input vector.
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
-        0, device_resource);
+        device_resource, vecmem::data::buffer_type::resizable);
     copy.setup(output_buffer);
 
     // Run a kernel that filters the elements of the input vector.

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -382,7 +382,8 @@ TEST_F(sycl_jagged_containers_test, filter) {
     // Create the output data on the device.
     vecmem::sycl::device_memory_resource device_resource(&m_queue);
     vecmem::data::jagged_vector_buffer<int> output_data_device(
-        {0, 0, 0, 0, 0, 0}, {10, 10, 10, 10, 10, 10}, device_resource, &m_mem);
+        {10, 10, 10, 10, 10, 10}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(output_data_device)->wait();
 
     // Create the view/data objects of the jagged vector outside of the
@@ -456,7 +457,8 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
 
     // Create the jagged vector buffer in managed memory.
     vecmem::data::jagged_vector_buffer<int> managed_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, m_mem);
+        {0, 1, 200, 1, 100, 2}, m_mem, nullptr,
+        vecmem::data::buffer_type::resizable);
     copy.setup(managed_data);
 
     // Run the vector filling.
@@ -485,7 +487,8 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
 
     // Create the jagged vector buffer in device memory.
     vecmem::data::jagged_vector_buffer<int> device_data(
-        {0, 0, 0, 0, 0, 0}, {0, 1, 200, 1, 100, 2}, device_resource, &m_mem);
+        {0, 1, 200, 1, 100, 2}, device_resource, &m_mem,
+        vecmem::data::buffer_type::resizable);
     copy.setup(device_data);
 
     // Run the vector filling.


### PR DESCRIPTION
Before going further with this, I wanted to get some feedback.

As discussed in #95, #221, #223 and possibly some other places as well, the API for creating resizable and non-resizable buffers is pretty poor in VecMem. :frowning: This is a simple proposal for how we could make the user interface a bit easier to understand.

I have some more complicated ideas as well, which could potentially allow us to create non-empty resizable buffers out of the box. (Finally addressing what I had in mind with #95.) But by now I don't actually think this is ever really useful. I mean, setting up a buffer that has a non-zero size, and undefined elements in that non-zero sized buffer. I can only imagine that we'd want to create a resizable buffer with a zero size, and then copy elements (fewer than the capacity of the buffer) into it on the host to create a non-zero sized, "well defined" buffer as input to a given kernel.

Long story short, I don't think an actual `size` variable would ever be useful for these resizable buffers. :thinking: But before I would modify `vecmem::data::jagged_vector_buffer` in a similar way, I wanted to get some feedback.

@stephenswat, @beomki-yeo, @guilhermeAlmeida1, @niermann999?

P.S. I'm also not in love with the naming in this PR. So feel free to suggest something better.