### PR TITLE
Jagged Vector Iterator Fix, main branch (2023.12.08.)

### DIFF
--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,7 @@
 // System include(s).
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 
 namespace vecmem {
 namespace details {
@@ -39,7 +40,7 @@ public:
     /// Type of the data object that we have an array of
     typedef data::vector_view<TYPE> data_type;
     /// Pointer to the data object
-    typedef data_type* data_pointer;
+    typedef const data_type* data_pointer;
 
     /// @}
 
@@ -92,6 +93,12 @@ public:
     /// Constructor from an underlying data object
     VECMEM_HOST_AND_DEVICE
     jagged_device_vector_iterator(data_pointer data);
+    /// Constructor from a slightly different underlying data object
+    template <typename OTHERTYPE,
+              std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE jagged_device_vector_iterator(
+        const data::vector_view<OTHERTYPE>* data);
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE
     jagged_device_vector_iterator(const jagged_device_vector_iterator& parent);

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -40,6 +40,16 @@ VECMEM_HOST_AND_DEVICE
 jagged_device_vector_iterator<TYPE>::jagged_device_vector_iterator(
     data_pointer data)
     : m_ptr(data) {}
+
+template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value, bool> >
+VECMEM_HOST_AND_DEVICE
+jagged_device_vector_iterator<TYPE>::jagged_device_vector_iterator(
+    const data::vector_view<OTHERTYPE>* data)
+    // Just like for vecmem::data::vector_view, this looks more scary than it
+    // is. We convert from a non-const type to a constant one here.
+    : m_ptr{reinterpret_cast<data_pointer>(data)} {}
 
 template <typename TYPE>
 VECMEM_HOST_AND_DEVICE

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -375,3 +375,142 @@ TEST_F(core_device_container_test, conversions) {
     vecmem::data::jagged_vector_view<int> view2d8 = data2d3;
     EXPECT_EQ(view2d7, view2d8);
 }
+
+TEST_F(core_device_container_test, vector_iteration) {
+
+    // Set up a simple host vector.
+    vecmem::vector<int> host_vector{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+                                    &m_resource};
+
+    // Create a non-const device vector from it.
+    vecmem::device_vector<int> device_vector1(vecmem::get_data(host_vector));
+
+    // Check that non-const iteration works.
+    vecmem::device_vector<int>::iterator it1 = device_vector1.begin();
+    vecmem::device_vector<int>::iterator end1 = device_vector1.end();
+    for (int i = 1; it1 != end1; ++it1, ++i) {
+        EXPECT_EQ(*it1, i);
+    }
+
+    // Check that const iteration works.
+    vecmem::device_vector<int>::const_iterator it2 = device_vector1.cbegin();
+    vecmem::device_vector<int>::const_iterator end2 = device_vector1.cend();
+    for (int i = 1; it2 != end2; ++it2, ++i) {
+        EXPECT_EQ(*it2, i);
+    }
+    it2 = [](const auto& vec) { return vec.begin(); }(device_vector1);
+    end2 = [](const auto& vec) { return vec.end(); }(device_vector1);
+    for (int i = 1; it2 != end2; ++it2, ++i) {
+        EXPECT_EQ(*it2, i);
+    }
+
+    // Create a const device vector from it.
+    vecmem::device_vector<const int> device_vector2(
+        vecmem::get_data(host_vector));
+
+    // Check that "non-const" iteration works.
+    vecmem::device_vector<const int>::iterator it3 = device_vector2.begin();
+    vecmem::device_vector<const int>::iterator end3 = device_vector2.end();
+    for (int i = 1; it3 != end3; ++it3, ++i) {
+        EXPECT_EQ(*it3, i);
+    }
+
+    // Check that const iteration works.
+    vecmem::device_vector<const int>::const_iterator it4 =
+        device_vector2.cbegin();
+    vecmem::device_vector<const int>::const_iterator end4 =
+        device_vector2.cend();
+    for (int i = 1; it4 != end4; ++it4, ++i) {
+        EXPECT_EQ(*it4, i);
+    }
+    it4 = [](const auto& vec) { return vec.begin(); }(device_vector2);
+    end4 = [](const auto& vec) { return vec.end(); }(device_vector2);
+    for (int i = 1; it4 != end4; ++it4, ++i) {
+        EXPECT_EQ(*it4, i);
+    }
+}
+
+TEST_F(core_device_container_test, jagged_vector_iteration) {
+
+    // Set up a "simple" host vector.
+    vecmem::jagged_vector<int> host_vector = {
+        {
+            {{1, 2, 3, 4}, &m_resource},
+            {{5, 6}, &m_resource},
+            vecmem::vector<int>{&m_resource},
+            {{7, 8, 9}, &m_resource},
+            {{10}, &m_resource},
+        },
+        &m_resource};
+    auto host_data = vecmem::get_data(host_vector);
+
+    // Create a non-const device vector from it.
+    vecmem::jagged_device_vector<int> device_vector1(
+        vecmem::get_data(host_data));
+
+    // Check that non-const iteration works.
+    int i = 1;
+    vecmem::jagged_device_vector<int>::iterator it1 = device_vector1.begin();
+    vecmem::jagged_device_vector<int>::iterator end1 = device_vector1.end();
+    for (; it1 != end1; ++it1) {
+        for (auto it = it1->begin(); it != it1->end(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+
+    // Check that const iteration works.
+    i = 1;
+    vecmem::jagged_device_vector<int>::const_iterator it2 =
+        device_vector1.cbegin();
+    vecmem::jagged_device_vector<int>::const_iterator end2 =
+        device_vector1.cend();
+    for (; it2 != end2; ++it2) {
+        for (auto it = it2->cbegin(); it != it2->cend(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+    i = 1;
+    it2 = [](const auto& vec) { return vec.begin(); }(device_vector1);
+    end2 = [](const auto& vec) { return vec.end(); }(device_vector1);
+    for (; it2 != end2; ++it2) {
+        for (auto it = it2->cbegin(); it != it2->cend(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+
+    // Create a const device vector from it.
+    vecmem::jagged_device_vector<const int> device_vector2(
+        vecmem::get_data(host_data));
+
+    // Check that "non-const" iteration works.
+    i = 1;
+    vecmem::jagged_device_vector<const int>::iterator it3 =
+        device_vector2.begin();
+    vecmem::jagged_device_vector<const int>::iterator end3 =
+        device_vector2.end();
+    for (; it3 != end3; ++it3) {
+        for (auto it = it3->begin(); it != it3->end(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+
+    // Check that const iteration works.
+    i = 1;
+    vecmem::jagged_device_vector<const int>::const_iterator it4 =
+        device_vector2.cbegin();
+    vecmem::jagged_device_vector<const int>::const_iterator end4 =
+        device_vector2.cend();
+    for (; it4 != end4; ++it4) {
+        for (auto it = it4->cbegin(); it != it4->cend(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+    i = 1;
+    it4 = [](const auto& vec) { return vec.begin(); }(device_vector2);
+    end4 = [](const auto& vec) { return vec.end(); }(device_vector2);
+    for (; it4 != end4; ++it4) {
+        for (auto it = it4->cbegin(); it != it4->cend(); ++it, ++i) {
+            EXPECT_EQ(*it, i);
+        }
+    }
+}


### PR DESCRIPTION
Fixed "constant iteration" over a non-const jagged vector. The code was not handling this case correctly before. Where one starts from a non-const jagged vector type, but asks for a constant iterator over that non-const container.

I came across this bug while writing the detailed unit tests for `vecmem::edm::buffer`. :thinking: