### PR TITLE
Conversion Warnings, main branch (2023.03.24.)

### DIFF
--- a/benchmarks/common/make_jagged_sizes.cpp
+++ b/benchmarks/common/make_jagged_sizes.cpp
@@ -11,21 +11,30 @@
 
 // System include(s).
 #include <algorithm>
+#include <cassert>
+#include <limits>
 #include <random>
 
 namespace vecmem::benchmark {
 
-std::vector<std::size_t> make_jagged_sizes(std::size_t outerSize,
-                                           std::size_t maxInnerSize) {
+std::vector<std::size_t> make_jagged_sizes(int64_t outerSize,
+                                           int64_t maxInnerSize) {
+
+    // Some security checks.
+    assert((outerSize >= 0) &&
+           (outerSize < std::numeric_limits<int32_t>::max()));
+    assert((maxInnerSize >= 0) &&
+           (maxInnerSize < std::numeric_limits<int32_t>::max()));
 
     // Set up a simple random number generator for the inner vector sizes.
     std::default_random_engine eng;
     eng.seed(static_cast<std::default_random_engine::result_type>(
         outerSize + maxInnerSize));
-    std::uniform_int_distribution<std::size_t> gen(0, maxInnerSize);
+    std::uniform_int_distribution<std::size_t> gen(
+        0, static_cast<std::size_t>(maxInnerSize));
 
     // Generate the result vector.
-    std::vector<std::size_t> result(outerSize);
+    std::vector<std::size_t> result(static_cast<std::size_t>(outerSize));
     std::generate(result.begin(), result.end(),
                   [&eng, &gen]() { return gen(eng); });
 

--- a/benchmarks/common/make_jagged_sizes.hpp
+++ b/benchmarks/common/make_jagged_sizes.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 
 // System include(s).
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace vecmem::benchmark {
@@ -24,7 +25,7 @@ namespace vecmem::benchmark {
 ///                     resulting vector (buffer)
 /// @return A vector of sizes corresponding to the received parameters
 ///
-std::vector<std::size_t> make_jagged_sizes(std::size_t outerSize,
-                                           std::size_t maxInnerSize);
+std::vector<std::size_t> make_jagged_sizes(int64_t outerSize,
+                                           int64_t maxInnerSize);
 
 }  // namespace vecmem::benchmark

--- a/benchmarks/core/benchmark_core.cpp
+++ b/benchmarks/core/benchmark_core.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,16 +16,17 @@
 static vecmem::host_memory_resource host_mr;
 
 void BenchmarkHost(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = host_mr.allocate(state.range(0));
-        host_mr.deallocate(p, state.range(0));
+        void* p = host_mr.allocate(size);
+        host_mr.deallocate(p, size);
     }
 }
 
 BENCHMARK(BenchmarkHost)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 void BenchmarkBinaryPage(benchmark::State& state) {
-    std::size_t size = state.range(0);
+    std::size_t size = static_cast<std::size_t>(state.range(0));
 
     vecmem::binary_page_memory_resource mr(host_mr);
 

--- a/benchmarks/cuda/benchmark_cuda.cpp
+++ b/benchmarks/cuda/benchmark_cuda.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,15 +18,16 @@
 
 static vecmem::cuda::device_memory_resource device_mr;
 void BenchmarkCudaDevice(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = device_mr.allocate(state.range(0));
-        device_mr.deallocate(p, state.range(0));
+        void* p = device_mr.allocate(size);
+        device_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkCudaDevice)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 void BenchmarkCudaDeviceBinaryPage(benchmark::State& state) {
-    std::size_t size = state.range(0);
+    std::size_t size = static_cast<std::size_t>(state.range(0));
 
     vecmem::binary_page_memory_resource mr(device_mr);
 
@@ -40,8 +41,8 @@ BENCHMARK(BenchmarkCudaDeviceBinaryPage)
     ->Range(1, 2UL << 31);
 
 void BenchmarkCudaDeviceBinaryPageMultiple(benchmark::State& state) {
-    std::size_t size = state.range(0);
-    std::size_t nallocs = state.range(1);
+    std::size_t size = static_cast<std::size_t>(state.range(0));
+    std::size_t nallocs = static_cast<std::size_t>(state.range(1));
 
     std::vector<void*> allocs;
 
@@ -64,15 +65,16 @@ BENCHMARK(BenchmarkCudaDeviceBinaryPageMultiple)
 
 static vecmem::cuda::host_memory_resource host_mr;
 void BenchmarkCudaPinned(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = host_mr.allocate(state.range(0));
-        host_mr.deallocate(p, state.range(0));
+        void* p = host_mr.allocate(size);
+        host_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkCudaPinned)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 void BenchmarkCudaPinnedBinaryPage(benchmark::State& state) {
-    std::size_t size = state.range(0);
+    std::size_t size = static_cast<std::size_t>(state.range(0));
 
     vecmem::binary_page_memory_resource mr(host_mr);
 
@@ -87,15 +89,16 @@ BENCHMARK(BenchmarkCudaPinnedBinaryPage)
 
 static vecmem::cuda::managed_memory_resource managed_mr;
 void BenchmarkCudaManaged(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = managed_mr.allocate(state.range(0));
-        managed_mr.deallocate(p, state.range(0));
+        void* p = managed_mr.allocate(size);
+        managed_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkCudaManaged)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 void BenchmarkCudaManagedBinaryPage(benchmark::State& state) {
-    std::size_t size = state.range(0);
+    std::size_t size = static_cast<std::size_t>(state.range(0));
 
     vecmem::binary_page_memory_resource mr(managed_mr);
 

--- a/benchmarks/sycl/benchmark_sycl.cpp
+++ b/benchmarks/sycl/benchmark_sycl.cpp
@@ -15,27 +15,30 @@
 
 static vecmem::sycl::device_memory_resource device_mr;
 void BenchmarkSYCLDevice(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = device_mr.allocate(state.range(0));
-        device_mr.deallocate(p, state.range(0));
+        void* p = device_mr.allocate(size);
+        device_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkSYCLDevice)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 static vecmem::sycl::host_memory_resource host_mr;
 void BenchmarkSYCLHost(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = host_mr.allocate(state.range(0));
-        host_mr.deallocate(p, state.range(0));
+        void* p = host_mr.allocate(size);
+        host_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkSYCLHost)->RangeMultiplier(2)->Range(1, 2UL << 31);
 
 static vecmem::sycl::shared_memory_resource shared_mr;
 void BenchmarkSYCLShared(benchmark::State& state) {
+    const std::size_t size = static_cast<std::size_t>(state.range(0));
     for (auto _ : state) {
-        void* p = shared_mr.allocate(state.range(0));
-        shared_mr.deallocate(p, state.range(0));
+        void* p = shared_mr.allocate(size);
+        shared_mr.deallocate(p, size);
     }
 }
 BENCHMARK(BenchmarkSYCLShared)->RangeMultiplier(2)->Range(1, 2UL << 31);

--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -14,12 +14,13 @@ set( CMAKE_CXX_STANDARD 17 CACHE STRING "The (host) C++ standard to use" )
 if( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
     ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
 
-   # Basic flags for all build modes.
+   # Turn on a schizophrenic amount of warnings.
    vecmem_add_flag( CMAKE_CXX_FLAGS "-Wall" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "-Wextra" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "-Wshadow" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "-Wunused-local-typedefs" )
    vecmem_add_flag( CMAKE_CXX_FLAGS "-pedantic" )
+   vecmem_add_flag( CMAKE_CXX_FLAGS "-Wconversion" )
 
    # Fail on warnings, if asked for that behaviour.
    if( VECMEM_FAIL_ON_WARNINGS )

--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -48,7 +48,7 @@ aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps... ps) {
     /*
      * We start out by calculating the size of the current region.
      */
-    std::size_t size = sizeof(T) * n;
+    std::size_t size = sizeof(T) * static_cast<std::size_t>(n);
 
     /*
      * We will start out by having this region point to null, because it is
@@ -175,7 +175,8 @@ aligned_multiple_placement(vecmem::memory_resource &r, Ps... ps) {
      * over-aligned types).
      */
     const std::size_t bytes =
-        ((ps * sizeof(Ts)) + ...) + sizeof...(Ts) * alignment;
+        ((static_cast<std::size_t>(ps) * sizeof(Ts)) + ...) +
+        sizeof...(Ts) * alignment;
 
     /*
      * We can now make the allocation request with the memory resource, which

--- a/core/include/vecmem/containers/impl/static_vector.ipp
+++ b/core/include/vecmem/containers/impl/static_vector.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -487,7 +487,7 @@ template <typename TYPE, std::size_t MAX_SIZE>
 VECMEM_HOST_AND_DEVICE typename static_vector<TYPE, MAX_SIZE>::ElementId
 static_vector<TYPE, MAX_SIZE>::element_id(const_iterator pos) {
 
-    size_type const index = pos - begin();
+    size_type const index = static_cast<size_type>(pos - begin());
     assert(index <= m_size);
     pointer const ptr = reinterpret_cast<pointer>(m_elements) + index;
     return {index, ptr};

--- a/core/src/memory/binary_page_memory_resource_impl.cpp
+++ b/core/src/memory/binary_page_memory_resource_impl.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,9 +39,9 @@ std::size_t round_up(std::size_t size) {
 
 inline std::size_t clzl(std::size_t i) {
 #if defined(VECMEM_HAVE_LZCNT_U64)
-    return _lzcnt_u64(i);
+    return static_cast<std::size_t>(_lzcnt_u64(i));
 #elif defined(VECMEM_HAVE_BUILTIN_CLZL)
-    return __builtin_clzl(i);
+    return static_cast<std::size_t>(__builtin_clzl(i));
 #else
     std::size_t b;
     for (b = 0;
@@ -189,7 +189,9 @@ void binary_page_memory_resource_impl::do_deallocate(void *p, std::size_t s,
     /*
      * Finally, change the state of the page to vacant.
      */
-    page_ref(*sp, p_min + (diff / (static_cast<std::size_t>(1UL) << goal)))
+    page_ref(*sp,
+             p_min + static_cast<std::size_t>(
+                         diff / (static_cast<std::ptrdiff_t>(1UL << goal))))
         .change_state_occupied_to_vacant();
 }
 

--- a/core/src/memory/contiguous_memory_resource.cpp
+++ b/core/src/memory/contiguous_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,7 @@
 #include "vecmem/utils/debug.hpp"
 
 // System include(s).
+#include <cassert>
 #include <memory>
 #include <stdexcept>
 
@@ -45,8 +46,10 @@ void *contiguous_memory_resource::do_allocate(std::size_t size,
      * Compute the remaining space, which needs to be an lvalue for standard
      * library-related reasons.
      */
+    assert(m_next >= m_begin);
     std::size_t rem =
-        m_size - (static_cast<char *>(m_next) - static_cast<char *>(m_begin));
+        m_size - static_cast<std::size_t>(static_cast<char *>(m_next) -
+                                          static_cast<char *>(m_begin));
 
     /*
      * Employ std::align to find the next properly aligned address.

--- a/core/src/memory/instrumenting_memory_resource.cpp
+++ b/core/src/memory/instrumenting_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -74,8 +74,8 @@ void *instrumenting_memory_resource::do_allocate(std::size_t size,
     std::chrono::high_resolution_clock::time_point t2 =
         std::chrono::high_resolution_clock::now();
 
-    std::size_t time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+    std::size_t time = static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count());
 
     /*
      * Add a new allocation event with the size, alignment, pointer, and time
@@ -132,8 +132,8 @@ void instrumenting_memory_resource::do_deallocate(void *ptr, std::size_t size,
     std::chrono::high_resolution_clock::time_point t2 =
         std::chrono::high_resolution_clock::now();
 
-    std::size_t time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+    std::size_t time = static_cast<std::size_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count());
 
     /*
      * Register a deallocation event.

--- a/tests/common/memory_resource_test_stress.ipp
+++ b/tests/common/memory_resource_test_stress.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -39,7 +39,7 @@ TEST_P(memory_resource_test_stress, stress_test) {
 
         // Check that all vectors have the intended content after all of this.
         for (int j = 0; j < n_vectors; ++j) {
-            for (int value : vectors.at(j)) {
+            for (int value : vectors.at(static_cast<std::size_t>(j))) {
                 EXPECT_EQ(value, j);
             }
         }

--- a/tests/core/test_core_array.cpp
+++ b/tests/core/test_core_array.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,8 +47,8 @@ protected:
     void test_array(vecmem::array<T, N>& a) {
 
         // Fill the array with some simple values.
-        for (int i = 0; i < static_cast<int>(a.size()); ++i) {
-            a.at(i) = T(i);
+        for (std::size_t i = 0; i < a.size(); ++i) {
+            a.at(i) = T(static_cast<int>(i));
         }
 
         // Check the contents using iterator based loops.

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -150,7 +150,7 @@ TEST_F(core_container_test, static_array) {
               std::accumulate(test_array2.rbegin(), test_array2.rend(), 0));
     test_array3.fill(12);
     for (int i = 0; i < ARRAY_SIZE; ++i) {
-        EXPECT_EQ(test_array3.at(i), 12);
+        EXPECT_EQ(test_array3.at(static_cast<std::size_t>(i)), 12);
     }
     const vecmem::static_array<int, 0> test_array4{};
     EXPECT_EQ(test_array4.size(), 0);

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -159,7 +159,7 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
     EXPECT_EQ(device_vector.capacity(), BUFFER_SIZE);
     EXPECT_EQ(device_vector.max_size(), BUFFER_SIZE);
     for (int i = 0; i < 10; ++i) {
-        EXPECT_EQ(device_vector[i], i + 1);
+        EXPECT_EQ(device_vector[static_cast<vector_size_type>(i)], i + 1);
     }
 
     // Modify the device vector in different ways, and check that it would work

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -69,10 +69,17 @@ typedef testing::Types<int, long, float, double, TestType1> tested_types;
 TYPED_TEST_SUITE(core_static_vector_test, tested_types, tested_names);
 
 namespace {
-/// Helper function for comparing the value of primitive types
+/// Helper function for comparing the value of non-integral primitive types
 template <typename T>
-bool almost_equal(const T& v1, const T& v2) {
+typename std::enable_if<!std::is_integral<T>::value, bool>::type almost_equal(
+    const T& v1, const T& v2) {
     return (std::abs(v1 - v2) < 0.001);
+}
+/// Helper function for comparing the value of integral primitive types
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, bool>::type almost_equal(
+    const T& v1, const T& v2) {
+    return (v1 == v2);
 }
 /// Specialisation for comparing @c TestType1 objects
 template <>

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -69,8 +69,10 @@ TEST_F(hip_containers_test, device_memory) {
 
     // Allocate a device memory block for the output container.
     auto outputvechost = vecmem::get_data(outputvec);
-    vecmem::data::vector_buffer<int> outputvecdevice(outputvec.size(),
-                                                     device_resource);
+    vecmem::data::vector_buffer<int> outputvecdevice(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(
+            outputvec.size()),
+        device_resource);
 
     // Create the array that is used in the linear transformation.
     vecmem::array<int, 2> constants(host_resource);
@@ -151,8 +153,9 @@ TEST_F(hip_containers_test, extendable_memory) {
     }
 
     // Create a buffer that will hold the filtered elements of the input vector.
-    vecmem::data::vector_buffer<int> output_buffer(input.size(), 0,
-                                                   device_resource);
+    vecmem::data::vector_buffer<int> output_buffer(
+        static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
+        0, device_resource);
     m_copy.setup(output_buffer);
 
     // Run the filtering kernel.


### PR DESCRIPTION
I got myself into a rabbit hole with this one...

I set out to update the build configuration of Detray a bit, to make it use `-Werror` in the same way as VecMem does. But as soon as I did that, I ran into:

```
[ 78%] Building CXX object tests/unit_tests/device/cuda/CMakeFiles/detray_test_core_cuda.dir/utils_ranges_cuda.cpp.o                                                                                              
In file included from /home/krasznaa/ATLAS/projects/detray/detray/tests/unit_tests/device/cuda/utils_ranges_cuda.cpp:13:
In file included from /home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/cuda/include/vecmem/utils/cuda/copy.hpp:11:
In file included from /home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/core/include/vecmem/utils/copy.hpp:11:
In file included from /home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/core/include/vecmem/containers/data/jagged_vector_buffer.hpp:123:
In file included from /home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp:11:
In file included from /home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/core/include/vecmem/containers/details/aligned_multiple_placement.hpp:95:
/home/krasznaa/ATLAS/projects/detray/build/_deps/vecmem-src/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp:177:11: error: implicit conversion changes signedness: 'int' to 'unsigned long' [-Werror,-Wsign-conversion]
        ((ps * sizeof(Ts)) + ...) + sizeof...(Ts) * alignment;
          ^~ ~
```

So I added `-Wconversion` to this project's default build as well. And that revealed a bit more than I bargained for. :stuck_out_tongue:

Still, I thought, this could be useful. Especially as long as we keep using `-Wconversion` in downstream projects...