### PR TITLE
Add target option for atomic ref

### DIFF
--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -190,6 +190,38 @@ TEST_F(cuda_containers_test, atomic_device_memory) {
     }
 }
 
+/// Test the execution of atomic operations in local memory
+TEST_F(cuda_containers_test, atomic_local_ref) {
+
+    // The memory resources.
+    vecmem::cuda::host_memory_resource host_resource;
+    vecmem::cuda::device_memory_resource device_resource;
+
+    // Local block size.
+    static constexpr int BLOCKSIZE = 128;
+
+    // Number of blocks.
+    static constexpr int NUMBLOCKS = 5;
+
+    // Allocate memory on the host, and set initial values in it.
+    vecmem::vector<int> host_vector(NUMBLOCKS, 0, &host_resource);
+
+    // Set up device buffers with the data.
+    auto device_buffer =
+        m_copy.to(vecmem::get_data(host_vector), device_resource);
+
+    // Run test function.
+    atomicLocalRef(NUMBLOCKS, BLOCKSIZE, device_buffer);
+
+    // Copy data back to the host.
+    m_copy(device_buffer, host_vector);
+
+    // Check the output.
+    for (std::size_t i = 0; i < NUMBLOCKS; ++i) {
+        EXPECT_EQ(host_vector[i], i * BLOCKSIZE);
+    }
+}
+
 /// Test the usage of extendable vectors in a kernel
 TEST_F(cuda_containers_test, extendable_memory) {
 

--- a/tests/cuda/test_cuda_containers_kernels.cuh
+++ b/tests/cuda/test_cuda_containers_kernels.cuh
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,6 +30,10 @@ void linearTransform(vecmem::data::vector_view<const int> constants,
 /// Function incrementing the elements of the received vector using atomics
 void atomicTransform(unsigned int iterations,
                      vecmem::data::vector_view<int> vec);
+
+/// Function filling vectors after using atomics in local address space
+void atomicLocalRef(std::size_t num_blocks, std::size_t block_size,
+                    vecmem::data::vector_view<int> vec);
 
 /// Function filtering elements of an input vector into an output vector
 void filterTransform(vecmem::data::vector_view<const int> input,

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -139,6 +139,38 @@ TEST_F(hip_containers_test, atomic_device_memory) {
     }
 }
 
+/// Test the execution of atomic operations in local memory
+TEST_F(hip_containers_test, atomic_local_ref) {
+
+    // The host/device memory resources.
+    vecmem::hip::host_memory_resource host_resource;
+    vecmem::hip::device_memory_resource device_resource;
+
+    // Local block size.
+    static constexpr int BLOCKSIZE = 128;
+
+    // Number of blocks.
+    static constexpr int NUMBLOCKS = 5;
+
+    // Allocate memory on the host, and set initial values in it.
+    vecmem::vector<int> host_vector(NUMBLOCKS, 0, &host_resource);
+
+    // Set up device buffers with the data.
+    auto device_buffer =
+        m_copy.to(vecmem::get_data(host_vector), device_resource);
+
+    // Run test function.
+    atomicLocalRef(NUMBLOCKS, BLOCKSIZE, device_buffer);
+
+    // Copy data back to the host.
+    m_copy(device_buffer, host_vector);
+
+    // Check the output.
+    for (std::size_t i = 0; i < NUMBLOCKS; ++i) {
+        EXPECT_EQ(host_vector[i], i * BLOCKSIZE);
+    }
+}
+
 /// Test the usage of extendable vectors in a kernel
 TEST_F(hip_containers_test, extendable_memory) {
 

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -150,6 +150,47 @@ void atomicTransform(std::size_t iterations,
     // Launch the kernel.
     hipLaunchKernelGGL(atomicTransformKernel, iterations, vec.size(), 0,
                        nullptr, iterations, vec);
+    // Check whether it succeeded to run.
+    VECMEM_HIP_ERROR_CHECK(hipGetLastError());
+    VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+}
+
+/// Kernel performing some basic atomic operations on local memory.
+__global__ void atomicLocalRefKernel(vecmem::data::vector_view<int> data) {
+
+    // Find the current block index.
+    const int i = hipBlockIdx_x;
+
+    __shared__ int shared;
+
+    // Initialise shared memory variable
+    if (hipThreadIdx_x == 0) {
+        shared = 0;
+    }
+    __syncthreads();
+
+    // Perform basic atomic operations on local memory.
+    vecmem::device_atomic_ref<int, vecmem::device_address_space::local> atom(
+        shared);
+    atom.fetch_add(2 * i);
+    atom.fetch_sub(i);
+    atom.fetch_and(0xffffffff);
+    atom.fetch_or(0x00000000);
+    __syncthreads();
+    if (hipThreadIdx_x == 0) {
+        vecmem::device_vector<int> dev(data);
+        dev.at(i) = shared;
+    }
+
+    return;
+}
+
+void atomicLocalRef(std::size_t num_blocks, std::size_t block_size,
+                    vecmem::data::vector_view<int> vec) {
+
+    // Launch the kernel.
+    hipLaunchKernelGGL(atomicLocalRefKernel, num_blocks, block_size, 0, nullptr,
+                       vec);
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());

--- a/tests/hip/test_hip_containers_kernels.hpp
+++ b/tests/hip/test_hip_containers_kernels.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,6 +27,10 @@ void linearTransform(vecmem::data::vector_view<const int> constants,
 /// Function incrementing the elements of the received vector using atomics
 void atomicTransform(std::size_t iterations,
                      vecmem::data::vector_view<int> vec);
+
+/// Function filling vectors after using atomics in local address space
+void atomicLocalRef(std::size_t num_blocks, std::size_t block_size,
+                    vecmem::data::vector_view<int> vec);
 
 /// Function filtering elements of an input vector into an output vector
 void filterTransform(vecmem::data::vector_view<const int> input,

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -294,6 +294,88 @@ TEST_F(sycl_containers_test, atomic_device_memory) {
     }
 }
 
+/// Test atomic access to local memory
+TEST_F(sycl_containers_test, atomic_local_ref) {
+
+    // Create the SYCL queue that we'll be using in the test.
+    cl::sycl::queue queue;
+
+    // Skip test if not running on a gpu.
+    if (queue.get_device().get_info<::sycl::info::device::device_type>() !=
+        ::sycl::info::device_type::gpu) {
+        GTEST_SKIP();
+    }
+
+    // The memory resources.
+    vecmem::sycl::host_memory_resource host_resource(&queue);
+    vecmem::sycl::device_memory_resource device_resource(&queue);
+
+    // Helper object for performing memory copies.
+    vecmem::sycl::async_copy copy(&queue);
+
+    // Local block size.
+    static constexpr int BLOCKSIZE = 128;
+
+    // Number of blocks.
+    static constexpr int NUMBLOCKS = 5;
+
+    // Allocate memory on the host, and set initial values in it.
+    vecmem::vector<int> host_vector(NUMBLOCKS, 0, &host_resource);
+
+    // Set up a device buffer with the data.
+    auto device_buffer =
+        copy.to(vecmem::get_data(host_vector), device_resource);
+
+    // Do basic atomic addition on local memory.
+    queue
+        .submit([&device_buffer](cl::sycl::handler& h) {
+            ::sycl::accessor<int, 1, ::sycl::access::mode::read_write,
+                             ::sycl::access::target::local>
+                shared(1, h);
+
+            h.parallel_for<class AtomicLocalRefTests>(
+                cl::sycl::nd_range<1>(BLOCKSIZE * NUMBLOCKS, BLOCKSIZE),
+                [buffer = vecmem::get_data(device_buffer),
+                 shared](cl::sycl::nd_item<1> item) {
+                    // Do simple stuff using local atomic ref
+                    const int i = item.get_group_linear_id();
+
+                    // Initialise shared memory variable
+                    if (item.get_local_linear_id() == 0) {
+                        shared[0] = 0;
+                    }
+                    item.barrier();
+
+                    // Perform basic atomic operations on local memory.
+                    vecmem::device_atomic_ref<
+                        int, vecmem::device_address_space::local>
+                        atom(shared[0]);
+                    atom.fetch_add(2 * i);
+                    atom.fetch_sub(i);
+                    atom.fetch_and(0xffffffff);
+                    atom.fetch_or(0x00000000);
+
+                    // Wait for work to be done
+                    item.barrier();
+
+                    // Write result to global memory
+                    if (item.get_local_linear_id() == 0) {
+                        vecmem::device_vector<int> dev(buffer);
+                        dev.at(i) = shared[0];
+                    }
+                });
+        })
+        .wait_and_throw();
+
+    // Copy data back to the host.
+    copy(device_buffer, vecmem::get_data(host_vector))->wait();
+
+    // Check the output.
+    for (std::size_t i = 0; i < NUMBLOCKS; ++i) {
+        EXPECT_EQ(host_vector[i], i * BLOCKSIZE);
+    }
+}
+
 /// Test the usage of extendable vectors in a kernel
 TEST_F(sycl_containers_test, extendable_memory) {
 


### PR DESCRIPTION
Current SYCL implementation of `device_atomic_ref` only allows using device-wide atomics in global space. 
This PR introduces the possibility of targetting local space instead.