### PR TITLE
Introduce vecmem::sycl::local_accessor, main branch (2023.05.31.)

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -84,6 +84,14 @@ if( VECMEM_HAVE_SYCL_MEMSET )
    target_compile_definitions( vecmem_sycl PRIVATE VECMEM_HAVE_SYCL_MEMSET )
 endif()
 
+# Check if sycl::local_accessor is available.
+vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_LOCAL_ACCESSOR
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/local_accessor_test.sycl" )
+if( VECMEM_HAVE_SYCL_LOCAL_ACCESSOR )
+   target_compile_definitions( vecmem_sycl INTERFACE
+      VECMEM_HAVE_SYCL_LOCAL_ACCESSOR )
+endif()
+
 # Test the public headers of vecmem::sycl.
 if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
    file( GLOB_RECURSE vecmem_sycl_public_headers

--- a/sycl/cmake/local_accessor_test.sycl
+++ b/sycl/cmake/local_accessor_test.sycl
@@ -1,0 +1,24 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+int main() {
+
+    // Check if sycl::local_accessor is available.
+    cl::sycl::queue queue;
+    queue
+        .submit([](cl::sycl::handler& h) {
+            ::sycl::local_accessor<int> dummy(10, h);
+            (void)dummy;
+        })
+        .wait_and_throw();
+
+    // Return gracefully.
+    return 0;
+}

--- a/sycl/include/vecmem/utils/sycl/local_accessor.hpp
+++ b/sycl/include/vecmem/utils/sycl/local_accessor.hpp
@@ -1,0 +1,40 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Cowardly don't include <CL/sycl.hpp> here, leave it up to the user to
+// do that. This way the vecmem::sycl library doesn't have to set up an
+// explicit public dependency on the SYCL headers.
+
+namespace vecmem::sycl {
+
+#if defined(VECMEM_HAVE_SYCL_LOCAL_ACCESSOR) && \
+    (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+
+/// @brief Set up @c vecmem::sycl::local_accessor as an alias for
+///       @c ::sycl::local_accessor.
+/// @tparam T The type of the local memory array.
+/// @tparam DIM Dimensions for the local memory array.
+///
+template <typename T, int DIM = 1>
+using local_accessor = ::sycl::local_accessor<T, DIM>;
+
+#elif (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+
+/// @brief Set up @c vecmem::sycl::local_accessor as an alias for
+///       @c ::sycl::accessor.
+/// @tparam T The type of the local memory array.
+/// @tparam DIM Dimensions for the local memory array.
+///
+template <typename T, int DIM = 1>
+using local_accessor =
+    ::sycl::accessor<T, DIM, ::sycl::access::mode::read_write,
+                     ::sycl::access::target::local>;
+
+#endif  // VECMEM_HAVE_SYCL_LOCAL_ACCESSOR
+
+}  // namespace vecmem::sycl

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -22,6 +22,7 @@
 #include "vecmem/memory/sycl/shared_memory_resource.hpp"
 #include "vecmem/utils/sycl/async_copy.hpp"
 #include "vecmem/utils/sycl/copy.hpp"
+#include "vecmem/utils/sycl/local_accessor.hpp"
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
@@ -329,9 +330,7 @@ TEST_F(sycl_containers_test, atomic_local_ref) {
     // Do basic atomic addition on local memory.
     queue
         .submit([&device_buffer](cl::sycl::handler& h) {
-            ::sycl::accessor<int, 1, ::sycl::access::mode::read_write,
-                             ::sycl::access::target::local>
-                shared(1, h);
+            vecmem::sycl::local_accessor<int> shared(1, h);
 
             h.parallel_for<class AtomicLocalRefTests>(
                 cl::sycl::nd_range<1>(BLOCKSIZE * NUMBLOCKS, BLOCKSIZE),


### PR DESCRIPTION
While in [traccc](https://github.com/acts-project/traccc) I told @guilhermeAlmeida1 that we shouldn't over-think how we use local/shared memory with SYCL, in this project I finally changed my mind...

With modern versions of Intel's compiler there is a warning about using `::sycl::access::target::local` on a "normal" `::sycl::accessor`. One is rather supposed to use `::sycl::local_accessor` nowadays. So to help with using the correct type in our code, I now introduced `vecmem::sycl::local_accessor`, which would resolve to the correct type with whatever SYCL compiler we use. By checking during CMake configuration whether `::sycl::local_accessor` is usable, and if it is, using that. If it's not, it falls back on using `::sycl::accessor`.

I thought this would be a more robust setup than to rely on some compiler macros.

As long as people are on board with this, we should eventually update the traccc code to use this type as well.