### PR TITLE
Add SoA View and Device Classes, main branch (2023.12.06.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -61,6 +61,15 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/memory/unique_ptr.hpp"
    "include/vecmem/memory/details/is_aligned.hpp"
    "src/memory/details/is_aligned.cpp"
+   # EDM types.
+   "include/vecmem/edm/device.hpp"
+   "include/vecmem/edm/impl/device.ipp"
+   "include/vecmem/edm/view.hpp"
+   "include/vecmem/edm/impl/view.ipp"
+   "include/vecmem/edm/schema.hpp"
+   "include/vecmem/edm/details/device_traits.hpp"
+   "include/vecmem/edm/details/schema_traits.hpp"
+   "include/vecmem/edm/details/view_traits.hpp"
    #
    # Memory resources.
    #

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -68,8 +68,9 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/edm/impl/view.ipp"
    "include/vecmem/edm/schema.hpp"
    "include/vecmem/edm/details/device_traits.hpp"
-   "include/vecmem/edm/details/schema_traits.hpp"
    "include/vecmem/edm/details/view_traits.hpp"
+   "include/vecmem/edm/details/schema_traits.hpp"
+   "include/vecmem/edm/details/types.hpp"
    #
    # Memory resources.
    #

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -19,6 +19,12 @@
 
 namespace vecmem {
 
+// Forward declaration(s).
+namespace edm {
+template <typename T>
+class device;
+}
+
 /// Class mimicking an @c std::vector in "device code"
 ///
 /// This type can be used in "generic device code" as an @c std::vector that
@@ -28,6 +34,10 @@ namespace vecmem {
 ///
 template <typename TYPE>
 class device_vector {
+
+    // Make @c vecmem::edm::device a friend of this class.
+    template <typename T>
+    friend class edm::device;
 
 public:
     /// @name Type definitions, mimicking @c std::vector

--- a/core/include/vecmem/edm/details/device_traits.hpp
+++ b/core/include/vecmem/edm/details/device_traits.hpp
@@ -1,0 +1,190 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/edm/view.hpp"
+#include "vecmem/utils/tuple.hpp"
+
+// System include(s).
+#include <type_traits>
+#include <utility>
+
+namespace vecmem {
+namespace edm {
+namespace details {
+
+/// @name Traits for the device types for the individual variables
+/// @{
+
+template <typename TYPE>
+struct device_type;
+
+template <typename TYPE>
+struct device_type<type::scalar<TYPE>> {
+    using type = std::add_pointer_t<TYPE>;
+    using return_type = std::add_lvalue_reference_t<TYPE>;
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<TYPE>>;
+};  // struct device_type
+
+template <typename TYPE>
+struct device_type<type::vector<TYPE>> {
+    using type = device_vector<TYPE>;
+    using return_type = std::add_lvalue_reference_t<type>;
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+};  // struct device_type
+
+template <typename TYPE>
+struct device_type<type::jagged_vector<TYPE>> {
+    using type = jagged_device_vector<TYPE>;
+    using return_type = std::add_lvalue_reference_t<type>;
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+};  // struct device_type
+
+template <std::size_t INDEX, typename... VARTYPES>
+struct device_type_at {
+    using type =
+        typename device_type<tuple_element_t<INDEX, tuple<VARTYPES...>>>::type;
+    using return_type = typename device_type<
+        tuple_element_t<INDEX, tuple<VARTYPES...>>>::return_type;
+    using const_return_type = typename device_type<
+        tuple_element_t<INDEX, tuple<VARTYPES...>>>::const_return_type;
+};  // struct device_type_at
+
+/// @}
+
+/// @name Helper traits for the @c vecmem::edm::device::get functions
+/// @{
+
+template <typename TYPE>
+struct device_get {
+    VECMEM_HOST_AND_DEVICE
+    static constexpr typename device_type<TYPE>::return_type get(
+        typename device_type<TYPE>::type& variable) {
+
+        return variable;
+    }
+    VECMEM_HOST_AND_DEVICE
+    static constexpr typename device_type<TYPE>::const_return_type get(
+        const typename device_type<TYPE>::type& variable) {
+
+        return variable;
+    }
+};  // struct device_get
+
+template <typename TYPE>
+struct device_get<type::scalar<TYPE>> {
+    VECMEM_HOST_AND_DEVICE
+    static constexpr typename device_type<type::scalar<TYPE>>::return_type get(
+        typename device_type<type::scalar<TYPE>>::type& variable) {
+
+        return *variable;
+    }
+    VECMEM_HOST_AND_DEVICE
+    static constexpr typename device_type<type::scalar<TYPE>>::const_return_type
+    get(const typename device_type<type::scalar<TYPE>>::type& variable) {
+
+        return *variable;
+    }
+};  // struct device_get
+
+/// @}
+
+/// Check whether a scalar variable has the right capacity (always true)
+template <typename TYPE, typename SIZE_TYPE>
+VECMEM_HOST_AND_DEVICE constexpr bool device_capacity_matches(
+    SIZE_TYPE, const typename device_type<type::scalar<TYPE>>::type&) {
+    return true;
+}
+
+/// Check whether a vector variable has the right capacity
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE constexpr bool device_capacity_matches(
+    const typename device_type<type::vector<TYPE>>::type::size_type capacity,
+    const typename device_type<type::vector<TYPE>>::type& variable) {
+
+    return (capacity == variable.capacity());
+}
+
+/// Check whether a jagged vector variable has the right capacity
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE constexpr bool device_capacity_matches(
+    const typename device_type<
+        type::jagged_vector<TYPE>>::type::value_type::size_type capacity,
+    const typename device_type<type::jagged_vector<TYPE>>::type& variable) {
+
+    return (capacity == variable.capacity());
+}
+
+/// Terminal node for @c vecmem::edm::details::device_capacities_match
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE constexpr bool device_capacities_match(
+    const typename view<schema<VARTYPES...>>::size_type,
+    const tuple<typename device_type<VARTYPES>::type...>&,
+    std::index_sequence<>) {
+
+    return true;
+}
+
+/// Helper function checking the capacities of all variables against a reference
+///
+/// This is only used in assertions in the code, to make sure that there would
+/// be no coding mistakes with setting up the individual variables.
+///
+template <typename... VARTYPES, std::size_t INDEX, std::size_t... INDICES>
+VECMEM_HOST_AND_DEVICE constexpr bool device_capacities_match(
+    const typename view<schema<VARTYPES...>>::size_type capacity,
+    const tuple<typename device_type<VARTYPES>::type...>& variables,
+    std::index_sequence<INDEX, INDICES...>) {
+
+    // Check the capacities recursively.
+    return device_capacity_matches<
+               typename tuple_element_t<INDEX, tuple<VARTYPES...>>::type>(
+               capacity, get<INDEX>(variables)) &&
+           device_capacities_match<VARTYPES...>(
+               capacity, variables, std::index_sequence<INDICES...>{});
+}
+
+/// Helper trait for setting the @c m_size variable of a device object
+template <typename SCHEMA, bool HAS_JAGGED_VECTOR>
+struct device_size_pointer;
+
+/// Helper trait for setting the @c m_size variable of a device object
+/// (for a "jagged schema")
+template <typename SCHEMA>
+struct device_size_pointer<SCHEMA, true> {
+    VECMEM_HOST_AND_DEVICE static constexpr typename view<SCHEMA>::size_pointer
+    get(const typename view<SCHEMA>::memory_view_type&) {
+
+        return nullptr;
+    }
+};
+
+/// Helper trait for setting the @c m_size variable of a device object
+/// (for a "non-jagged schema")
+template <typename SCHEMA>
+struct device_size_pointer<SCHEMA, false> {
+    VECMEM_HOST_AND_DEVICE static constexpr typename view<SCHEMA>::size_pointer
+    get(const typename view<SCHEMA>::memory_view_type& v) {
+
+        // A sanity check.
+        assert((v.ptr() == nullptr) ||
+               (v.size() == sizeof(typename view<SCHEMA>::size_type)));
+        // Do a forceful conversion.
+        return reinterpret_cast<typename view<SCHEMA>::size_pointer>(v.ptr());
+    }
+};
+
+}  // namespace details
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/details/schema_traits.hpp
+++ b/core/include/vecmem/edm/details/schema_traits.hpp
@@ -1,0 +1,150 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/utils/type_traits.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace vecmem {
+namespace edm {
+namespace type {
+namespace details {
+
+/// @name Traits turning variable types into constant types
+/// @{
+
+template <typename T>
+struct add_const;
+
+template <typename TYPE>
+struct add_const<type::scalar<TYPE>> {
+    using type = type::scalar<std::add_const_t<TYPE>>;
+};  // struct add_const
+
+template <typename TYPE>
+struct add_const<type::vector<TYPE>> {
+    using type = type::vector<std::add_const_t<TYPE>>;
+};  // struct add_const
+
+template <typename TYPE>
+struct add_const<type::jagged_vector<TYPE>> {
+    using type = type::jagged_vector<std::add_const_t<TYPE>>;
+};  // struct add_const
+
+template <typename T>
+using add_const_t = typename add_const<T>::type;
+
+/// @}
+
+/// @name Traits checking the type of a variable
+/// @{
+
+template <typename T>
+struct is_scalar {
+    static constexpr bool value = false;
+};  // struct is_scalar
+
+template <typename TYPE>
+struct is_scalar<type::scalar<TYPE>> {
+    static constexpr bool value = true;
+};  // struct is_scalar
+
+template <typename T>
+constexpr bool is_scalar_v = is_scalar<T>::value;
+
+template <typename T>
+struct is_vector {
+    static constexpr bool value = false;
+};  // struct is_vector
+
+template <typename TYPE>
+struct is_vector<type::vector<TYPE>> {
+    static constexpr bool value = true;
+};  // struct is_vector
+
+template <typename TYPE>
+struct is_vector<type::jagged_vector<TYPE>> {
+    static constexpr bool value = true;
+};  // struct is_vector
+
+template <typename T>
+constexpr bool is_vector_v = is_vector<T>::value;
+
+template <typename T>
+struct is_jagged_vector {
+    static constexpr bool value = false;
+};  // struct is_jagged_vector
+
+template <typename TYPE>
+struct is_jagged_vector<type::jagged_vector<TYPE>> {
+    static constexpr bool value = true;
+};  // struct is_jagged_vector
+
+template <typename T>
+constexpr bool is_jagged_vector_v = is_jagged_vector<T>::value;
+
+/// @}
+
+/// @name Traits checking if two types are the same, except for constness
+/// @{
+
+template <typename TYPE1, typename TYPE2>
+struct is_same_nc {
+    static constexpr bool value = false;
+};  // struct is_same_nc
+
+template <typename TYPE1, typename TYPE2>
+struct is_same_nc<type::scalar<TYPE1>, type::scalar<TYPE2>> {
+    static constexpr bool value =
+        vecmem::details::is_same_nc<TYPE1, TYPE2>::value;
+};  // struct is_same_nc
+
+template <typename TYPE1, typename TYPE2>
+struct is_same_nc<type::vector<TYPE1>, type::vector<TYPE2>> {
+    static constexpr bool value =
+        vecmem::details::is_same_nc<TYPE1, TYPE2>::value;
+};  // struct is_same_nc
+
+template <typename TYPE1, typename TYPE2>
+struct is_same_nc<type::jagged_vector<TYPE1>, type::jagged_vector<TYPE2>> {
+    static constexpr bool value =
+        vecmem::details::is_same_nc<TYPE1, TYPE2>::value;
+};  // struct is_same_nc
+
+template <typename TYPE1, typename TYPE2>
+constexpr bool is_same_nc_v = is_same_nc<TYPE1, TYPE2>::value;
+
+/// @}
+
+}  // namespace details
+}  // namespace type
+
+namespace details {
+
+/// @name Trait(s) making an entire schema into a constant one
+/// @{
+
+template <typename... VARTYPES>
+struct add_const;
+
+template <typename... VARTYPES>
+struct add_const<schema<VARTYPES...>> {
+    using type = schema<typename type::details::add_const<VARTYPES>::type...>;
+};
+
+template <typename... VARTYPES>
+using add_const_t = typename add_const<VARTYPES...>::type;
+
+/// @}
+
+}  // namespace details
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/details/types.hpp
+++ b/core/include/vecmem/edm/details/types.hpp
@@ -1,0 +1,36 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/vector_view.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace vecmem {
+namespace edm {
+namespace details {
+
+/// Type-less, non-const view of a memory block
+using memory_view = data::vector_view<char>;
+
+/// Type-less, const view of a memory block
+using const_memory_view = data::vector_view<const char>;
+
+/// Size type used in the SoA classes
+using size_type = memory_view::size_type;
+
+/// Non-const pointer type to the size of the SoA classes
+using size_pointer = std::add_pointer_t<size_type>;
+
+/// Constant pointer type to the size of the SoA classes
+using const_size_pointer = std::add_pointer_t<std::add_const_t<size_type> >;
+
+}  // namespace details
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/details/view_traits.hpp
+++ b/core/include/vecmem/edm/details/view_traits.hpp
@@ -1,0 +1,60 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/edm/schema.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace vecmem {
+namespace edm {
+namespace details {
+
+/// @name Traits for the view types for the individual variables
+/// @{
+
+template <typename TYPE>
+struct view_type_base {
+    using payload_type = TYPE;
+    using payload_ptr = std::add_pointer_t<payload_type>;
+    using size_type = unsigned int;
+    using size_ptr = std::add_pointer_t<size_type>;
+};  // struct view_type_base
+
+template <typename TYPE>
+struct view_type : public view_type_base<TYPE> {};
+
+template <typename TYPE>
+struct view_type<type::scalar<TYPE> > : public view_type_base<TYPE> {
+    using layout_type = int;
+    using layout_ptr = std::add_pointer_t<layout_type>;
+    using type = typename view_type_base<TYPE>::payload_ptr;
+};  // struct view_type
+
+template <typename TYPE>
+struct view_type<type::vector<TYPE> > : public view_type_base<TYPE> {
+    using layout_type = int;
+    using layout_ptr = std::add_pointer_t<layout_type>;
+    using type = data::vector_view<TYPE>;
+};  // struct view_type
+
+template <typename TYPE>
+struct view_type<type::jagged_vector<TYPE> > : public view_type_base<TYPE> {
+    using layout_type = vecmem::data::vector_view<TYPE>;
+    using layout_ptr = std::add_pointer_t<layout_type>;
+    using type = data::jagged_vector_view<TYPE>;
+};  // struct view_type
+
+/// @}
+
+}  // namespace details
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/device.hpp
+++ b/core/include/vecmem/edm/device.hpp
@@ -1,0 +1,129 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/details/device_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/edm/view.hpp"
+#include "vecmem/utils/tuple.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <utility>
+
+namespace vecmem {
+namespace edm {
+
+/// Technical base type for @c device<schema<VARTYPES...>>
+template <typename T>
+class device;
+
+/// Structure-of-Arrays device container
+///
+/// This class implements a structure-of-arrays container using device vector
+/// types. Allowing the same operations on the individual variables that are
+/// available from @c vecmem::device_vector and @c vecmem::jagged_device_vector.
+///
+/// @tparam ...VARTYPES The variable types stored in the container
+///
+template <typename... VARTYPES>
+class device<schema<VARTYPES...>> {
+
+    // Sanity check(s).
+    static_assert(sizeof...(VARTYPES) > 0,
+                  "SoA containers without variables are not supported.");
+
+public:
+    /// The schema describing the device-accessible variables
+    using schema_type = schema<VARTYPES...>;
+    /// Size type used for the container
+    using size_type = typename view<schema_type>::size_type;
+    /// Pointer type to the size of the container
+    using size_pointer = typename view<schema_type>::size_pointer;
+    /// The tuple type holding all of the the individual "device objects"
+    using tuple_type = tuple<typename details::device_type<VARTYPES>::type...>;
+
+    /// @name Constructors and assignment operators
+    /// @{
+
+    /// Constructor from an approptiate view
+    VECMEM_HOST_AND_DEVICE
+    device(const view<schema_type>& view);
+
+    /// @}
+
+    /// @name Function(s) meant for normal, client use
+    /// @{
+
+    /// Get the size of the container
+    VECMEM_HOST_AND_DEVICE
+    size_type size() const;
+    /// Get the maximum capacity of the container
+    VECMEM_HOST_AND_DEVICE
+    size_type capacity() const;
+
+    /// Add one default element to all (vector) variables (thread safe)
+    VECMEM_HOST_AND_DEVICE
+    size_type push_back_default();
+
+    /// Get a specific variable (non-const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE
+        typename details::device_type_at<INDEX, VARTYPES...>::return_type
+        get();
+    /// Get a specific variable (const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE
+        typename details::device_type_at<INDEX, VARTYPES...>::const_return_type
+        get() const;
+
+    /// @}
+
+    /// @name Function(s) meant for internal use by other VecMem types
+    /// @{
+
+    /// Direct (non-const) access to the underlying tuple of variables
+    VECMEM_HOST_AND_DEVICE
+    tuple_type& variables();
+    /// Direct (const) access to the underlying tuple of variables
+    VECMEM_HOST_AND_DEVICE
+    const tuple_type& variables() const;
+
+    /// @}
+
+private:
+    /// Construct a default element for every vector variable
+    template <std::size_t INDEX, std::size_t... Is>
+    VECMEM_HOST_AND_DEVICE void construct_default(
+        size_type index, std::index_sequence<INDEX, Is...>);
+    /// Construct a default element for every vector variable (terminal node)
+    VECMEM_HOST_AND_DEVICE void construct_default(size_type index,
+                                                  std::index_sequence<>);
+
+    /// Default, no-op vector element construction helper function
+    template <typename T>
+    VECMEM_HOST_AND_DEVICE void construct_vector(size_type, T&);
+    /// Vector element constructor helper function
+    template <typename T>
+    VECMEM_HOST_AND_DEVICE void construct_vector(size_type index,
+                                                 device_vector<T>& vec);
+
+    /// Maximum capacity of the container
+    size_type m_capacity = 0;
+    /// (Resizable) Size of the container described by this view
+    size_pointer m_size = nullptr;
+    /// The tuple holding all of the individual "device objects"
+    tuple_type m_data;
+
+};  // class device
+
+}  // namespace edm
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/edm/impl/device.ipp"

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -1,0 +1,151 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/details/device_traits.hpp"
+#include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/memory/device_atomic_ref.hpp"
+
+// System include(s).
+#include <cassert>
+
+namespace vecmem {
+namespace edm {
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE device<schema<VARTYPES...>>::device(
+    const view<schema_type>& view)
+    : m_capacity{view.capacity()},
+      m_size{details::device_size_pointer<
+          schema_type,
+          vecmem::details::disjunction_v<
+              type::details::is_jagged_vector<VARTYPES>...>>::get(view.size())},
+      m_data{view.variables()} {
+
+    // Check that all variables have the correct capacities.
+    assert(details::device_capacities_match<VARTYPES...>(
+        m_capacity, m_data, std::index_sequence_for<VARTYPES...>{}));
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::size() const
+    -> size_type {
+
+    // Check that all variables have the correct capacities.
+    assert(details::device_capacities_match<VARTYPES...>(
+        m_capacity, m_data, std::index_sequence_for<VARTYPES...>{}));
+
+    return (m_size == nullptr ? m_capacity : *m_size);
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::capacity() const
+    -> size_type {
+
+    // Check that all variables have the correct capacities.
+    assert(details::device_capacities_match<VARTYPES...>(
+        m_capacity, m_data, std::index_sequence_for<VARTYPES...>{}));
+
+    return m_capacity;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::push_back_default()
+    -> size_type {
+
+    // There must be no jagged vector variables for this to work.
+    static_assert(!vecmem::details::disjunction<
+                      type::details::is_jagged_vector<VARTYPES>...>::value,
+                  "Containers with jagged vector variables cannot be resized!");
+    // There must be at least one vector variable in the container.
+    static_assert(vecmem::details::disjunction<
+                      type::details::is_vector<VARTYPES>...>::value,
+                  "This function requires at least one vector variable.");
+    // This can only be done on a resizable container.
+    assert(m_size != nullptr);
+    // Check that all variables have the correct capacities.
+    assert(details::device_capacities_match<VARTYPES...>(
+        m_capacity, m_data, std::index_sequence_for<VARTYPES...>{}));
+
+    // Increment the size of the container at first. So that we would "claim"
+    // the index from other threads.
+    device_atomic_ref<size_type> asize(*m_size);
+    const size_type index = asize.fetch_add(1);
+    assert(index < m_capacity);
+
+    // Construct the new elements in all of the vector variables.
+    construct_default(index, std::index_sequence_for<VARTYPES...>{});
+
+    // Return the position of the new variable(s).
+    return index;
+}
+
+template <typename... VARTYPES>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE
+    typename details::device_type_at<INDEX, VARTYPES...>::return_type
+    device<schema<VARTYPES...>>::get() {
+
+    return details::device_get<tuple_element_t<INDEX, tuple<VARTYPES...>>>::get(
+        vecmem::get<INDEX>(m_data));
+}
+
+template <typename... VARTYPES>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE
+    typename details::device_type_at<INDEX, VARTYPES...>::const_return_type
+    device<schema<VARTYPES...>>::get() const {
+
+    return details::device_get<tuple_element_t<INDEX, tuple<VARTYPES...>>>::get(
+        vecmem::get<INDEX>(m_data));
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::variables()
+    -> tuple_type& {
+
+    return m_data;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::variables() const
+    -> const tuple_type& {
+
+    return m_data;
+}
+
+template <typename... VARTYPES>
+template <std::size_t INDEX, std::size_t... Is>
+VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_default(
+    size_type index, std::index_sequence<INDEX, Is...>) {
+
+    // Construct the new element in this variable, if it's a vector.
+    construct_vector(index, vecmem::get<INDEX>(m_data));
+    // Continue the recursion.
+    construct_default(index, std::index_sequence<Is...>{});
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_default(
+    size_type, std::index_sequence<>) {}
+
+template <typename... VARTYPES>
+template <typename T>
+VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_vector(
+    size_type, T&) {}
+
+template <typename... VARTYPES>
+template <typename T>
+VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_vector(
+    size_type index, device_vector<T>& vec) {
+
+    vec.construct(index, {});
+}
+
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -21,10 +21,8 @@ template <typename... VARTYPES>
 VECMEM_HOST_AND_DEVICE device<schema<VARTYPES...>>::device(
     const view<schema_type>& view)
     : m_capacity{view.capacity()},
-      m_size{details::device_size_pointer<
-          schema_type,
-          vecmem::details::disjunction_v<
-              type::details::is_jagged_vector<VARTYPES>...>>::get(view.size())},
+      m_size{details::device_size_pointer<vecmem::details::disjunction_v<
+          type::details::is_jagged_vector<VARTYPES>...>>::get(view.size())},
       m_data{view.variables()} {
 
     // Check that all variables have the correct capacities.

--- a/core/include/vecmem/edm/impl/view.ipp
+++ b/core/include/vecmem/edm/impl/view.ipp
@@ -1,0 +1,145 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/utils/type_traits.hpp"
+
+// System include(s).
+#include <cassert>
+
+namespace vecmem {
+namespace edm {
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE view<schema<VARTYPES...>>::view(
+    size_type capacity, const memory_view_type& size)
+    : m_capacity(capacity),
+      m_views{},
+      m_size{size},
+      m_payload{0, nullptr},
+      m_layout{0, nullptr},
+      m_host_layout{0, nullptr} {}
+
+template <typename... VARTYPES>
+template <typename... OTHERTYPES,
+          std::enable_if_t<
+              vecmem::details::conjunction_v<std::is_constructible<
+                  typename details::view_type<VARTYPES>::type,
+                  typename details::view_type<OTHERTYPES>::type>...> &&
+                  vecmem::details::disjunction_v<
+                      vecmem::details::negation<std::is_same<
+                          typename details::view_type<VARTYPES>::type,
+                          typename details::view_type<OTHERTYPES>::type>>...>,
+              bool>>
+VECMEM_HOST_AND_DEVICE view<schema<VARTYPES...>>::view(
+    const view<schema<OTHERTYPES...>>& other)
+    : m_capacity{other.capacity()},
+      m_views{other.variables()},
+      m_size{other.size()},
+      m_payload{other.payload()},
+      m_layout{other.layout()},
+      m_host_layout{other.host_layout()} {}
+
+template <typename... VARTYPES>
+template <typename... OTHERTYPES,
+          std::enable_if_t<
+              vecmem::details::conjunction_v<std::is_constructible<
+                  typename details::view_type<VARTYPES>::type,
+                  typename details::view_type<OTHERTYPES>::type>...> &&
+                  vecmem::details::disjunction_v<
+                      vecmem::details::negation<std::is_same<
+                          typename details::view_type<VARTYPES>::type,
+                          typename details::view_type<OTHERTYPES>::type>>...>,
+              bool>>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::operator=(
+    const view<schema<OTHERTYPES...>>& rhs) -> view& {
+
+    // Note that self-assignment with this function should never be a thing.
+    // So we don't need to check for it in production code.
+    assert(static_cast<const void*>(this) != static_cast<const void*>(&rhs));
+
+    // Copy the data from the other view.
+    m_capacity = rhs.capacity();
+    m_views = rhs.variables();
+    m_size = rhs.size();
+    m_payload = rhs.payload();
+    m_layout = rhs.layout();
+    m_host_layout = rhs.host_layout();
+
+    // Return a reference to this object.
+    return *this;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::capacity() const
+    -> size_type {
+
+    return m_capacity;
+}
+
+template <typename... VARTYPES>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::get()
+    -> tuple_element_t<INDEX, tuple_type>& {
+
+    return vecmem::get<INDEX>(m_views);
+}
+
+template <typename... VARTYPES>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::get() const
+    -> const tuple_element_t<INDEX, tuple_type>& {
+
+    return vecmem::get<INDEX>(m_views);
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::variables()
+    -> tuple_type& {
+
+    return m_views;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::variables() const
+    -> const tuple_type& {
+
+    return m_views;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::size() const
+    -> const memory_view_type& {
+
+    return m_size;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::payload() const
+    -> const memory_view_type& {
+
+    return m_payload;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::layout() const
+    -> const memory_view_type& {
+
+    return m_layout;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST_AND_DEVICE auto view<schema<VARTYPES...>>::host_layout() const
+    -> const memory_view_type& {
+
+    return m_host_layout;
+}
+
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/schema.hpp
+++ b/core/include/vecmem/edm/schema.hpp
@@ -1,0 +1,49 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem {
+namespace edm {
+namespace type {
+
+/// @name Meta-types describing individual variables in an SoA container
+/// @{
+
+/// @brief Scalar variable, one for a whole container
+/// @tparam TYPE The type of the scalar variable
+template <typename TYPE>
+struct scalar {
+    using type = TYPE;
+};  // struct scalar
+
+/// @brief 1D vector variable
+/// @tparam TYPE The type of the 1D vector
+template <typename TYPE>
+struct vector {
+    using type = TYPE;
+};  // struct vector
+
+/// @brief 2D jagged vector variable
+/// @tparam TYPE The type of the 2D jagged vector
+template <typename TYPE>
+struct jagged_vector {
+    using type = TYPE;
+};  // struct jagged_vector
+
+/// @}
+
+}  // namespace type
+
+/// Meta type describing the "schema" of an SoA container
+///
+/// @tparam ...VARTYPES The variable types in the SoA container
+///
+template <typename... VARTYPES>
+struct schema {};
+
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/view.hpp
+++ b/core/include/vecmem/edm/view.hpp
@@ -8,6 +8,7 @@
 
 // Local include(s).
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/edm/details/types.hpp"
 #include "vecmem/edm/details/view_traits.hpp"
 #include "vecmem/edm/schema.hpp"
 #include "vecmem/utils/tuple.hpp"
@@ -46,22 +47,21 @@ public:
     /// The schema describing the container view
     using schema_type = schema<VARTYPES...>;
     /// Size type used for the container
-    using size_type = data::vector_view<int>::size_type;
+    using size_type = details::size_type;
     /// Pointer type to the size of the container
     using size_pointer = std::conditional_t<
         vecmem::details::disjunction_v<std::is_const<
             typename details::view_type<VARTYPES>::payload_type>...>,
-        std::add_pointer_t<std::add_const_t<size_type>>,
-        std::add_pointer_t<size_type>>;
+        details::const_size_pointer, details::size_pointer>;
     /// Constant pointer type to the size of the container
-    using const_size_pointer = std::add_const_t<size_pointer>;
+    using const_size_pointer = details::const_size_pointer;
     /// The tuple type holding all of the views for the individual variables
     using tuple_type = tuple<typename details::view_type<VARTYPES>::type...>;
     /// Type of the view(s) into the raw data of the view
-    using memory_view_type = data::vector_view<std::conditional_t<
+    using memory_view_type = std::conditional_t<
         vecmem::details::disjunction_v<std::is_const<
             typename details::view_type<VARTYPES>::payload_type>...>,
-        const char, char>>;
+        details::const_memory_view, details::memory_view>;
 
     /// @name Constructors and assignment operators
     /// @{

--- a/core/include/vecmem/edm/view.hpp
+++ b/core/include/vecmem/edm/view.hpp
@@ -1,0 +1,196 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/edm/details/view_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/utils/tuple.hpp"
+#include "vecmem/utils/type_traits.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <type_traits>
+
+namespace vecmem {
+
+/// Namespace for the types implementing Struct-of-Array container support
+namespace edm {
+
+/// Technical base type for @c view<schema<VARTYPES...>>
+template <typename T>
+class view;
+
+/// View of a Struct-of-Arrays container
+///
+/// Much like how @c vecmem::data::vector_view can be used to communicate the
+/// needed information about a single 1D vector to a device function, this type
+/// is meant to communicate the same type of information about an entire
+/// container of variables.
+///
+/// @tparam ...VARTYPES The variable types described by the view
+///
+template <typename... VARTYPES>
+class view<schema<VARTYPES...>> {
+
+    // Sanity check(s).
+    static_assert(sizeof...(VARTYPES) > 0,
+                  "SoA containers without variables are not supported.");
+
+public:
+    /// The schema describing the container view
+    using schema_type = schema<VARTYPES...>;
+    /// Size type used for the container
+    using size_type = data::vector_view<int>::size_type;
+    /// Pointer type to the size of the container
+    using size_pointer = std::conditional_t<
+        vecmem::details::disjunction_v<std::is_const<
+            typename details::view_type<VARTYPES>::payload_type>...>,
+        std::add_pointer_t<std::add_const_t<size_type>>,
+        std::add_pointer_t<size_type>>;
+    /// Constant pointer type to the size of the container
+    using const_size_pointer = std::add_const_t<size_pointer>;
+    /// The tuple type holding all of the views for the individual variables
+    using tuple_type = tuple<typename details::view_type<VARTYPES>::type...>;
+    /// Type of the view(s) into the raw data of the view
+    using memory_view_type = data::vector_view<std::conditional_t<
+        vecmem::details::disjunction_v<std::is_const<
+            typename details::view_type<VARTYPES>::payload_type>...>,
+        const char, char>>;
+
+    /// @name Constructors and assignment operators
+    /// @{
+
+    /// Default constructor
+    view() = default;
+
+    /// Constructor with a capacity and size.
+    ///
+    /// @param capacity The maximum capacity of the container
+    /// @param size Optional pointer to the size of the container
+    ///
+    VECMEM_HOST_AND_DEVICE
+    view(size_type capacity, const memory_view_type& size = {0u, nullptr});
+
+    /// Constructor from a (possibly/slightly) different view
+    ///
+    /// As with @c vecmem::data::vector_view and
+    /// @c vecmem::data::jagged_vector_view, this constructor must only be
+    /// active for non-const to const conversions. As we need to use the default
+    /// copy and move constructors for copying/moving identical types. Otherwise
+    /// SYCL is not happy with sending these as kernel parameters.
+    ///
+    /// @tparam OTHERTYPES The variable types described by the "other view"
+    /// @param other The "other view" to copy from
+    ///
+    template <
+        typename... OTHERTYPES,
+        std::enable_if_t<
+            vecmem::details::conjunction_v<std::is_constructible<
+                typename details::view_type<VARTYPES>::type,
+                typename details::view_type<OTHERTYPES>::type>...> &&
+                vecmem::details::disjunction_v<
+                    vecmem::details::negation<std::is_same<
+                        typename details::view_type<VARTYPES>::type,
+                        typename details::view_type<OTHERTYPES>::type>>...>,
+            bool> = true>
+    VECMEM_HOST_AND_DEVICE view(const view<schema<OTHERTYPES...>>& other);
+
+    /// Assignment operator from a (possibly/slightly) different view
+    ///
+    /// @see view(const view<schema<OTHERTYPES...>>&)
+    ///
+    /// @tparam OTHERTYPES The variable types described by the "other view"
+    /// @param rhs The "other view" to assign from
+    ///
+    template <
+        typename... OTHERTYPES,
+        std::enable_if_t<
+            vecmem::details::conjunction_v<std::is_constructible<
+                typename details::view_type<VARTYPES>::type,
+                typename details::view_type<OTHERTYPES>::type>...> &&
+                vecmem::details::disjunction_v<
+                    vecmem::details::negation<std::is_same<
+                        typename details::view_type<VARTYPES>::type,
+                        typename details::view_type<OTHERTYPES>::type>>...>,
+            bool> = true>
+    VECMEM_HOST_AND_DEVICE view& operator=(
+        const view<schema<OTHERTYPES...>>& rhs);
+
+    /// @}
+
+    /// @name Function(s) meant for normal, client use
+    /// @{
+
+    /// Get the maximum capacity of the container
+    VECMEM_HOST_AND_DEVICE
+    size_type capacity() const;
+
+    /// Get the view of a specific variable (non-const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE tuple_element_t<INDEX, tuple_type>& get();
+    /// Get the view of a specific variable (const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE const tuple_element_t<INDEX, tuple_type>& get()
+        const;
+
+    /// @}
+
+    /// @name Function(s) meant for internal use by other VecMem types
+    /// @{
+
+    /// Direct (non-const) access to the underlying tuple of views
+    VECMEM_HOST_AND_DEVICE
+    tuple_type& variables();
+    /// Direct (const) access to the underlying tuple of views
+    VECMEM_HOST_AND_DEVICE
+    const tuple_type& variables() const;
+
+    /// View of the memory allocated for the container's size variable(s)
+    VECMEM_HOST_AND_DEVICE
+    const memory_view_type& size() const;
+
+    /// View at the single (device) memory allocation of the container
+    VECMEM_HOST_AND_DEVICE
+    const memory_view_type& payload() const;
+
+    /// View at the memory that describes the layout of the container
+    VECMEM_HOST_AND_DEVICE
+    const memory_view_type& layout() const;
+    /// View at the memory that describes the layout of the container (in host
+    /// accessible memory)
+    VECMEM_HOST_AND_DEVICE
+    const memory_view_type& host_layout() const;
+
+    /// @}
+
+protected:
+    /// Maximum capacity of the container
+    size_type m_capacity;
+    /// Views for the individual variables
+    tuple_type m_views;
+
+    /// View into the memory allocated for the container's size variable(s)
+    memory_view_type m_size;
+
+    /// View into the single (device) memory allocation for the "payload"
+    memory_view_type m_payload;
+
+    /// View into the memory that describes the layout of the container
+    memory_view_type m_layout;
+    /// View into the memory that describes the layout of the container (in host
+    /// accessible memory)
+    memory_view_type m_host_layout;
+
+};  // class view
+
+}  // namespace edm
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/edm/impl/view.ipp"

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -23,4 +23,6 @@ vecmem_add_test( core
    "test_core_unique_alloc_ptr.cpp"
    "test_core_unique_obj_ptr.cpp"
    "test_core_tuple.cpp"
+   "test_core_edm_view.cpp"
+   "test_core_edm_device.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_edm_device.cpp
+++ b/tests/core/test_core_edm_device.cpp
@@ -1,0 +1,62 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/edm/device.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <vector>
+
+TEST(core_edm_device_test, construct) {
+
+    using schema =
+        vecmem::edm::schema<vecmem::edm::type::scalar<int>,
+                            vecmem::edm::type::vector<float>,
+                            vecmem::edm::type::jagged_vector<double>>;
+    using const_schema = vecmem::edm::details::add_const_t<schema>;
+
+    vecmem::edm::view<schema> view1{};
+    vecmem::edm::view<const_schema> view2{};
+
+    vecmem::edm::device<schema> device1{view1};
+    vecmem::edm::device<const_schema> device2{view1};
+    vecmem::edm::device<const_schema> device3{view2};
+}
+
+TEST(core_edm_device_test, members) {
+
+    int value1 = 1;
+    std::vector<float> value2{2.0f, 3.0f};
+
+    using schema = vecmem::edm::schema<vecmem::edm::type::scalar<int>,
+                                       vecmem::edm::type::vector<float>>;
+    using const_schema = vecmem::edm::details::add_const_t<schema>;
+
+    vecmem::edm::view<schema> view{2};  // 2 is the size of the vector variable,
+                                        // not the number of variables
+    view.get<0>() = &value1;
+    view.get<1>() = {static_cast<unsigned int>(value2.size()), value2.data()};
+
+    vecmem::edm::device<schema> device1{view};
+    vecmem::edm::device<const_schema> device2{view};
+
+    EXPECT_EQ(device2.get<0>(), value1);
+    ASSERT_EQ(device2.get<1>().size(), value2.size());
+    EXPECT_EQ(device2.get<1>()[0], value2[0]);
+    EXPECT_EQ(device2.get<1>()[1], value2[1]);
+
+    device1.get<0>() = 2;
+    device1.get<1>()[0] = 4.0f;
+    device1.get<1>()[1] = 5.0f;
+
+    EXPECT_EQ(device2.get<0>(), 2);
+    EXPECT_EQ(device2.get<1>()[0], 4.0f);
+    EXPECT_EQ(device2.get<1>()[1], 5.0f);
+}

--- a/tests/core/test_core_edm_view.cpp
+++ b/tests/core/test_core_edm_view.cpp
@@ -1,0 +1,50 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/edm/view.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <vector>
+
+TEST(core_edm_view_test, construct_assign) {
+
+    vecmem::edm::view<vecmem::edm::schema<
+        vecmem::edm::type::scalar<int>, vecmem::edm::type::vector<float>,
+        vecmem::edm::type::jagged_vector<double>>>
+        view1{};
+    vecmem::edm::view<
+        vecmem::edm::schema<vecmem::edm::type::scalar<const int>,
+                            vecmem::edm::type::vector<const float>,
+                            vecmem::edm::type::jagged_vector<const double>>>
+        view2{view1};
+    vecmem::edm::view<
+        vecmem::edm::schema<vecmem::edm::type::scalar<const int>,
+                            vecmem::edm::type::vector<const float>,
+                            vecmem::edm::type::jagged_vector<const double>>>
+        view3{};
+    view3 = view1;
+}
+
+TEST(core_edm_view_test, members) {
+
+    int value1 = 1;
+    std::vector<float> value2{2.0f, 3.0f};
+
+    vecmem::edm::view<vecmem::edm::schema<vecmem::edm::type::scalar<int>,
+                                          vecmem::edm::type::vector<float>>>
+        view{2};
+    view.get<0>() = &value1;
+    view.get<1>() = {static_cast<unsigned int>(value2.size()), value2.data()};
+
+    EXPECT_EQ(view.get<0>(), &value1);
+    EXPECT_EQ(view.get<1>().size(), value2.size());
+    EXPECT_EQ(view.get<1>().ptr(), value2.data());
+}


### PR DESCRIPTION
Following #250, this is the 2nd PR for reviewing everything from #246. 😄

Introduced `vecmem::edm::view` and `vecmem::edm::device`. (And all the utility code that they require.) They can't be used for much at the moment, without adding some host types as well, but they allow for some trivial tests even like this at least.
  - `vecmem::edm::device` is not much more than a `vecmem::tuple` of appropriate types, with some helper functions. The implementation gets a bit complicated even like this, but logically that class is really just some syntactic sugar around a tuple.
    * The only slightly tricky thing it provides is the ability to resize / enlarge resizable containers in a thread-safe way.
  - `vecmem::edm::view` on the other hand may look a bit over-complicated in this PR. 🤔
    * `m_capacity` is simply the overall capacity of the SoA container being described;
    * `m_views` is a tuple of "view types" for the individual variables. Logically this is still meant to be simple to follow.
    * `m_payload` is a type-less view of the memory block holding the payload of the container. In case it uses a contiguous memory allocation. Which the `vecmem::edm::buffer` class, introduced in a follow-up PR, will provide. When creating a view on top of a host object directly, this view will be invalid.
    * `m_size` is a type-less view of the memory block holding the resizable size(s) of the container. The thing that `vecmem::copy` would be able to easily initialize to `0` for resizable containers/buffers. (For non-resizable containers this view is invalid.)
    * `m_layout` and `m_host_layout` are the type-less views of the data describing "the layout" of the view's payload. Which is needed for describing jagged vectors. `vecmem::copy` will set up containers for usage on a device using these views. (Copying from the host view to the device one when necessary.)

As I wrote, this PR does not actively test every aspect of these classes. For that we'll need the `vecmem::edm::host` and `vecmem::edm::buffer` classes as well. (Coming soon to a repository near you. :wink:)