### PR TITLE
Copy / MR Improvements, main branch (2023.11.10.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -43,6 +43,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/containers/impl/jagged_device_vector_iterator.ipp"
    "include/vecmem/containers/details/reverse_iterator.hpp"
    "include/vecmem/containers/impl/reverse_iterator.ipp"
+   # Container helper code.
+   "include/vecmem/containers/details/resize_jagged_vector.hpp"
    # Allocator
    "include/vecmem/memory/allocator.hpp"
    "include/vecmem/memory/impl/allocator.ipp"

--- a/core/include/vecmem/containers/details/resize_jagged_vector.hpp
+++ b/core/include/vecmem/containers/details/resize_jagged_vector.hpp
@@ -1,0 +1,41 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/jagged_vector.hpp"
+#include "vecmem/containers/vector.hpp"
+
+namespace vecmem::details {
+
+/// Resize a generic jagged vector
+///
+/// It does exactly what @c std::vector::resize does.
+///
+/// @param vec The vector to resize
+/// @param size The size to resize the jagged vector to
+///
+template <typename T, typename ALLOC1, typename ALLOC2>
+void resize_jagged_vector(std::vector<std::vector<T, ALLOC1>, ALLOC2>& vec,
+                          std::size_t size) {
+    vec.resize(size);
+}
+
+/// Resize a vecmem jagged vector
+///
+/// It makes sure that all of the "internal" vectors would use the same memory
+/// resource as the "external" one does.
+///
+/// @param vec The vector to resize
+/// @param size The size to resize the jagged vector to
+///
+template <typename T>
+void resize_jagged_vector(jagged_vector<T>& vec, std::size_t size) {
+    vec.resize(size, vecmem::vector<T>(vec.get_allocator().resource()));
+}
+
+}  // namespace vecmem::details

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -8,6 +8,7 @@
 #pragma once
 
 // VecMem include(s).
+#include "vecmem/containers/details/resize_jagged_vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/memory/host_memory_resource.hpp"
 #include "vecmem/utils/debug.hpp"
@@ -314,7 +315,7 @@ copy::event_type copy::operator()(
                   "Can only use compatible types in the copy");
 
     // Resize the output object to the correct size.
-    to_vec.resize(from_view.size());
+    details::resize_jagged_vector(to_vec, from_view.size());
     const auto sizes = get_sizes(from_view);
     assert(sizes.size() == to_vec.size());
     for (typename data::jagged_vector_view<TYPE1>::size_type i = 0;

--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -36,12 +36,15 @@ public:
 
 protected:
     /// Perform an asynchronous memory copy using CUDA
+    VECMEM_CUDA_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) const override;
     /// Fill a memory area using CUDA asynchronously
+    VECMEM_CUDA_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
                            int value) const override;
     /// Create an event for synchronization
+    VECMEM_CUDA_EXPORT
     virtual event_type create_event() const override;
 
 private:

--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -38,14 +38,14 @@ protected:
     /// Perform an asynchronous memory copy using CUDA
     VECMEM_CUDA_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override;
+                         type::copy_type cptype) const override final;
     /// Fill a memory area using CUDA asynchronously
     VECMEM_CUDA_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override;
+                           int value) const override final;
     /// Create an event for synchronization
     VECMEM_CUDA_EXPORT
-    virtual event_type create_event() const override;
+    virtual event_type create_event() const override final;
 
 private:
     /// The stream that the copies are performed on

--- a/cuda/include/vecmem/utils/cuda/copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/copy.hpp
@@ -19,10 +19,10 @@ class VECMEM_CUDA_EXPORT copy : public vecmem::copy {
 protected:
     /// Perform a memory copy using CUDA
     virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override;
+                         type::copy_type cptype) const override final;
     /// Fill a memory area using CUDA
     virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override;
+                           int value) const override final;
 
 };  // class copy
 

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -35,16 +35,17 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_HIP_EXPORT
-    void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+    virtual void* do_allocate(std::size_t nbytes,
+                              std::size_t alignment) override final;
 
     /// Function performing the memory de-allocation
     VECMEM_HIP_EXPORT
-    void do_deallocate(void* ptr, std::size_t nbytes,
-                       std::size_t alignment) override final;
+    virtual void do_deallocate(void* ptr, std::size_t nbytes,
+                               std::size_t alignment) override final;
 
     /// Function comparing two memory resource instances
     VECMEM_HIP_EXPORT
-    bool do_is_equal(
+    virtual bool do_is_equal(
         const memory_resource& other) const noexcept override final;
 
     /// @}

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -31,16 +31,17 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_HIP_EXPORT
-    void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+    virtual void* do_allocate(std::size_t nbytes,
+                              std::size_t alignment) override final;
 
     /// Function performing the memory de-allocation
     VECMEM_HIP_EXPORT
-    void do_deallocate(void* ptr, std::size_t nbytes,
-                       std::size_t alignment) override final;
+    virtual void do_deallocate(void* ptr, std::size_t nbytes,
+                               std::size_t alignment) override final;
 
     /// Function comparing two memory resource instances
     VECMEM_HIP_EXPORT
-    bool do_is_equal(
+    virtual bool do_is_equal(
         const memory_resource& other) const noexcept override final;
 
     /// @}

--- a/hip/include/vecmem/utils/hip/copy.hpp
+++ b/hip/include/vecmem/utils/hip/copy.hpp
@@ -19,10 +19,10 @@ class VECMEM_HIP_EXPORT copy : public vecmem::copy {
 protected:
     /// Perform a memory copy using HIP
     virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override;
+                         type::copy_type cptype) const override final;
     /// Fill a memory area using HIP
     virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override;
+                           int value) const override final;
 
 };  // class copy
 

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -39,12 +39,12 @@ private:
 
     /// Function performing the memory de-allocation
     VECMEM_SYCL_EXPORT
-    void do_deallocate(void* ptr, std::size_t nbytes,
-                       std::size_t alignment) override final;
+    virtual void do_deallocate(void* ptr, std::size_t nbytes,
+                               std::size_t alignment) override final;
 
     /// Function comparing two memory resource instances
     VECMEM_SYCL_EXPORT
-    bool do_is_equal(
+    virtual bool do_is_equal(
         const memory_resource& other) const noexcept override final;
 
     /// @}

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -32,7 +32,8 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+    virtual void* do_allocate(std::size_t nbytes,
+                              std::size_t alignment) override final;
 
     /// @}
 

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -31,7 +31,8 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+    virtual void* do_allocate(std::size_t nbytes,
+                              std::size_t alignment) override final;
 
     /// @}
 

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -31,7 +31,8 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    void* do_allocate(std::size_t nbytes, std::size_t alignment) override final;
+    virtual void* do_allocate(std::size_t nbytes,
+                              std::size_t alignment) override final;
 
     /// @}
 

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -44,12 +44,15 @@ public:
 
 protected:
     /// Perform a memory copy using SYCL
+    VECMEM_SYCL_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) const override;
     /// Fill a memory area using SYCL
+    VECMEM_SYCL_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
                            int value) const override;
     /// Create an event for synchronization
+    VECMEM_SYCL_EXPORT
     virtual event_type create_event() const override;
 
 private:

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -46,14 +46,14 @@ protected:
     /// Perform a memory copy using SYCL
     VECMEM_SYCL_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override;
+                         type::copy_type cptype) const override final;
     /// Fill a memory area using SYCL
     VECMEM_SYCL_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override;
+                           int value) const override final;
     /// Create an event for synchronization
     VECMEM_SYCL_EXPORT
-    virtual event_type create_event() const override;
+    virtual event_type create_event() const override final;
 
 private:
     /// Internal data for the object

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -40,9 +40,11 @@ public:
 
 protected:
     /// Perform a memory copy using SYCL
+    VECMEM_SYCL_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
                          type::copy_type cptype) const override;
     /// Fill a memory area using SYCL
+    VECMEM_SYCL_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
                            int value) const override;
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -42,11 +42,11 @@ protected:
     /// Perform a memory copy using SYCL
     VECMEM_SYCL_EXPORT
     virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override;
+                         type::copy_type cptype) const override final;
     /// Fill a memory area using SYCL
     VECMEM_SYCL_EXPORT
     virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override;
+                           int value) const override final;
 
 private:
     /// Internal data for the object

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -424,7 +424,8 @@ TEST_F(sycl_jagged_containers_test, filter) {
         .wait_and_throw();
 
     // Copy the filtered output back into the host's memory.
-    vecmem::jagged_vector<int> output(&m_mem);
+    vecmem::sycl::host_memory_resource host_resource(&m_queue);
+    vecmem::jagged_vector<int> output(&host_resource);
     copy(output_data_device, output)->wait();
 
     // Check the output. Note that the order of elements in the "inner vectors"


### PR DESCRIPTION
I ran into a few things while trying to make things work inside of WSL2 with oneAPI's NVIDIA backend.
  - For some reason GCC 9 in Ubuntu 20.04 in WSL2 has an issue with the symbols of the virtual functions on the copy types not being exported. 😕 Very strange given that we haven't seen issues with this in any other place. (It's a question of whether the compiler is smart enough to know at compile time which function it would have to call, relying on `override` and `final` declarations.)
  - I kept seeing a crash in one of the SYCL tests that just didn't give me a usable/understandable backtrace. 😦 In the end it turned out to be an issue with asynchronous memory copies into SYCL shared memory.
    * But while hunting for the issue, I ended up making copies into host jagged vectors a little smarter. (Thinking that this may be the issue behind the crash.) Ensuring that the output jagged vector of a copy would use the same memory resource for all of its `std::vector` components.

While at it, I also made sure that all virtual functions on the `vecmem::copy` and memory resource classes would use the same set of keywords. Adding `virtual` and `final` in places where they were missing before. (The first one is just a stylistic thing, but the added `final` keywords may help slightly in some cases.)