### PR TITLE
Multi-Alloc Fix, main branch (2023.10.31.)

### DIFF
--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -159,7 +159,7 @@ aligned_multiple_placement(vecmem::memory_resource &r, Ps... ps) {
      * parameter pack, which will determine the amount of additional space
      * we need to allocate.
      */
-    std::size_t alignment = std::max(alignof(Ts)...);
+    std::size_t alignment = vecmem::details::max(alignof(Ts)...);
 
     /*
      * Next, we pessimistically calculate the number of bytes we need. We do

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -1,12 +1,13 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
 
 // System include(s).
+#include <algorithm>
 #include <iterator>
 #include <type_traits>
 
@@ -60,6 +61,26 @@ struct conjunction<B1, Bn...>
 
 template <class... B>
 constexpr bool conjunction_v = conjunction<B...>::value;
+
+/// Find the maximum of a variadic number of elements, terminal function
+/// @tparam T The type of the (final) element
+/// @param t The value of the (final) element
+/// @return  The value of the (final) element
+template <typename T>
+auto max(T&& t) {
+    return std::forward<T>(t);
+}
+
+/// Find the maximum of a variadic number of elements, recursive function
+/// @tparam T  The type of the (next) element
+/// @tparam Ts The types of the remaining element(s)
+/// @param t   The value of the (next) element
+/// @param ts  The values of the remaining element(s)
+/// @return    The maximum of the elements
+template <typename T, typename... Ts>
+auto max(T&& t, Ts&&... ts) {
+    return std::max(std::forward<T>(t), max(std::forward<Ts>(ts)...));
+}
 
 }  // namespace details
 }  // namespace vecmem


### PR DESCRIPTION
Made the `vecmem::details::aligned_multiple_placement` function work with other than 2 arguments. As it turns out, so far no client needed to use a different number of allocations through this function. :confused: But in my tests for an SoA based EDM for [traccc](https://github.com/acts-project/traccc) (more on that once I have something usable to show...), I managed to run into this. :thinking:

Note that how much of the code style in `vecmem::details::max` comes from CoPilot, we may need to include authorship credits for it at one point. :stuck_out_tongue: