### PR TITLE
Windows Warning Fixes, main branch (2023.07.03.)

### DIFF
--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -51,8 +51,27 @@ protected:
     virtual event_type create_event() const override;
 
 private:
+// Disable the warning(s) about using standard library types
+// with an exported class.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1394
+#endif  // CUDA disgnostics
+
     /// Internal data for the object
     std::unique_ptr<details::async_copy_data> m_data;
+
+// Re-enable the warning(s).
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // CUDA disgnostics
 
 };  // class async_copy
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -45,8 +45,27 @@ protected:
                            int value) const override;
 
 private:
+// Disable the warning(s) about using standard library types
+// with an exported class.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1394
+#endif  // CUDA disgnostics
+
     /// Internal data for the object
     std::unique_ptr<details::copy_data> m_data;
+
+// Re-enable the warning(s).
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // CUDA disgnostics
 
 };  // class copy
 

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,13 +18,6 @@ namespace vecmem::sycl {
 namespace details {
 class opaque_queue;
 }
-
-// Disable the warning(s) about inheriting from/using standard library types
-// with an exported class.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif  // MSVC
 
 /// Wrapper class for @c cl::sycl::queue
 ///
@@ -70,14 +63,29 @@ public:
 private:
     /// Bare pointer to the wrapped @c cl::sycl::queue object
     void* m_queue;
+
+// Disable the warning(s) about using standard library types
+// with an exported class.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic push
+#pragma nv_diag_suppress 1394
+#endif  // CUDA disgnostics
+
     /// Smart pointer to the managed @c cl::sycl::queue object
     std::unique_ptr<details::opaque_queue> m_managedQueue;
-
-};  // class queue_wrapper
-
-}  // namespace vecmem::sycl
 
 // Re-enable the warning(s).
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif  // MSVC
+#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
+#pragma nv_diagnostic pop
+#endif  // CUDA disgnostics
+
+};  // class queue_wrapper
+
+}  // namespace vecmem::sycl


### PR DESCRIPTION
MSVC and CUDA on Windows don't like it when we use an STL type member variable in an exported class. Which I absolutely want to do in these places. So ended up silencing these warnings explicitly.

Unfortunately our CI is blind to these, as all of these warnings were in the SYCL code. (And there's no good way to do a SYCL build on Windows in the CI...)

I've been trying to find a way in which I could hide the smart pointers from the class's header, but was not able to find one. 😦 So massive amounts of pre-compiler statements it is...