### PR TITLE
(Open)SYCL Fixes, main branch (2023.06.01.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -196,9 +196,9 @@ if( VECMEM_BUILD_SYCL_LIBRARY )
          VECMEM_SYCL_PRINTF_FUNCTION=cl::sycl::ONEAPI::experimental::printf )
    else()
       message( WARNING "No valid printf function found for SYCL."
-         " Enabling debug messages will likely not work." )
+         " Enabling debug messages will likely not work in device code." )
       target_compile_definitions( vecmem_core PUBLIC
-         VECMEM_ONEAPI_PRINTF_FUNCTION=printf )
+         VECMEM_SYCL_PRINTF_FUNCTION=printf VECMEM_MSG_ATTRIBUTES= )
    endif()
 
    # Test whether sycl::atomic_ref is available.

--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -1,10 +1,13 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
+
+// System include(s).
+#include <cstdio>
 
 /// Function name to use for printout operations
 #ifndef VECMEM_PRINTF

--- a/sycl/cmake/local_accessor_test.sycl
+++ b/sycl/cmake/local_accessor_test.sycl
@@ -14,7 +14,7 @@ int main() {
     cl::sycl::queue queue;
     queue
         .submit([](cl::sycl::handler& h) {
-            ::sycl::local_accessor<int> dummy(10, h);
+            cl::sycl::local_accessor<int> dummy(10, h);
             (void)dummy;
         })
         .wait_and_throw();

--- a/sycl/include/vecmem/utils/sycl/local_accessor.hpp
+++ b/sycl/include/vecmem/utils/sycl/local_accessor.hpp
@@ -21,7 +21,7 @@ namespace vecmem::sycl {
 /// @tparam DIM Dimensions for the local memory array.
 ///
 template <typename T, int DIM = 1>
-using local_accessor = ::sycl::local_accessor<T, DIM>;
+using local_accessor = cl::sycl::local_accessor<T, DIM>;
 
 #elif (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
 
@@ -32,8 +32,8 @@ using local_accessor = ::sycl::local_accessor<T, DIM>;
 ///
 template <typename T, int DIM = 1>
 using local_accessor =
-    ::sycl::accessor<T, DIM, ::sycl::access::mode::read_write,
-                     ::sycl::access::target::local>;
+    cl::sycl::accessor<T, DIM, cl::sycl::access::mode::read_write,
+                       cl::sycl::access::target::local>;
 
 #endif  // VECMEM_HAVE_SYCL_LOCAL_ACCESSOR
 

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,13 +23,13 @@ namespace {
 struct sycl_event : public vecmem::abstract_event {
 
     /// Constructor with a SYCL event
-    sycl_event(const std::vector<::sycl::event>& events) : m_events(events) {}
+    sycl_event(const std::vector<cl::sycl::event>& events) : m_events(events) {}
 
     /// Synchronize on the underlying SYCL event
-    virtual void wait() override { ::sycl::event::wait_and_throw(m_events); }
+    virtual void wait() override { cl::sycl::event::wait_and_throw(m_events); }
 
     /// The managed SYCL event
-    std::vector<::sycl::event> m_events;
+    std::vector<cl::sycl::event> m_events;
 
 };  // struct sycl_event
 
@@ -40,7 +40,7 @@ namespace details {
 
 struct async_copy_data {
     queue_wrapper m_queue;
-    std::vector<::sycl::event> m_events;
+    std::vector<cl::sycl::event> m_events;
 };
 
 }  // namespace details

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -302,8 +302,8 @@ TEST_F(sycl_containers_test, atomic_local_ref) {
     cl::sycl::queue queue;
 
     // Skip test if not running on a gpu.
-    if (queue.get_device().get_info<::sycl::info::device::device_type>() !=
-        ::sycl::info::device_type::gpu) {
+    if (queue.get_device().get_info<cl::sycl::info::device::device_type>() !=
+        cl::sycl::info::device_type::gpu) {
         GTEST_SKIP();
     }
 


### PR DESCRIPTION
This is to make our project work correctly with [OpenSYCL 0.9.4](https://github.com/OpenSYCL/OpenSYCL/releases/tag/v0.9.4). (Formerly known as the artist [hipSYCL](https://github.com/OpenSYCL/OpenSYCL).)

As it turns out, we've been using the "SYCL namespace" a bit too loosely lately. :frowning: The SYCL2020 standard is actually fairly clear on what one should do.

https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:headers-and-namespaces

  - When using `<CL/sycl.hpp>`, you need to use the `::cl::sycl` namespace;
  - and with `<sycl/sycl.hpp>` you need to use the `::sycl` namespace.

The Intel implementation is quite forgiving with this, it provides all types in both the `::cl::sycl` and `::sycl` namespaces in all cases. But OpenSYCL rather goes for the following strict setup:

| Header | Namespace |
|---|---|
| `<CL/sycl.hpp>` | `::cl::sycl` |
| `<sycl/sycl.hpp>` | `::sycl` |
| `<hipSYCL/sycl.hpp>` | `::hipsycl` |

With all this in mind, since `<CL/sycl.hpp>` + `::cl::sycl` are the things supported since the earliest times, I went with those in our code. :thinking: (We could go for the `<sycl/sycl.hpp>` + `::sycl` combination in the future at one point, once SYCL2020 becomes the minimum that we would support.)

I also made sure that when no [oneAPI printf](https://intel.github.io/llvm-docs/doxygen/namespacesycl_1_1__V1_1_1ext_1_1oneapi_1_1experimental.html#a087ad354789a1bc1659c7bbea1f5a3f3) function is available, the standard [::printf](https://en.cppreference.com/w/cpp/io/c/fprintf) function could be used correctly at least in host code during SYCL code compilation. To make this work I had to fix some "actual bugs" hiding in our code...