### PR TITLE
Bool Containers, main branch (2023.09.25.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -43,6 +43,10 @@ namespace data {
 template <typename T>
 class jagged_vector_view {
 
+    /// We cannot use boolean types.
+    static_assert(!std::is_same<typename std::remove_cv<T>::type, bool>::value,
+                  "bool is not supported in VecMem containers");
+
 public:
     /// Size type used in the class
     typedef std::size_t size_type;

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -36,6 +36,11 @@ namespace data {
 ///
 template <typename TYPE>
 class vector_view {
+
+    /// We cannot use boolean types.
+    static_assert(
+        !std::is_same<typename std::remove_cv<TYPE>::type, bool>::value,
+        "bool is not supported in VecMem containers");
 
 public:
     /// Size type used in the class


### PR DESCRIPTION
Prevent the usage of bool containers, addressing #236.

Since `vecmem::vector<bool>` cannot provide a memory block like what all other parts of the code assume, just prevent using `bool` as an element type in any container. Even if technically buffer types could function with that type. 🤔

@stephenswat, I suppose the following type of error is clear enough, right?

```
test_core_containers.cpp
C:\Users\krasz\ATLAS\vecmem\vecmem\core\include\vecmem/containers/data/vector_view.hpp(41): error C2338: static_assert failed: 'bool is not supported in VecMem containers'
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\core\test_core_containers.cpp(41): note: see reference to class template instantiation 'vecmem::data::vector_view<const bool>' being compiled
```

(In this case coming through MSVC, just for fun. :wink:)