### PR TITLE
SYCL Build Dependency Generation (2023.12.02.)

### DIFF
--- a/cmake/sycl/Platform/Linux-ComputeCpp-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-ComputeCpp-SYCL.cmake
@@ -1,12 +1,20 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
 # Use the standard GNU compiler options for ComputeCpp.
 include( Platform/Linux-GNU )
 __linux_compiler_gnu( SYCL )
+include( Compiler/GNU )
+__compiler_gnu( SYCL )
+
+# Set up the dependency file generation for this platform. Note that SYCL
+# compilation only works with Makefile and Ninja generators, so no check is made
+# here for the current generator.
+set( CMAKE_SYCL_DEPENDS_USE_COMPILER TRUE )
+set( CMAKE_SYCL_DEPFILE_FORMAT gcc )
 
 # Set a compiler command from scratch for this platform.
 set( CMAKE_SYCL_COMPILE_OBJECT

--- a/cmake/sycl/Platform/Linux-hipSYCL-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-hipSYCL-SYCL.cmake
@@ -1,12 +1,20 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
-# Use the standard GNU compiler options for ComputeCpp.
+# Use the standard GNU compiler options for hipSYCL.
 include( Platform/Linux-GNU )
 __linux_compiler_gnu( SYCL )
+include( Compiler/GNU )
+__compiler_gnu( SYCL )
+
+# Set up the dependency file generation for this platform. Note that SYCL
+# compilation only works with Makefile and Ninja generators, so no check is made
+# here for the current generator.
+set( CMAKE_SYCL_DEPENDS_USE_COMPILER TRUE )
+set( CMAKE_SYCL_DEPFILE_FORMAT gcc )
 
 # Set an archive (static library) creation command explicitly for this platform.
 set( CMAKE_SYCL_CREATE_STATIC_LIBRARY

--- a/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Windows-IntelLLVM-SYCL.cmake
@@ -6,9 +6,17 @@
 
 # CMake include(s).
 include( Platform/Windows-IntelLLVM )
+include( Compiler/IntelLLVM )
 
 # Set up the variables specifying the command line arguments of the compiler.
 __windows_compiler_intel( SYCL )
+__compiler_intel_llvm( SYCL )
+
+# Set up the dependency file generation for this platform. Note that SYCL
+# compilation only works with Makefile and Ninja generators, so no check is made
+# here for the current generator.
+set( CMAKE_SYCL_DEPENDS_USE_COMPILER TRUE )
+set( CMAKE_SYCL_DEPFILE_FORMAT gcc )
 
 # With CMake 3.27 by default CMake would try to add version information into
 # the DLL file names. Confusing the linking process.


### PR DESCRIPTION
By accident I stumbled upon something that fixes **the biggest** problem with our SYCL build setup. That SYCL compilation doesn't respect/track header file changes.

As it turns out, in CMake 3.20 it became possible to leave dependency file generation up to the compiler(s). Without teaching the CMake C\+\+ code about a new language. But one needs to be explicit about it.

At the same time included some further configuration for the SYCL compilers from standard CMake include files. Since the `Compiler/...` includes are the ones defining the `CMAKE_DEPFILE_FLAGS_SYCL` variables for us. (Which are the flags that CMake adds to the build to generate the dependency files.)

Relevant documentation page is: https://cmake.org/cmake/help/latest/variable/CMAKE_DEPENDS_USE_COMPILER.html Everything else I learned by reading through the CMake code...

And yes, it even works on Windows. :smile: