### PR TITLE
Warning Suppression Removal, main branch (2023.10.25.)

### DIFF
--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,11 +24,15 @@ namespace vecmem::cuda {
 /// right order, and they would finish before an operation that needs them
 /// is executed.
 ///
-class VECMEM_CUDA_EXPORT async_copy : public vecmem::copy {
+class async_copy : public vecmem::copy {
 
 public:
     /// Constructor with the stream to operate on
+    VECMEM_CUDA_EXPORT
     async_copy(const stream_wrapper& stream);
+    /// Destructor
+    VECMEM_CUDA_EXPORT
+    ~async_copy();
 
 protected:
     /// Perform an asynchronous memory copy using CUDA

--- a/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
+++ b/cuda/include/vecmem/utils/cuda/stream_wrapper.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,53 +21,51 @@ namespace details {
 class opaque_stream;
 }
 
-// Disable the warning(s) about inheriting from/using standard library types
-// with an exported class.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 1394
-#endif  // CUDA disgnostics
-
 /// Wrapper class for @c cudaStream_t
 ///
 /// It is necessary for passing around CUDA stream objects in code that should
 /// not be directly exposed to the CUDA header(s).
 ///
-class VECMEM_CUDA_EXPORT stream_wrapper {
+class stream_wrapper {
 
 public:
     /// Invalid/default device identifier
     static constexpr int INVALID_DEVICE = -1;
 
     /// Construct a new stream (for the specified device)
+    VECMEM_CUDA_EXPORT
     stream_wrapper(int device = INVALID_DEVICE);
     /// Wrap an existing @c cudaStream_t object
     ///
     /// Without taking ownership of it!
     ///
+    VECMEM_CUDA_EXPORT
     stream_wrapper(void* stream);
 
     /// Copy constructor
+    VECMEM_CUDA_EXPORT
     stream_wrapper(const stream_wrapper& parent);
     /// Move constructor
+    VECMEM_CUDA_EXPORT
     stream_wrapper(stream_wrapper&& parent);
 
     /// Destructor
+    VECMEM_CUDA_EXPORT
     ~stream_wrapper();
 
     /// Copy assignment
+    VECMEM_CUDA_EXPORT
     stream_wrapper& operator=(const stream_wrapper& rhs);
     /// Move assignment
+    VECMEM_CUDA_EXPORT
     stream_wrapper& operator=(stream_wrapper&& rhs);
 
     /// Access a typeless pointer to the managed @c cudaStream_t object
+    VECMEM_CUDA_EXPORT
     void* stream() const;
 
     /// Wait for all queued tasks from the stream to complete
+    VECMEM_CUDA_EXPORT
     void synchronize();
 
 private:
@@ -80,11 +78,3 @@ private:
 
 }  // namespace cuda
 }  // namespace vecmem
-
-// Re-enable the warning(s).
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic pop
-#endif  // CUDA disgnostics

--- a/cuda/src/utils/cuda/async_copy.cpp
+++ b/cuda/src/utils/cuda/async_copy.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -56,6 +56,8 @@ static const std::string copy_type_printer[copy::type::count] = {
     "unknown"};
 
 async_copy::async_copy(const stream_wrapper& stream) : m_stream(stream) {}
+
+async_copy::~async_copy() {}
 
 void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                          type::copy_type cptype) const {

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -32,12 +32,14 @@ struct async_copy_data;
 /// asynchronously, requiring users to introduce synchronisation points
 /// explicitly into their code as needed.
 ///
-class VECMEM_SYCL_EXPORT async_copy : public vecmem::copy {
+class async_copy : public vecmem::copy {
 
 public:
     /// Constructor on top of a user-provided queue
+    VECMEM_SYCL_EXPORT
     async_copy(const queue_wrapper& queue);
     /// Destructor
+    VECMEM_SYCL_EXPORT
     ~async_copy();
 
 protected:
@@ -51,27 +53,8 @@ protected:
     virtual event_type create_event() const override;
 
 private:
-// Disable the warning(s) about using standard library types
-// with an exported class.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 1394
-#endif  // CUDA disgnostics
-
     /// Internal data for the object
     std::unique_ptr<details::async_copy_data> m_data;
-
-// Re-enable the warning(s).
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic pop
-#endif  // CUDA disgnostics
 
 };  // class async_copy
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -28,12 +28,14 @@ struct copy_data;
 /// @c cl::sycl::queue object. So this object needs to point to a valid
 /// queue object itself.
 ///
-class VECMEM_SYCL_EXPORT copy : public vecmem::copy {
+class copy : public vecmem::copy {
 
 public:
     /// Constructor on top of a user-provided queue
+    VECMEM_SYCL_EXPORT
     copy(const queue_wrapper& queue);
     /// Destructor
+    VECMEM_SYCL_EXPORT
     ~copy();
 
 protected:
@@ -45,27 +47,8 @@ protected:
                            int value) const override;
 
 private:
-// Disable the warning(s) about using standard library types
-// with an exported class.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 1394
-#endif  // CUDA disgnostics
-
     /// Internal data for the object
     std::unique_ptr<details::copy_data> m_data;
-
-// Re-enable the warning(s).
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic pop
-#endif  // CUDA disgnostics
 
 };  // class copy
 

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -24,20 +24,24 @@ class opaque_queue;
 /// It is necessary for passing around SYCL queue objects in code that should
 /// not be directly exposed to the SYCL headers.
 ///
-class VECMEM_SYCL_EXPORT queue_wrapper {
+class queue_wrapper {
 
 public:
     /// Construct a queue for the default device
+    VECMEM_SYCL_EXPORT
     queue_wrapper();
     /// Wrap an existing @c cl::sycl::queue object
     ///
     /// Without taking ownership of it!
     ///
+    VECMEM_SYCL_EXPORT
     queue_wrapper(void* queue);
 
     /// Copy constructor
+    VECMEM_SYCL_EXPORT
     queue_wrapper(const queue_wrapper& parent);
     /// Move constructor
+    VECMEM_SYCL_EXPORT
     queue_wrapper(queue_wrapper&& parent);
 
     /// Destructor
@@ -48,43 +52,29 @@ public:
     /// @c vecmem::sycl::details::opaque_queue not being available in
     /// client code.
     ///
+    VECMEM_SYCL_EXPORT
     ~queue_wrapper();
 
     /// Copy assignment
+    VECMEM_SYCL_EXPORT
     queue_wrapper& operator=(const queue_wrapper& rhs);
     /// Move assignment
+    VECMEM_SYCL_EXPORT
     queue_wrapper& operator=(queue_wrapper&& rhs);
 
     /// Access a typeless pointer to the managed @c cl::sycl::queue object
+    VECMEM_SYCL_EXPORT
     void* queue();
     /// Access a typeless pointer to the managed @c cl::sycl::queue object
+    VECMEM_SYCL_EXPORT
     const void* queue() const;
 
 private:
     /// Bare pointer to the wrapped @c cl::sycl::queue object
     void* m_queue;
 
-// Disable the warning(s) about using standard library types
-// with an exported class.
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4251)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic push
-#pragma nv_diag_suppress 1394
-#endif  // CUDA disgnostics
-
     /// Smart pointer to the managed @c cl::sycl::queue object
     std::unique_ptr<details::opaque_queue> m_managedQueue;
-
-// Re-enable the warning(s).
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif  // MSVC
-#ifdef __NVCC_DIAG_PRAGMA_SUPPORT__
-#pragma nv_diagnostic pop
-#endif  // CUDA disgnostics
 
 };  // class queue_wrapper
 


### PR DESCRIPTION
Being drunk on the success of #242, narrowed the exports on more classes. This allowed the removal of all warning suppression rules from the public headers of the project.

Had to add an explicit destructor for `vecmem::cuda::async_copy`, so that client code would not need to know how to destruct the private members of the class.

Note that at this stage the only remaining warning suppression is in: https://github.com/acts-project/vecmem/blob/main/sycl/src/utils/sycl/cuda_assert_polyfill.sycl But with that being a hacky workaround to begin with, that will just stay as-is...