### PR TITLE
CI CMake Fix, main branch (2023.03.27.)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -47,11 +47,6 @@ jobs:
                  -DVECMEM_FAIL_ON_WARNINGS=TRUE
                  -S ${{ github.workspace }} -B build
                  ${{ matrix.PLATFORM.GENERATOR }}
-    # Print the configuration log for debugging
-    - name: Print CMake Configure Output
-      run: cat build/CMakeFiles/CMakeOutput.log
-    - name: Print CMake Configure Errors
-      run: cat build/CMakeFiles/CMakeError.log
     # Perform the build.
     - name: Build
       run: cmake --build build --config ${{ matrix.BUILD.TYPE }}


### PR DESCRIPTION
Removed the CMake debug printouts for the native builds.

CMake 3.26 switched to a new way of storing the detailed output of its tests. (In a file called `CMakeFiles/CMakeConfigureLog.yaml`.) But as long as all of `windows-latest`, `macos-latest` and `ubuntu-latest` don't switch to CMake 3.26, we can't switch to the new formalism yet. (At least not without more effort than I'm willing to give it.)

So for now it's easier to just disable this printouts for the native builds, and only keep them for the containerised ones.