### PR TITLE
Extra Utility Types, main branch (2023.12.05.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -124,6 +124,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/utils/debug.hpp"
    "src/utils/memory_monitor.cpp"
    "include/vecmem/utils/memory_monitor.hpp"
+   "include/vecmem/utils/tuple.hpp"
+   "include/vecmem/utils/impl/tuple.ipp"
    "include/vecmem/utils/type_traits.hpp"
    "include/vecmem/utils/types.hpp" )
 

--- a/core/include/vecmem/utils/impl/tuple.ipp
+++ b/core/include/vecmem/utils/impl/tuple.ipp
@@ -1,0 +1,92 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// System include(s).
+#include <cstddef>
+#include <type_traits>
+
+namespace vecmem {
+namespace details {
+
+/// Struct used to implement @c vecmem::get in a C++14 style
+///
+/// @tparam I The index of the tuple element to get
+///
+template <std::size_t I>
+struct tuple_get_impl {
+
+    /// Get the I-th (const) tuple element recursively
+    template <typename... Ts>
+    VECMEM_HOST_AND_DEVICE static constexpr const auto &get(
+        const tuple<Ts...> &t) {
+        return tuple_get_impl<I - 1>::get(t.m_tail);
+    }
+    /// Get the I-th (non-const) tuple element recursively
+    template <typename... Ts>
+    VECMEM_HOST_AND_DEVICE static constexpr auto &get(tuple<Ts...> &t) {
+        return tuple_get_impl<I - 1>::get(t.m_tail);
+    }
+
+};  // struct tuple_get_impl
+
+/// Specialization of @c vecmem::details::tuple_get_impl for the 0th element
+template <>
+struct tuple_get_impl<0> {
+
+    /// Get the first (const) tuple element
+    template <typename... Ts>
+    VECMEM_HOST_AND_DEVICE static constexpr const auto &get(
+        const tuple<Ts...> &t) {
+        return t.m_head;
+    }
+    /// Get the first (non-const) tuple element
+    template <typename... Ts>
+    VECMEM_HOST_AND_DEVICE static constexpr auto &get(tuple<Ts...> &t) {
+        return t.m_head;
+    }
+
+};  // struct tuple_get_impl
+
+}  // namespace details
+
+template <std::size_t I, typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr const auto &get(
+    const tuple<Ts...> &t) noexcept {
+
+    // Make sure that the requested index is valid.
+    static_assert(I < sizeof...(Ts),
+                  "Attempt to access index greater than tuple size.");
+
+    // Return the correct element using the helper struct.
+    return details::tuple_get_impl<I>::get(t);
+}
+
+template <std::size_t I, typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr auto &get(tuple<Ts...> &t) noexcept {
+
+    // Make sure that the requested index is valid.
+    static_assert(I < sizeof...(Ts),
+                  "Attempt to access index greater than tuple size.");
+
+    // Return the correct element using the helper struct.
+    return details::tuple_get_impl<I>::get(t);
+}
+
+template <typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr tuple<Ts &...> tie(Ts &... args) {
+
+    return tuple<Ts &...>(args...);
+}
+
+template <class... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr tuple<typename std::decay<Ts>::type...>
+make_tuple(Ts &&... args) {
+    return tuple<typename std::decay<Ts>::type...>{std::forward<Ts>(args)...};
+}
+
+}  // namespace vecmem

--- a/core/include/vecmem/utils/tuple.hpp
+++ b/core/include/vecmem/utils/tuple.hpp
@@ -1,0 +1,160 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/utils/type_traits.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace vecmem {
+
+/// Default tuple type
+///
+/// Serving as the final node in the recursive implementation of this tuple
+/// type.
+///
+template <typename... Ts>
+struct tuple {
+
+    // As long as we did everything correctly, this should only get instantiated
+    // with an empty parameter list, for the implementation to work correctly.
+    static_assert(sizeof...(Ts) == 0,
+                  "There's a coding error in vecmem::tuple!");
+
+    /// Default constructor for the default tuple type
+    constexpr tuple() = default;
+
+};  // struct tuple
+
+/// Simple tuple implementation for the vecmem EDM classes
+///
+/// The vecmem EDM classes require something analogous to @c std::tuple,
+/// but that type is not officially supported by CUDA in device code. Worse yet,
+/// @c std::tuple actively generates invalid code with @c nvcc at the time of
+/// writing (up to CUDA 12.3.0).
+///
+/// This is a very simple implementation for a tuple type, which can do exactly
+/// as much as we need from it.
+///
+/// @tparam T     The first type to be stored in the tuple
+/// @tparam ...Ts The rest of the types to be stored in the tuple
+///
+template <typename T, typename... Ts>
+struct tuple<T, Ts...> {
+
+    /// Default constructor
+    constexpr tuple() = default;
+
+    /// Copy constructor
+    ///
+    /// @param parent The parent to copy
+    ///
+    template <typename U, typename... Us,
+              std::enable_if_t<sizeof...(Ts) == sizeof...(Us), bool> = true>
+    VECMEM_HOST_AND_DEVICE constexpr tuple(const tuple<U, Us...> &parent)
+        : m_head(parent.m_head), m_tail(parent.m_tail) {}
+
+    /// Main constructor, from a list of tuple elements
+    ///
+    /// @param head The first element to be stored in the tuple
+    /// @param tail The rest of the elements to be stored in the tuple
+    ///
+    template <typename U, typename... Us,
+              std::enable_if_t<vecmem::details::conjunction<
+                                   std::is_constructible<T, U &&>,
+                                   std::is_constructible<Ts, Us &&>...>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE constexpr tuple(U &&head, Us &&... tail)
+        : m_head(std::forward<U>(head)), m_tail(std::forward<Us>(tail)...) {}
+
+    /// The first/head element of the tuple
+    T m_head;
+    /// The rest of the tuple elements
+    tuple<Ts...> m_tail;
+
+};  // struct tuple
+
+/// @name Utility functions for @c vecmem::tuple
+/// @{
+
+/// Get a constant element out of a tuple
+///
+/// @tparam I The index of the element to get
+/// @tparam ...Ts The types held by the tuple
+/// @param t The tuple to get the element from
+/// @return The I-th element of the tuple
+///
+template <std::size_t I, typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr const auto &get(
+    const tuple<Ts...> &t) noexcept;
+
+/// Get a non-constant element out of a tuple
+///
+/// @tparam I The index of the element to get
+/// @tparam ...Ts The types held by the tuple
+/// @param t The tuple to get the element from
+/// @return The I-th element of the tuple
+///
+template <std::size_t I, typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr auto &get(tuple<Ts...> &t) noexcept;
+
+/// Tie references to existing objects, into a tuple
+///
+/// @tparam ...Ts Types to refer to with the resulting tuple
+/// @param ...args References to the objects that the tuple should point to
+/// @return A tuple of references to some existing objects
+///
+template <typename... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr tuple<Ts &...> tie(Ts &... args);
+
+/// Make a tuple with automatic type deduction
+///
+/// @tparam ...Ts Types deduced for the resulting tuple
+/// @param args   Values to make a tuple out of
+/// @return A tuple constructed from the received values
+///
+template <class... Ts>
+VECMEM_HOST_AND_DEVICE inline constexpr tuple<typename std::decay<Ts>::type...>
+make_tuple(Ts &&... args);
+
+/// Default/empty implementation for @c vecmem::tuple_element
+///
+/// @tparam T Dummy template argument
+/// @tparam I Dummy index argument
+///
+template <std::size_t I, class T>
+struct tuple_element;
+
+/// Get the type of the I-th element of a tuple
+///
+/// @tparam ...Ts The element types in the tuple
+/// @tparam I     Index of the element to get the type of
+///
+template <std::size_t I, typename... Ts>
+struct tuple_element<I, tuple<Ts...>> {
+
+    /// Type of the I-th element of the specified tuple
+    using type = std::decay_t<decltype(get<I>(std::declval<tuple<Ts...>>()))>;
+};
+
+/// Convenience accessor for the I-th element of a tuple
+///
+/// @tparam T The type of the tuple to investigate
+/// @tparam I Index of the element to get the type of
+///
+template <std::size_t I, class T>
+using tuple_element_t = typename tuple_element<I, T>::type;
+
+/// @}
+
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/utils/impl/tuple.ipp"

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -62,6 +62,37 @@ struct conjunction<B1, Bn...>
 template <class... B>
 constexpr bool conjunction_v = conjunction<B...>::value;
 
+/// Implementation for @c std::disjunction
+///
+/// Since @c std::disjunction is only available starting with C++17, but it
+/// comes in very handy in some places in the VecMem code, this is a naive
+/// custom implementation for it.
+///
+template <class...>
+struct disjunction : std::false_type {};
+
+template <class B1>
+struct disjunction<B1> : B1 {};
+
+template <class B1, class... Bn>
+struct disjunction<B1, Bn...>
+    : std::conditional_t<bool(B1::value), B1, disjunction<Bn...>> {};
+
+template <class... B>
+constexpr bool disjunction_v = disjunction<B...>::value;
+
+/// Implementation for @c std::negation
+///
+/// Since @c std::negation is only available starting with C++17, but it
+/// comes in very handy in some places in the VecMem code, this is a naive
+/// custom implementation for it.
+///
+template <class B>
+struct negation : std::integral_constant<bool, !bool(B::value)> {};
+
+template <class B>
+constexpr bool negation_v = negation<B>::value;
+
 /// Find the maximum of a variadic number of elements, terminal function
 /// @tparam T The type of the (final) element
 /// @param t The value of the (final) element

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2023 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -22,4 +22,5 @@ vecmem_add_test( core
    "test_core_debug_memory_resource.cpp"
    "test_core_unique_alloc_ptr.cpp"
    "test_core_unique_obj_ptr.cpp"
+   "test_core_tuple.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_tuple.cpp
+++ b/tests/core/test_core_tuple.cpp
@@ -1,0 +1,88 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/utils/tuple.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <type_traits>
+
+TEST(core_tuple_test, set_get) {
+
+    // Construct trivial tuples in a few different ways.
+    vecmem::tuple<int, float, double> t1;
+    (void)t1;
+    vecmem::tuple<float, int> t2{2.f, 3};
+    vecmem::tuple<double, int> t3{t2};  // Type mismatch on purpose!
+
+    // Get/set elements in those tuples.
+    EXPECT_FLOAT_EQ(vecmem::get<0>(t2), 2.f);
+    EXPECT_EQ(vecmem::get<1>(t2), 3);
+
+    vecmem::get<0>(t3) = 4.;
+    vecmem::get<1>(t3) = 6;
+    EXPECT_DOUBLE_EQ(vecmem::get<0>(t3), 4.f);
+    EXPECT_EQ(vecmem::get<1>(t3), 6);
+}
+
+TEST(core_tuple_test, tie) {
+
+    // Exercise vecmem::tie(...).
+    int value1 = 0;
+    float value2 = 1.f;
+    double value3 = 2.;
+
+    auto t = vecmem::tie(value1, value2, value3);
+    EXPECT_EQ(vecmem::get<0>(t), 0);
+    EXPECT_FLOAT_EQ(vecmem::get<1>(t), 1.f);
+    EXPECT_DOUBLE_EQ(vecmem::get<2>(t), 2.);
+
+    vecmem::get<0>(t) = 3;
+    vecmem::get<1>(t) = 4.f;
+    vecmem::get<2>(t) = 5.;
+    EXPECT_EQ(value1, 3);
+    EXPECT_FLOAT_EQ(value2, 4.f);
+    EXPECT_DOUBLE_EQ(value3, 5.);
+}
+
+TEST(core_tuple_test, element) {
+
+    // Exercise vecmem::tuple_element.
+    static constexpr bool type_check1 = std::is_same_v<
+        vecmem::tuple_element<1, vecmem::tuple<int, float, double>>::type,
+        float>;
+    EXPECT_TRUE(type_check1);
+    static constexpr bool type_check2 = std::is_same_v<
+        vecmem::tuple_element_t<2, vecmem::tuple<int, float, double>>, double>;
+    EXPECT_TRUE(type_check2);
+}
+
+TEST(core_tuple_test, make) {
+
+    // Exercise vecmem::make_tuple(...).
+    auto t = vecmem::make_tuple(1, 2u, 3.f, 4.);
+    EXPECT_EQ(vecmem::get<0>(t), 1);
+    EXPECT_EQ(vecmem::get<1>(t), 2);
+    EXPECT_FLOAT_EQ(vecmem::get<2>(t), 3.f);
+    EXPECT_DOUBLE_EQ(vecmem::get<3>(t), 4.);
+
+    static constexpr bool type_check1 =
+        std::is_same_v<vecmem::tuple_element_t<0, decltype(t)>, int>;
+    EXPECT_TRUE(type_check1);
+    static constexpr bool type_check2 =
+        std::is_same_v<vecmem::tuple_element_t<1, decltype(t)>, unsigned int>;
+    EXPECT_TRUE(type_check2);
+    static constexpr bool type_check3 =
+        std::is_same_v<vecmem::tuple_element_t<2, decltype(t)>, float>;
+    EXPECT_TRUE(type_check3);
+    static constexpr bool type_check4 =
+        std::is_same_v<vecmem::tuple_element_t<3, decltype(t)>, double>;
+    EXPECT_TRUE(type_check4);
+}

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -16,6 +16,7 @@
 #include "vecmem/containers/static_array.hpp"
 #include "vecmem/memory/atomic.hpp"
 #include "vecmem/memory/device_atomic_ref.hpp"
+#include "vecmem/utils/tuple.hpp"
 
 // System include(s).
 #include <cassert>
@@ -36,12 +37,15 @@ __global__ void linearTransformKernel(
     const vecmem::const_device_array<int, 2> constantarray1(constants);
     const vecmem::static_array<int, 2> constantarray2 = {constantarray1[0],
                                                          constantarray1[1]};
+    auto tuple1 = vecmem::make_tuple(constantarray1[0], constantarray1[1]);
+    auto tuple2 = vecmem::tie(constantarray1, constantarray2);
     const vecmem::const_device_vector<int> inputvec(input);
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) =
-        inputvec.at(i) * constantarray1.at(0) + vecmem::get<1>(constantarray2);
+    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) +
+                      vecmem::get<1>(constantarray2) + vecmem::get<0>(tuple1) -
+                      vecmem::get<1>(tuple2)[0];
     return;
 }
 

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -19,6 +19,7 @@
 #include "vecmem/containers/static_array.hpp"
 #include "vecmem/memory/atomic.hpp"
 #include "vecmem/memory/device_atomic_ref.hpp"
+#include "vecmem/utils/tuple.hpp"
 
 /// Kernel performing a linear transformation using the vector helper types
 __global__ void linearTransformKernel(
@@ -36,12 +37,15 @@ __global__ void linearTransformKernel(
     const vecmem::const_device_array<int, 2> constantarray1(constants);
     const vecmem::static_array<int, 2> constantarray2 = {constantarray1[0],
                                                          constantarray1[1]};
+    auto tuple1 = vecmem::make_tuple(constantarray1[0], constantarray1[1]);
+    auto tuple2 = vecmem::tie(constantarray1, constantarray2);
     const vecmem::const_device_vector<int> inputvec(input);
     vecmem::device_vector<int> outputvec(output);
 
     // Perform the linear transformation.
-    outputvec.at(i) =
-        inputvec.at(i) * constantarray1.at(0) + vecmem::get<1>(constantarray2);
+    outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) +
+                      vecmem::get<1>(constantarray2) + vecmem::get<0>(tuple1) -
+                      vecmem::get<1>(tuple2)[0];
     return;
 }
 

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -23,6 +23,7 @@
 #include "vecmem/utils/sycl/async_copy.hpp"
 #include "vecmem/utils/sycl/copy.hpp"
 #include "vecmem/utils/sycl/local_accessor.hpp"
+#include "vecmem/utils/tuple.hpp"
 
 // GoogleTest include(s).
 #include <gtest/gtest.h>
@@ -71,12 +72,17 @@ TEST_F(sycl_containers_test, shared_memory) {
                         constants);
                     const vecmem::static_array<int, 2> constantarray2 = {
                         constantarray1[0], constantarray1[1]};
+                    auto tuple1 = vecmem::make_tuple(constantarray1[0],
+                                                     constantarray1[1]);
+                    auto tuple2 = vecmem::tie(constantarray1, constantarray2);
                     const vecmem::const_device_vector<int> inputvec(input);
                     vecmem::device_vector<int> outputvec(output);
 
                     // Perform the linear transformation.
                     outputvec.at(i) = inputvec.at(i) * constantarray1.at(0) +
-                                      vecmem::get<1>(constantarray2);
+                                      vecmem::get<1>(constantarray2) +
+                                      vecmem::get<0>(tuple1) -
+                                      vecmem::get<1>(tuple2)[0];
                     return;
                 });
         })


### PR DESCRIPTION
This is step 1 in getting #246 into the repository.

Introduced `vecmem::tuple`, `vecmem::details::disjunction` and `vecmem::details::negation`. All in preparation for the SoA EDM base classes.
  - `vecmem::details::disjunction` is a stand-in for [std::disjunction](https://en.cppreference.com/w/cpp/types/disjunction) with [C++14](https://en.cppreference.com/w/cpp/14). (Which is still our minimum requirement for device code!)
  - In a similar manner, `vecmem::details::negation` is a stand-in for [std::negation](https://en.cppreference.com/w/cpp/types/negation) in device code.
  - `vecmem::tuple` is a shameless copy of [detray::tuple](https://github.com/acts-project/detray/blob/main/core/include/detray/utils/tuple.hpp). With very slight modifications for [C++14](https://en.cppreference.com/w/cpp/14) compatibility.

Not sure yet how I'll make the rest of #246 digestible, but for now let's just get this reviewed. Then we'll see about the rest. :wink: