### PR TITLE
Doxygen Improvement, main branch (2023.06.12.)

### DIFF
--- a/core/include/vecmem/containers/details/aligned_multiple_placement.hpp
+++ b/core/include/vecmem/containers/details/aligned_multiple_placement.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -35,11 +35,11 @@ namespace details {
  * Under these rules, the function would allocate a chunk of memory that looks
  * like this:
  *
- *      ┌────────────────────────────────────────────────────────────────┐
- * Byte │╭ 00      ╭ 10      ╭ 20      ╭ 30      ╭ 40      ╭ 50      ╭ 60│
- * Data │-----###IIIIIIIIIIII####LLLLLLLLLLLLLLLLSSSSSSSSSSSSSS###-------│
- * Info │╰ A  ╰ B╰ C             ╰ D             ╰ E             ╰ F     │
- *      └────────────────────────────────────────────────────────────────┘
+ *          ┌────────────────────────────────────────────────────────────────┐
+ *     Byte │╭ 00      ╭ 10      ╭ 20      ╭ 30      ╭ 40      ╭ 50      ╭ 60│
+ *     Data │-----###IIIIIIIIIIII####LLLLLLLLLLLLLLLLSSSSSSSSSSSSSS###-------│
+ *     Info │╰ A  ╰ B╰ C             ╰ D             ╰ E             ╰ F     │
+ *          └────────────────────────────────────────────────────────────────┘
  *
  * In this diagram, we see a small 64-byte memory space, with the "-" character
  * denoting memory that is unallocated, "#" denoting memory that is used as


### PR DESCRIPTION
Last week I was pointing people at the `vecmem::details::aligned_multiple_placement` function, and realised along the way that its documentation doesn't show up all too well on the generated Doxygen page. :frowning:

![image](https://github.com/acts-project/vecmem/assets/30694331/5e749a19-68b2-417a-943e-992916f13eb2)

With this change the documentation looks like:

![image](https://github.com/acts-project/vecmem/assets/30694331/8ad0f7e3-da09-4226-959f-f97c0cb340d4)

So this is just to help my OCD... :stuck_out_tongue: