### PR TITLE
Add SoA Buffer Class, main branch (2023.12.08.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -62,6 +62,8 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/memory/details/is_aligned.hpp"
    "src/memory/details/is_aligned.cpp"
    # EDM types.
+   "include/vecmem/edm/buffer.hpp"
+   "include/vecmem/edm/impl/buffer.ipp"
    "include/vecmem/edm/data.hpp"
    "include/vecmem/edm/impl/data.ipp"
    "include/vecmem/edm/device.hpp"
@@ -71,6 +73,7 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/edm/view.hpp"
    "include/vecmem/edm/impl/view.ipp"
    "include/vecmem/edm/schema.hpp"
+   "include/vecmem/edm/details/buffer_traits.hpp"
    "include/vecmem/edm/details/data_traits.hpp"
    "include/vecmem/edm/details/device_traits.hpp"
    "include/vecmem/edm/details/host_traits.hpp"

--- a/core/include/vecmem/edm/buffer.hpp
+++ b/core/include/vecmem/edm/buffer.hpp
@@ -1,0 +1,263 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/data/buffer_type.hpp"
+#include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/edm/view.hpp"
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/memory/unique_ptr.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace vecmem {
+namespace edm {
+
+/// Technical base type for @c buffer<schema<VARTYPES...>>
+template <typename T>
+class buffer;
+
+/// Buffer for a Struct-of-Arrays container
+///
+/// This type can be used to hold the memory of an entire SoA container in an
+/// efficient way. Allowing for block copies of the data between the host and
+/// a device.
+///
+/// The buffer holds on to either 1 or 2 blocks of memory.
+///   - Only one block is needed if:
+///      * The container doesn't have any jagged vector variables;
+///      * The main memory resource used by the buffer is host accessible.
+///   - If the container has at least one jagged vector variable and the main
+///     memory resource is not host accessible, then the buffer will hold on to
+///     two blocks of memory. One allocated on the device and one on the host.
+///
+/// The "main/device memory block" is structured as follows:
+///
+///   <table>
+///     <caption id="buffer_layout">
+///        `vecmem::edm::buffer` memory layout
+///     </caption>
+///     <tr>
+///       <th colspan="3">
+///         Fixed size buffer
+///       </th>
+///     </tr>
+///     <tr><th>Bytes</th><th>Description</th><th>Notes</th></tr>
+///     <tr>
+///       <td>
+///         `sizeof(vecmem::data::vector_view)` *
+///         number of "inner vectors" in all jagged vectors
+///       </td>
+///       <td>
+///         Layout metadata of the jagged vectors
+///       </td>
+///       <td>
+///          Pointed to by `vecmem::edm::view::layout()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <td>
+///         Many
+///       </td>
+///       <td>
+///         Payload of the buffer, with memory for all variables held by the
+///         container
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::payload()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <th colspan="3">
+///         Resizable buffer without any jagged vector variables
+///       </th>
+///     </tr>
+///     <tr><th>Bytes</th><th>Description</th><th>Notes</th></tr>
+///     <tr>
+///       <td>
+///         `4`
+///       </td>
+///       <td>
+///         Size of all 1D vector variables in the container
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::size_ptr()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <td>
+///         Many
+///       </td>
+///       <td>
+///         Payload of the buffer, with memory for all variables held by the
+///         container
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::payload()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <th colspan="3">
+///         Resizable buffer with at least one jagged vector variable
+///       </th>
+///     </tr>
+///     <tr><th>Bytes</th><th>Description</th><th>Notes</th></tr>
+///     <tr>
+///       <td>
+///         `4` * number of "inner vectors" in all jagged vectors
+///       </td>
+///       <td>
+///         Individual "inner sizes" of the jagged vectors
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::size_ptr()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <td>
+///         `sizeof(vecmem::data::vector_view)` *
+///         number of "inner vectors" in all jagged vectors
+///       </td>
+///       <td>
+///         Layout metadata of the jagged vectors
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::layout()`
+///       </td>
+///     </tr>
+///     <tr>
+///       <td>
+///         Many
+///       </td>
+///       <td>
+///         Payload of the buffer, with memory for all variables held by the
+///         container
+///       </td>
+///       <td>
+///         Pointed to by `vecmem::edm::view::payload()`
+///       </td>
+///     </tr>
+///   </table>
+///
+/// The "host memory block", if used holds the same layout data for the jagged
+/// vector variables as the "main memory block", just in a host-accessible
+/// location. This allocation is pointed to by
+/// `vecmem::edm::view::host_layout()`.
+///
+/// @tparam ...VARTYPES The variable types to store in the buffer
+///
+template <typename... VARTYPES>
+class buffer<schema<VARTYPES...>> : public view<schema<VARTYPES...>> {
+
+    // Make sure that all variable types are supported. It needs to be possible
+    // to copy the contents of all variables with simple memory copies, and
+    // it has to be possible to trivially destruct all objects.
+    static_assert(
+        std::conjunction<
+            std::is_trivially_destructible<typename VARTYPES::type>...>::value,
+        "Unsupported variable type");
+    static_assert(std::conjunction<std::is_trivially_assignable<
+                      std::add_lvalue_reference_t<typename VARTYPES::type>,
+                      typename VARTYPES::type>...>::value,
+                  "Unsupported variable type");
+
+public:
+    /// The schema describing the buffer's payload
+    using schema_type = schema<VARTYPES...>;
+    /// Base view type
+    using view_type = view<schema_type>;
+    /// Size type used for the container
+    using size_type = typename view_type::size_type;
+    /// Type holding on to the memory managed by this object
+    using memory_type = unique_alloc_ptr<char[]>;
+
+    /// Constructor for a 1D buffer
+    ///
+    /// @param capacity The capacity of the 1D arrays in the buffer
+    /// @param mr       The memory resource to use for the allocation
+    /// @param type     The type of the buffer (fixed or variable size)
+    ///
+    VECMEM_HOST
+    buffer(
+        size_type capacity, memory_resource& mr,
+        vecmem::data::buffer_type type = vecmem::data::buffer_type::fixed_size);
+
+    /// Constructor for a 2D buffer
+    ///
+    /// Note that the inner sizes of the jagged vector variables are technically
+    /// allowed to be different. But this constructor sets them all up to have
+    /// the same inner capacities.
+    ///
+    /// The 1D vectors of the buffer are set up to be non-resizable, with their
+    /// sizes taken from @c capacities.size().
+    ///
+    /// @param capacities The capacities of the 1D/2D arrays in the buffer
+    /// @param mr         The (main) memory resource to use for the allocation
+    /// @param host_mr    The memory resource to use for the host allocation(s)
+    /// @param type       The type of the buffer (fixed or variable size)
+    ///
+    template <typename SIZE_TYPE = std::size_t,
+              std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
+                                   std::is_unsigned<SIZE_TYPE>::value,
+                               bool> = true>
+    VECMEM_HOST buffer(
+        const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
+        memory_resource* host_mr = nullptr,
+        vecmem::data::buffer_type type = vecmem::data::buffer_type::fixed_size);
+
+private:
+    /// Set up a fixed sized buffer
+    template <typename SIZE_TYPE = std::size_t, std::size_t... INDICES>
+    VECMEM_HOST void setup_fixed(const std::vector<SIZE_TYPE>& capacities,
+                                 memory_resource& mr, memory_resource* host_mr,
+                                 std::index_sequence<INDICES...>);
+    /// Set up a resizable buffer
+    template <typename SIZE_TYPE = std::size_t, std::size_t... INDICES>
+    VECMEM_HOST void setup_resizable(const std::vector<SIZE_TYPE>& capacities,
+                                     memory_resource& mr,
+                                     memory_resource* host_mr,
+                                     std::index_sequence<INDICES...>);
+
+    /// The full allocated block of (device) memory
+    memory_type m_memory;
+    /// The full allocated block of host accessible memory
+    memory_type m_host_memory;
+
+};  // class buffer
+
+}  // namespace edm
+
+/// Helper function for getting a (possibly non-const) view for a buffer
+///
+/// @tparam ...VARTYPES The variable types describing the container
+/// @param buffer The buffer to get a view for
+/// @return A (possibly non-const) view into for the buffer
+///
+template <typename... VARTYPES>
+VECMEM_HOST edm::view<edm::schema<VARTYPES...>> get_data(
+    edm::buffer<edm::schema<VARTYPES...>>& buffer);
+
+/// Helper function for getting a (const) view for a buffer
+///
+/// @tparam ...VARTYPES The variable types describing the container
+/// @param buffer The buffer to get a view for
+/// @return A (const) view into for the buffer
+///
+template <typename... VARTYPES>
+VECMEM_HOST edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>
+get_data(const edm::buffer<edm::schema<VARTYPES...>>& buffer);
+
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/edm/impl/buffer.ipp"

--- a/core/include/vecmem/edm/details/buffer_traits.hpp
+++ b/core/include/vecmem/edm/details/buffer_traits.hpp
@@ -1,0 +1,259 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/edm/details/view_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/edm/view.hpp"
+#include "vecmem/memory/unique_ptr.hpp"
+#include "vecmem/utils/tuple.hpp"
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <array>
+#include <numeric>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace vecmem::edm::details {
+
+/// @name Traits used for making allocations inside of buffers
+/// @{
+
+template <typename TYPE>
+struct buffer_alloc;
+
+template <typename TYPE>
+struct buffer_alloc<type::scalar<TYPE> > {
+    /// The number of @c TYPE elements to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t payload_size(const std::vector<SIZE_TYPE>&) {
+        return 1u;
+    }
+    /// The number of "layout meta-objects" to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t layout_size(const std::vector<SIZE_TYPE>&) {
+        return 0u;
+    }
+    /// Construct a view for a scalar variable.
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static typename view_type<type::scalar<TYPE> >::type make_view(
+        const std::vector<SIZE_TYPE>&, unsigned int*,
+        typename view_type<type::scalar<TYPE> >::layout_ptr,
+        typename view_type<type::scalar<TYPE> >::layout_ptr,
+        typename view_type<type::scalar<TYPE> >::payload_ptr ptr) {
+        return ptr;
+    }
+};  // struct buffer_alloc
+
+template <typename TYPE>
+struct buffer_alloc<type::vector<TYPE> > {
+    /// The number of @c TYPE elements to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t payload_size(
+        const std::vector<SIZE_TYPE>& sizes) {
+        return sizes.size();
+    }
+    /// The number of "layout meta-objects" to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t layout_size(const std::vector<SIZE_TYPE>&) {
+        return 0u;
+    }
+    /// Construct a view for a vector variable.
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static typename view_type<type::vector<TYPE> >::type make_view(
+        const std::vector<SIZE_TYPE>& capacity, unsigned int* size,
+        typename view_type<type::vector<TYPE> >::layout_ptr,
+        typename view_type<type::vector<TYPE> >::layout_ptr,
+        typename view_type<type::vector<TYPE> >::payload_ptr ptr) {
+        return {static_cast<
+                    typename view_type<type::vector<TYPE> >::type::size_type>(
+                    capacity.size()),
+                size, ptr};
+    }
+};  // struct buffer_alloc
+
+template <typename TYPE>
+struct buffer_alloc<type::jagged_vector<TYPE> > {
+    /// The number of @c TYPE elements to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t payload_size(
+        const std::vector<SIZE_TYPE>& sizes) {
+        return std::accumulate(sizes.begin(), sizes.end(),
+                               static_cast<std::size_t>(0));
+    }
+    /// The number of "layout meta-objects" to allocate for the payload
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static std::size_t layout_size(
+        const std::vector<SIZE_TYPE>& sizes) {
+        return sizes.size();
+    }
+    /// Construct a view for a jagged vector variable.
+    template <typename SIZE_TYPE = std::size_t>
+    VECMEM_HOST static typename view_type<type::jagged_vector<TYPE> >::type
+    make_view(
+        const std::vector<SIZE_TYPE>& capacities, unsigned int* sizes,
+        typename view_type<type::jagged_vector<TYPE> >::layout_ptr layout,
+        typename view_type<type::jagged_vector<TYPE> >::layout_ptr host_layout,
+        typename view_type<type::jagged_vector<TYPE> >::payload_ptr ptr) {
+
+        // Set up the "layout objects" for use by the view.
+        typename view_type<type::jagged_vector<TYPE> >::layout_ptr used_layout =
+            (host_layout != nullptr ? host_layout : layout);
+        std::ptrdiff_t ptrdiff = 0;
+        for (std::size_t i = 0; i < capacities.size(); ++i) {
+            new (used_layout + i)
+                typename view_type<type::jagged_vector<TYPE> >::layout_type(
+                    static_cast<typename view_type<
+                        type::jagged_vector<TYPE> >::layout_type::size_type>(
+                        capacities[i]),
+                    (sizes != nullptr ? &(sizes[i]) : nullptr), ptr + ptrdiff);
+            ptrdiff += capacities[i];
+        }
+
+        // Create the jagged vector view.
+        return {static_cast<
+                    typename view_type<type::vector<TYPE> >::type::size_type>(
+                    capacities.size()),
+                layout, host_layout};
+    }
+};  // struct buffer_alloc
+
+/// @}
+
+/// Function constructing fixed size view objects for @c vecmem::edm::buffer
+template <typename SIZE_TYPE, typename... TYPES, std::size_t... INDICES>
+VECMEM_HOST auto make_buffer_views(
+    const std::vector<SIZE_TYPE>& sizes,
+    const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
+    const std::tuple<typename view_type<TYPES>::layout_ptr...>& host_layouts,
+    const std::tuple<typename view_type<TYPES>::payload_ptr...>& payloads,
+    std::index_sequence<INDICES...>) {
+
+    return vecmem::make_tuple(buffer_alloc<TYPES>::make_view(
+        sizes, nullptr, std::get<INDICES>(layouts),
+        std::get<INDICES>(host_layouts), std::get<INDICES>(payloads))...);
+}
+
+/// Function constructing resizable view objects for @c vecmem::edm::buffer
+template <typename SIZE_TYPE, typename... TYPES, std::size_t... INDICES>
+VECMEM_HOST auto make_buffer_views(
+    const std::vector<SIZE_TYPE>& capacities,
+    const std::tuple<typename view_type<TYPES>::size_ptr...>& sizes,
+    const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
+    const std::tuple<typename view_type<TYPES>::layout_ptr...>& host_layouts,
+    const std::tuple<typename view_type<TYPES>::payload_ptr...>& payloads,
+    const std::index_sequence<INDICES...>) {
+
+    // Helper variable(s).
+    constexpr auto is_jagged_vector =
+        std::make_tuple(type::details::is_jagged_vector<TYPES>::value...);
+    constexpr bool has_jagged_vector =
+        std::disjunction_v<type::details::is_jagged_vector<TYPES>...>;
+
+    // The logic here is that if there are any jagged vectors in the schema,
+    // then only the jagged vectors are resizable, the "normal vectors" are not.
+    // But the received "sizes" variable would be hard to set up like that
+    // outside of this function, so the logic has to sit here.
+    return make_tuple(buffer_alloc<TYPES>::make_view(
+        capacities,
+        ((has_jagged_vector && (!std::get<INDICES>(is_jagged_vector)))
+             ? nullptr
+             : std::get<INDICES>(sizes)),
+        std::get<INDICES>(layouts), std::get<INDICES>(host_layouts),
+        std::get<INDICES>(payloads))...);
+}
+
+/// Generic function finding the first non-nullptr pointer in a tuple.
+template <typename... TYPES, std::size_t INDEX, std::size_t... INDICES>
+VECMEM_HOST constexpr void* find_first_pointer(
+    const std::tuple<TYPES...>& pointers,
+    std::index_sequence<INDEX, INDICES...>) {
+
+    auto ptr = std::get<INDEX>(pointers);
+    if (ptr != nullptr) {
+        return ptr;
+    } else {
+        if constexpr (sizeof...(INDICES) > 0) {
+            return find_first_pointer<TYPES...>(
+                pointers, std::index_sequence<INDICES...>());
+        } else {
+            return nullptr;
+        }
+    }
+}
+
+/// Generic function finding the last non-nullptr pointer in a tuple.
+template <typename... TYPES, std::size_t INDEX, std::size_t... INDICES>
+VECMEM_HOST constexpr void* find_last_pointer(
+    const std::tuple<TYPES...>& pointers,
+    const std::array<std::size_t, sizeof...(TYPES)>& sizes,
+    std::index_sequence<INDEX, INDICES...>) {
+
+    auto ptr = std::get<sizeof...(TYPES) - 1 - INDEX>(pointers);
+    if (ptr != nullptr) {
+        return ptr + std::get<sizeof...(TYPES) - 1 - INDEX>(sizes);
+    } else {
+        if constexpr (sizeof...(INDICES) > 0) {
+            return find_last_pointer<TYPES...>(
+                pointers, sizes, std::index_sequence<INDICES...>());
+        } else {
+            return nullptr;
+        }
+    }
+}
+
+/// Function creating a view for the layout of a buffer.
+template <typename... TYPES>
+VECMEM_HOST constexpr typename view<schema<TYPES...> >::memory_view_type
+find_layout_view(
+    const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
+    const std::array<std::size_t, sizeof...(TYPES)>& sizes) {
+
+    // The result type.
+    using result_type = typename view<schema<TYPES...> >::memory_view_type;
+
+    // Find the first non-zero pointer.
+    typename result_type::pointer ptr =
+        reinterpret_cast<typename result_type::pointer>(
+            find_first_pointer(layouts, std::index_sequence_for<TYPES...>()));
+    // Find the last non-zero pointer.
+    typename result_type::pointer end_ptr =
+        reinterpret_cast<typename result_type::pointer>(find_last_pointer(
+            layouts, sizes, std::index_sequence_for<TYPES...>()));
+
+    // Construct the result.
+    return {static_cast<typename result_type::size_type>(end_ptr - ptr), ptr};
+}
+
+/// Function creating a view of the payload of a buffer
+template <typename... TYPES>
+VECMEM_HOST constexpr typename view<schema<TYPES...> >::memory_view_type
+find_payload_view(
+    const std::tuple<typename view_type<TYPES>::payload_ptr...>& payloads,
+    const std::array<std::size_t, sizeof...(TYPES)>& sizes) {
+
+    // The result type.
+    using result_type = typename view<schema<TYPES...> >::memory_view_type;
+
+    // Find the first non-zero pointer.
+    typename result_type::pointer ptr =
+        reinterpret_cast<typename result_type::pointer>(
+            find_first_pointer(payloads, std::index_sequence_for<TYPES...>()));
+    // Find the last non-zero pointer.
+    typename result_type::pointer end_ptr =
+        reinterpret_cast<typename result_type::pointer>(find_last_pointer(
+            payloads, sizes, std::index_sequence_for<TYPES...>()));
+
+    // Construct the result.
+    return {static_cast<typename result_type::size_type>(end_ptr - ptr), ptr};
+}
+
+}  // namespace vecmem::edm::details

--- a/core/include/vecmem/edm/impl/buffer.ipp
+++ b/core/include/vecmem/edm/impl/buffer.ipp
@@ -1,0 +1,261 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/details/aligned_multiple_placement.hpp"
+#include "vecmem/edm/details/buffer_traits.hpp"
+#include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/edm/details/view_traits.hpp"
+
+// System include(s).
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+
+namespace vecmem {
+namespace edm {
+
+template <typename... VARTYPES>
+VECMEM_HOST buffer<schema<VARTYPES...>>::buffer(size_type capacity,
+                                                memory_resource& mr,
+                                                vecmem::data::buffer_type type)
+    : view_type(capacity) {
+
+    // Make sure that this constructor is not used for a container that has
+    // jagged vectors in it.
+    static_assert(
+        std::disjunction_v<type::details::is_jagged_vector<VARTYPES>...> ==
+            false,
+        "Use the other buffer constructor with jagged vector variables!");
+
+    // Perform the appropriate setup.
+    switch (type) {
+        case vecmem::data::buffer_type::fixed_size:
+            setup_fixed(std::vector<std::size_t>(capacity), mr, nullptr,
+                        std::index_sequence_for<VARTYPES...>{});
+            break;
+        case vecmem::data::buffer_type::resizable:
+            setup_resizable(std::vector<std::size_t>(capacity), mr, nullptr,
+                            std::index_sequence_for<VARTYPES...>{});
+            break;
+        default:
+            throw std::runtime_error("Unknown buffer type");
+    }
+}
+
+template <typename... VARTYPES>
+template <typename SIZE_TYPE,
+          std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
+                               std::is_unsigned<SIZE_TYPE>::value,
+                           bool>>
+VECMEM_HOST buffer<schema<VARTYPES...>>::buffer(
+    const std::vector<SIZE_TYPE>& capacities, memory_resource& main_mr,
+    memory_resource* host_mr, vecmem::data::buffer_type type)
+    : view_type(static_cast<size_type>(capacities.size())) {
+
+    // Make sure that this constructor is only used for a container that has
+    // jagged vectors in it.
+    static_assert(
+        std::disjunction_v<type::details::is_jagged_vector<VARTYPES>...>,
+        "Use the other buffer constructor without jagged vector variables!");
+
+    // Perform the appropriate setup.
+    switch (type) {
+        case vecmem::data::buffer_type::fixed_size:
+            setup_fixed(capacities, main_mr, host_mr,
+                        std::index_sequence_for<VARTYPES...>{});
+            break;
+        case vecmem::data::buffer_type::resizable:
+            setup_resizable(capacities, main_mr, host_mr,
+                            std::index_sequence_for<VARTYPES...>{});
+            break;
+        default:
+            throw std::runtime_error("Unknown buffer type");
+    }
+}
+
+template <typename... VARTYPES>
+template <typename SIZE_TYPE, std::size_t... INDICES>
+VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_fixed(
+    const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
+    memory_resource* host_mr, std::index_sequence<INDICES...>) {
+
+    // Sanity check.
+    static_assert(sizeof...(VARTYPES) == sizeof...(INDICES),
+                  "Invalid number of indices");
+
+    // Tuple of pointers to the allocated "layout objects" and "payloads".
+    std::tuple<typename details::view_type<VARTYPES>::layout_ptr...>
+        layout_ptrs, host_layout_ptrs;
+    std::tuple<typename details::view_type<VARTYPES>::payload_ptr...>
+        payload_ptrs;
+
+    // Allocate memory for fixed sized variables.
+    std::tie(m_memory, std::get<INDICES>(layout_ptrs)...,
+             std::get<INDICES>(payload_ptrs)...) =
+        vecmem::details::aligned_multiple_placement<
+            typename details::view_type<VARTYPES>::layout_type...,
+            typename details::view_type<VARTYPES>::payload_type...>(
+            mr, details::buffer_alloc<VARTYPES>::layout_size(capacities)...,
+            details::buffer_alloc<VARTYPES>::payload_size(capacities)...);
+
+    // Set the base class's memory views.
+    view_type::m_layout = details::find_layout_view<VARTYPES...>(
+        layout_ptrs,
+        {details::buffer_alloc<VARTYPES>::layout_size(capacities)...});
+    view_type::m_payload = details::find_payload_view<VARTYPES...>(
+        payload_ptrs,
+        {details::buffer_alloc<VARTYPES>::payload_size(capacities)...});
+
+    // If requested, allocate host memory for the layouts.
+    if (host_mr != nullptr) {
+
+        // Allocate memory for just the layout in host memory.
+        std::tie(m_host_memory, std::get<INDICES>(host_layout_ptrs)...) =
+            vecmem::details::aligned_multiple_placement<
+                typename details::view_type<VARTYPES>::layout_type...>(
+                *host_mr,
+                details::buffer_alloc<VARTYPES>::layout_size(capacities)...);
+
+        // Set the base class's memory view.
+        view_type::m_host_layout = details::find_layout_view<VARTYPES...>(
+            host_layout_ptrs,
+            {details::buffer_alloc<VARTYPES>::layout_size(capacities)...});
+    } else {
+        // The layout is apparently host accessible.
+        view_type::m_host_layout = view_type::m_layout;
+    }
+
+    // Initialize the views from all the raw pointers.
+    view_type::m_views = details::make_buffer_views<SIZE_TYPE, VARTYPES...>(
+        capacities, layout_ptrs, host_layout_ptrs, payload_ptrs,
+        std::index_sequence_for<VARTYPES...>{});
+}
+
+template <typename... VARTYPES>
+template <typename SIZE_TYPE, std::size_t... INDICES>
+VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_resizable(
+    const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
+    memory_resource* host_mr, std::index_sequence<INDICES...>) {
+
+    // Sanity check(s).
+    static_assert(sizeof...(VARTYPES) == sizeof...(INDICES),
+                  "Invalid number of indices");
+    static_assert(
+        std::disjunction_v<type::details::is_vector<VARTYPES>...>,
+        "Trying to create a resizable container without any vector variables!");
+
+    // Does the container have jagged vectors in it?
+    constexpr bool has_jagged_vectors =
+        std::disjunction_v<type::details::is_jagged_vector<VARTYPES>...>;
+
+    // Pointers to the allocated "size variables".
+    std::tuple<typename details::view_type<VARTYPES>::size_ptr...> sizes_ptrs;
+
+    // Tuple of pointers to the allocated "layout objects" and "payloads".
+    std::tuple<typename details::view_type<VARTYPES>::layout_ptr...>
+        layout_ptrs, host_layout_ptrs;
+    std::tuple<typename details::view_type<VARTYPES>::payload_ptr...>
+        payload_ptrs;
+
+    // Allocate memory for fixed sized variables. A little differently for
+    // containers that have some jagged vectors, versus ones that only have
+    // 1D vectors.
+    if constexpr (has_jagged_vectors) {
+        // Perform the allocation.
+        std::tie(m_memory, std::get<INDICES>(sizes_ptrs)...,
+                 std::get<INDICES>(layout_ptrs)...,
+                 std::get<INDICES>(payload_ptrs)...) =
+            vecmem::details::aligned_multiple_placement<
+                typename details::view_type<VARTYPES>::size_type...,
+                typename details::view_type<VARTYPES>::layout_type...,
+                typename details::view_type<VARTYPES>::payload_type...>(
+                mr, details::buffer_alloc<VARTYPES>::layout_size(capacities)...,
+                details::buffer_alloc<VARTYPES>::layout_size(capacities)...,
+                details::buffer_alloc<VARTYPES>::payload_size(capacities)...);
+        // Point the base class at the size array.
+        view_type::m_size = {
+            static_cast<typename view_type::memory_view_type::size_type>(
+                (details::buffer_alloc<VARTYPES>::layout_size(capacities) +
+                 ...) *
+                sizeof(typename view_type::size_type)),
+            reinterpret_cast<typename view_type::memory_view_type::pointer>(
+                details::find_first_pointer(
+                    sizes_ptrs, std::index_sequence_for<VARTYPES...>{}))};
+    } else {
+        // Perform the allocation.
+        typename view_type::size_pointer size = nullptr;
+        std::tie(m_memory, size, std::get<INDICES>(layout_ptrs)...,
+                 std::get<INDICES>(payload_ptrs)...) =
+            vecmem::details::aligned_multiple_placement<
+                typename view_type::size_type,
+                typename details::view_type<VARTYPES>::layout_type...,
+                typename details::view_type<VARTYPES>::payload_type...>(
+                mr, 1u,
+                details::buffer_alloc<VARTYPES>::layout_size(capacities)...,
+                details::buffer_alloc<VARTYPES>::payload_size(capacities)...);
+        // Point the base class at the size variable.
+        view_type::m_size = {
+            static_cast<typename view_type::memory_view_type::size_type>(
+                sizeof(typename view_type::size_type)),
+            reinterpret_cast<typename view_type::memory_view_type::pointer>(
+                size)};
+        // Set all size pointers to point at the one allocated number.
+        ((std::get<INDICES>(sizes_ptrs) = size), ...);
+    }
+
+    // Set the base class's memory views.
+    view_type::m_layout = details::find_layout_view<VARTYPES...>(
+        layout_ptrs,
+        {details::buffer_alloc<VARTYPES>::layout_size(capacities)...});
+    view_type::m_payload = details::find_payload_view<VARTYPES...>(
+        payload_ptrs,
+        {details::buffer_alloc<VARTYPES>::payload_size(capacities)...});
+
+    // If requested, allocate host memory for the layouts.
+    if (host_mr != nullptr) {
+
+        // Allocate memory for just the layout in host memory.
+        std::tie(m_host_memory, std::get<INDICES>(host_layout_ptrs)...) =
+            vecmem::details::aligned_multiple_placement<
+                typename details::view_type<VARTYPES>::layout_type...>(
+                *host_mr,
+                details::buffer_alloc<VARTYPES>::layout_size(capacities)...);
+
+        // Set the base class's memory view.
+        view_type::m_host_layout = details::find_layout_view<VARTYPES...>(
+            host_layout_ptrs,
+            {details::buffer_alloc<VARTYPES>::layout_size(capacities)...});
+    } else {
+        // The layout is apparently host accessible.
+        view_type::m_host_layout = view_type::m_layout;
+    }
+
+    // Initialize the views from all the raw pointers.
+    view_type::m_views = details::make_buffer_views<SIZE_TYPE, VARTYPES...>(
+        capacities, sizes_ptrs, layout_ptrs, host_layout_ptrs, payload_ptrs,
+        std::index_sequence_for<VARTYPES...>{});
+}
+
+}  // namespace edm
+
+template <typename... VARTYPES>
+VECMEM_HOST edm::view<edm::schema<VARTYPES...>> get_data(
+    edm::buffer<edm::schema<VARTYPES...>>& buffer) {
+
+    return buffer;
+}
+
+template <typename... VARTYPES>
+VECMEM_HOST edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>
+get_data(const edm::buffer<edm::schema<VARTYPES...>>& buffer) {
+
+    return buffer;
+}
+
+}  // namespace vecmem

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -23,6 +23,7 @@ vecmem_add_test( core
    "test_core_unique_alloc_ptr.cpp"
    "test_core_unique_obj_ptr.cpp"
    "test_core_tuple.cpp"
+   "test_core_edm_buffer.cpp"
    "test_core_edm_device.cpp"
    "test_core_edm_host.cpp"
    "test_core_edm_view.cpp"

--- a/tests/core/test_core_edm_buffer.cpp
+++ b/tests/core/test_core_edm_buffer.cpp
@@ -1,0 +1,416 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/edm/buffer.hpp"
+#include "vecmem/edm/device.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/utils/copy.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+// System include(s).
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+/// Test case for @c vecmem::edm::buffer.
+class core_edm_buffer_test : public testing::Test {
+
+protected:
+    /// Schema without any jagged vectors.
+    using simple_schema = vecmem::edm::schema<
+        vecmem::edm::type::scalar<int>, vecmem::edm::type::vector<float>,
+        vecmem::edm::type::scalar<double>, vecmem::edm::type::vector<double>,
+        vecmem::edm::type::vector<int>>;
+    /// Constant schema without any jagged vectors.
+    using simple_const_schema =
+        vecmem::edm::details::add_const_t<simple_schema>;
+
+    /// Schema with some jagged vectors.
+    using jagged_schema =
+        vecmem::edm::schema<vecmem::edm::type::vector<float>,
+                            vecmem::edm::type::jagged_vector<double>,
+                            vecmem::edm::type::scalar<int>,
+                            vecmem::edm::type::jagged_vector<int>>;
+    /// Constant schema with some jagged vectors.
+    using jagged_const_schema =
+        vecmem::edm::details::add_const_t<jagged_schema>;
+
+    /// Memory resource for the test(s)
+    vecmem::host_memory_resource m_resource;
+    /// Copy object for the test(s)
+    vecmem::copy m_copy;
+
+};  // class core_edm_buffer_test
+
+/// Capacities used for the test(s)
+static const std::vector<unsigned int> CAPACITIES = {10, 100, 1000};
+static const unsigned int CAPACITY =
+    static_cast<unsigned int>(CAPACITIES.size());
+
+TEST_F(core_edm_buffer_test, construct) {
+
+    // Test the creation of fixed sized and resizable "simple buffers".
+    vecmem::edm::buffer<simple_schema> buffer1{
+        CAPACITY, m_resource, vecmem::data::buffer_type::fixed_size};
+    vecmem::edm::buffer<simple_schema> buffer2{
+        CAPACITY, m_resource, vecmem::data::buffer_type::resizable};
+
+    // Test the creation of fixed sized and resizable "jagged buffers".
+    vecmem::edm::buffer<jagged_schema> buffer3{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::fixed_size};
+    vecmem::edm::buffer<jagged_schema> buffer4{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
+}
+
+TEST_F(core_edm_buffer_test, get_data) {
+
+    // Lambda creating constant views.
+    auto create_const_view = [](const auto& buffer) {
+        return vecmem::get_data(buffer);
+    };
+
+    // Construct a fixed sized, simple buffer.
+    vecmem::edm::buffer<simple_schema> buffer1{
+        CAPACITY, m_resource, vecmem::data::buffer_type::fixed_size};
+
+    // Make views of it.
+    vecmem::edm::view<simple_schema> view1 = vecmem::get_data(buffer1);
+    vecmem::edm::view<simple_const_schema> view2 = vecmem::get_data(buffer1);
+    vecmem::edm::view<simple_const_schema> view3 = create_const_view(buffer1);
+
+    // Lambda checking the simple, fixed sized views.
+    auto check_simple_fixed = [&](const auto& view) {
+        EXPECT_EQ(view.capacity(), CAPACITY);
+        EXPECT_EQ(view.size().size(), 0u);
+        EXPECT_EQ(view.size().ptr(), nullptr);
+        auto check_scalar = [](const auto& v) { EXPECT_NE(v, nullptr); };
+        auto check_vector = [&](const auto& v) {
+            EXPECT_EQ(v.size(), CAPACITY);
+            EXPECT_EQ(v.size_ptr(), nullptr);
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+        };
+        check_scalar(view.template get<0>());
+        check_vector(view.template get<1>());
+        check_scalar(view.template get<2>());
+        check_vector(view.template get<3>());
+        check_vector(view.template get<4>());
+    };
+
+    // Check the views.
+    check_simple_fixed(view1);
+    check_simple_fixed(view2);
+    check_simple_fixed(view3);
+
+    // Construct a resizable, simple buffer.
+    vecmem::edm::buffer<simple_schema> buffer2{
+        CAPACITY, m_resource, vecmem::data::buffer_type::resizable};
+    m_copy.memset(buffer2.size(), 0);
+
+    // Make views of it.
+    vecmem::edm::view<simple_schema> view4 = vecmem::get_data(buffer2);
+    vecmem::edm::view<simple_const_schema> view5 = vecmem::get_data(buffer2);
+    vecmem::edm::view<simple_const_schema> view6 = create_const_view(buffer2);
+
+    // Lambda checking the simple, resizable views.
+    auto check_simple_resizable = [&](const auto& view) {
+        EXPECT_EQ(view.capacity(), CAPACITY);
+        EXPECT_EQ(view.size().size(), sizeof(unsigned int));
+        EXPECT_NE(view.size().ptr(), nullptr);
+        auto check_scalar = [](const auto& v) { EXPECT_NE(v, nullptr); };
+        auto check_vector = [&](const auto& v) {
+            EXPECT_EQ(v.size(), 0u);
+            EXPECT_EQ(static_cast<const void*>(v.size_ptr()),
+                      static_cast<const void*>(view.size().ptr()));
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+        };
+        check_scalar(view.template get<0>());
+        check_vector(view.template get<1>());
+        check_scalar(view.template get<2>());
+        check_vector(view.template get<3>());
+        check_vector(view.template get<4>());
+    };
+
+    // Check the views.
+    check_simple_resizable(view4);
+    check_simple_resizable(view5);
+    check_simple_resizable(view6);
+
+    // Construct a fixed sized, jagged buffer.
+    vecmem::edm::buffer<jagged_schema> buffer3{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::fixed_size};
+
+    // Make views of it.
+    vecmem::edm::view<jagged_schema> view7 = vecmem::get_data(buffer3);
+    vecmem::edm::view<jagged_const_schema> view8 = vecmem::get_data(buffer3);
+    vecmem::edm::view<jagged_const_schema> view9 = create_const_view(buffer3);
+
+    // Lambda checking the jagged, fixed sized views.
+    auto check_jagged_fixed = [&](const auto& view) {
+        EXPECT_EQ(view.capacity(), CAPACITY);
+        EXPECT_EQ(view.size().size(), 0u);
+        EXPECT_EQ(view.size().ptr(), nullptr);
+        auto check_scalar = [](const auto& v) { EXPECT_NE(v, nullptr); };
+        auto check_vector = [&](const auto& v) {
+            EXPECT_EQ(v.size(), CAPACITY);
+            EXPECT_EQ(v.size_ptr(), nullptr);
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+        };
+        auto check_jagged = [&](const auto& v) {
+            EXPECT_EQ(v.size(), CAPACITY);
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+            EXPECT_NE(v.host_ptr(), nullptr);
+            EXPECT_EQ(v.host_ptr(), v.ptr());
+            for (unsigned int i = 0; i < CAPACITY; ++i) {
+                EXPECT_EQ(v.host_ptr()[i].size(), CAPACITIES[i]);
+                EXPECT_EQ(v.host_ptr()[i].size_ptr(), nullptr);
+                EXPECT_EQ(v.host_ptr()[i].capacity(), CAPACITIES[i]);
+                EXPECT_NE(v.host_ptr()[i].ptr(), nullptr);
+            }
+        };
+        check_vector(view.template get<0>());
+        check_jagged(view.template get<1>());
+        check_scalar(view.template get<2>());
+        check_jagged(view.template get<3>());
+    };
+
+    // Check the views.
+    check_jagged_fixed(view7);
+    check_jagged_fixed(view8);
+    check_jagged_fixed(view9);
+
+    // Construct a resizable, jagged buffer.
+    vecmem::edm::buffer<jagged_schema> buffer4{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
+    m_copy.memset(buffer4.size(), 0);
+
+    // Make views of it.
+    vecmem::edm::view<jagged_schema> view10 = vecmem::get_data(buffer4);
+    vecmem::edm::view<jagged_const_schema> view11 = vecmem::get_data(buffer4);
+    vecmem::edm::view<jagged_const_schema> view12 = create_const_view(buffer4);
+
+    // Lambda checking the jagged, resizable views.
+    auto check_jagged_resizable = [&](const auto& view) {
+        EXPECT_EQ(view.capacity(), CAPACITY);
+        // There are 2 jagged vectors in the container, which all need 3
+        // unsigned integers for their sizes.
+        EXPECT_EQ(view.size().size(), 2 * CAPACITY * sizeof(unsigned int));
+        EXPECT_NE(view.size().ptr(), nullptr);
+        auto check_scalar = [](const auto& v) { EXPECT_NE(v, nullptr); };
+        auto check_vector = [&](const auto& v) {
+            EXPECT_EQ(v.size(), CAPACITY);
+            EXPECT_EQ(v.size_ptr(), nullptr);
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+        };
+        auto check_jagged = [&](const auto& v) {
+            EXPECT_EQ(v.size(), CAPACITY);
+            EXPECT_EQ(v.capacity(), CAPACITY);
+            EXPECT_NE(v.ptr(), nullptr);
+            EXPECT_NE(v.host_ptr(), nullptr);
+            EXPECT_EQ(v.host_ptr(), v.ptr());
+            for (unsigned int i = 0; i < CAPACITY; ++i) {
+                EXPECT_EQ(v.host_ptr()[i].size(), 0u);
+                // Checking the exact value of v.host_ptr()[i].size_ptr()
+                // would be a bit too hard, to be worth it...
+                EXPECT_EQ(v.host_ptr()[i].capacity(), CAPACITIES[i]);
+                EXPECT_NE(v.host_ptr()[i].ptr(), nullptr);
+            }
+        };
+        check_vector(view.template get<0>());
+        check_jagged(view.template get<1>());
+        check_scalar(view.template get<2>());
+        check_jagged(view.template get<3>());
+    };
+
+    // Check the views.
+    check_jagged_resizable(view10);
+    check_jagged_resizable(view11);
+    check_jagged_resizable(view12);
+}
+
+TEST_F(core_edm_buffer_test, device) {
+
+    // Construct a fixed sized, simple buffer.
+    vecmem::edm::buffer<simple_schema> buffer1{
+        CAPACITY, m_resource, vecmem::data::buffer_type::fixed_size};
+
+    // Make a device container on top of it.
+    vecmem::edm::device<simple_schema> device1{buffer1};
+    ASSERT_EQ(device1.size(), CAPACITY);
+    ASSERT_EQ(device1.capacity(), CAPACITY);
+    auto check_fixed_vector = [&](const auto& v) {
+        ASSERT_EQ(v.size(), CAPACITY);
+        ASSERT_EQ(v.capacity(), CAPACITY);
+    };
+    check_fixed_vector(device1.get<1>());
+    check_fixed_vector(device1.get<3>());
+    check_fixed_vector(device1.get<4>());
+
+    // Fill it in some non-trivial way.
+    device1.get<0>() = 1;
+    std::fill(device1.get<1>().begin(), device1.get<1>().end(), 2.f);
+    device1.get<2>() = 3.;
+    std::fill(device1.get<3>().begin(), device1.get<3>().end(), 4.);
+    std::iota(device1.get<4>().begin(), device1.get<4>().end(), 5);
+
+    // Check the values. Making sure that there is no overlap between the
+    // variables in the buffer due to some bug.
+    EXPECT_EQ(device1.get<0>(), 1);
+    EXPECT_DOUBLE_EQ(device1.get<2>(), 3.);
+    std::for_each(device1.get<1>().begin(), device1.get<1>().end(),
+                  [](const auto& v) { EXPECT_FLOAT_EQ(v, 2.f); });
+    std::for_each(device1.get<3>().begin(), device1.get<3>().end(),
+                  [](const auto& v) { EXPECT_DOUBLE_EQ(v, 4.); });
+    for (unsigned int i = 0; i < CAPACITY; ++i) {
+        EXPECT_EQ(device1.get<4>()[i], static_cast<int>(5 + i));
+    }
+
+    // Construct a resizable, simple buffer.
+    vecmem::edm::buffer<simple_schema> buffer2{
+        CAPACITY, m_resource, vecmem::data::buffer_type::resizable};
+    m_copy.memset(buffer2.size(), 0);
+
+    // Make a device container on top of it.
+    vecmem::edm::device<simple_schema> device2{buffer2};
+    ASSERT_EQ(device2.size(), 0u);
+    ASSERT_EQ(device2.capacity(), CAPACITY);
+    auto check_resizable_vector = [&](const auto& v) {
+        ASSERT_EQ(v.size(), 0u);
+        ASSERT_EQ(v.capacity(), CAPACITY);
+    };
+    check_resizable_vector(device2.get<1>());
+    check_resizable_vector(device2.get<3>());
+    check_resizable_vector(device2.get<4>());
+
+    // Fill it in some non-trivial way.
+    device2.get<0>() = 1;
+    device2.get<2>() = 2.;
+    for (unsigned int i = 0; i < 2; ++i) {
+        const unsigned int ii = device2.push_back_default();
+        EXPECT_EQ(ii, i);
+        device2.get<1>()[ii] = 3.f;
+        device2.get<3>()[ii] = 4.;
+        device2.get<4>()[ii] = static_cast<int>(5 + i);
+    }
+
+    // Check the values.
+    EXPECT_EQ(device2.get<0>(), 1);
+    EXPECT_DOUBLE_EQ(device2.get<2>(), 2.);
+    EXPECT_EQ(device2.size(), 2u);
+    EXPECT_EQ(device2.get<1>().size(), 2u);
+    EXPECT_EQ(device2.get<3>().size(), 2u);
+    ASSERT_EQ(device2.get<4>().size(), 2u);
+    std::for_each(device2.get<1>().begin(), device2.get<1>().end(),
+                  [](const auto& v) { EXPECT_FLOAT_EQ(v, 3.f); });
+    std::for_each(device2.get<3>().begin(), device2.get<3>().end(),
+                  [](const auto& v) { EXPECT_DOUBLE_EQ(v, 4.); });
+    for (unsigned int i = 0; i < 2u; ++i) {
+        EXPECT_EQ(device2.get<4>()[i], static_cast<int>(5 + i));
+    }
+
+    // Construct a fixed sized, jagged buffer.
+    vecmem::edm::buffer<jagged_schema> buffer3{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::fixed_size};
+
+    // Make a device container on top of it.
+    vecmem::edm::device<jagged_schema> device3{buffer3};
+    ASSERT_EQ(device3.size(), CAPACITY);
+    ASSERT_EQ(device3.capacity(), CAPACITY);
+    auto check_fixed_jagged = [&](const auto& v) {
+        ASSERT_EQ(v.size(), CAPACITY);
+        ASSERT_EQ(v.capacity(), CAPACITY);
+        for (std::size_t i = 0; i < CAPACITY; ++i) {
+            ASSERT_EQ(v[i].size(), CAPACITIES[i]);
+            ASSERT_EQ(v[i].capacity(), CAPACITIES[i]);
+        }
+    };
+    check_fixed_vector(device3.get<0>());
+    check_fixed_jagged(device3.get<1>());
+    check_fixed_jagged(device3.get<3>());
+
+    // Fill it in some non-trivial way.
+    std::fill(device3.get<0>().begin(), device3.get<0>().end(), 1.f);
+    device3.get<2>() = 2;
+    for (unsigned int i = 0; i < CAPACITY; ++i) {
+        std::fill(device3.get<1>()[i].begin(), device3.get<1>()[i].end(), 3.);
+        std::iota(device3.get<3>()[i].begin(), device3.get<3>()[i].end(), 4);
+    }
+
+    // Check the values.
+    std::for_each(device3.get<0>().begin(), device3.get<0>().end(),
+                  [](const auto& v) { EXPECT_FLOAT_EQ(v, 1.f); });
+    EXPECT_EQ(device3.get<2>(), 2);
+    for (unsigned int i = 0; i < CAPACITY; ++i) {
+        std::for_each(device3.get<1>()[i].begin(), device3.get<1>()[i].end(),
+                      [](const auto& v) { EXPECT_DOUBLE_EQ(v, 3.); });
+        for (unsigned int j = 0; j < device3.get<3>()[i].size(); ++j) {
+            EXPECT_EQ(device3.get<3>()[i][j], static_cast<int>(4 + j));
+        }
+    }
+
+    // Construct a resizable, jagged buffer.
+    vecmem::edm::buffer<jagged_schema> buffer4{
+        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
+    m_copy.memset(buffer4.size(), 0);
+
+    // Make a device container on top of it.
+    vecmem::edm::device<jagged_schema> device4{buffer4};
+    ASSERT_EQ(device4.size(), CAPACITY);
+    ASSERT_EQ(device4.capacity(), CAPACITY);
+    auto check_resizable_jagged = [&](const auto& v) {
+        ASSERT_EQ(v.size(), CAPACITY);
+        ASSERT_EQ(v.capacity(), CAPACITY);
+        for (std::size_t i = 0; i < CAPACITY; ++i) {
+            ASSERT_EQ(v[i].size(), 0u);
+            ASSERT_EQ(v[i].capacity(), CAPACITIES[i]);
+        }
+    };
+    check_fixed_vector(device4.get<0>());
+    check_resizable_jagged(device4.get<1>());
+    check_resizable_jagged(device4.get<3>());
+
+    // Fill it in some non-trivial way.
+    std::fill(device4.get<0>().begin(), device4.get<0>().end(), 6.f);
+    device4.get<2>() = 7;
+    std::for_each(device4.get<1>().begin(), device4.get<1>().end(),
+                  [&](auto v) {
+                      const unsigned int size = v.capacity() / 2u;
+                      for (unsigned int i = 0; i < size; ++i) {
+                          v.push_back(8. + static_cast<double>(i));
+                      }
+                  });
+    std::for_each(device4.get<3>().begin(), device4.get<3>().end(),
+                  [&](auto v) {
+                      const unsigned int size = v.capacity() / 2u;
+                      for (unsigned int i = 0; i < size; ++i) {
+                          v.push_back(9 + static_cast<int>(i));
+                      }
+                  });
+
+    // Check the values.
+    std::for_each(device4.get<0>().begin(), device4.get<0>().end(),
+                  [](const auto& v) { EXPECT_FLOAT_EQ(v, 6.f); });
+    EXPECT_EQ(device4.get<2>(), 7);
+    for (unsigned int i = 0; i < CAPACITY; ++i) {
+        EXPECT_EQ(device4.get<1>()[i].size(), CAPACITIES[i] / 2u);
+        for (unsigned int j = 0; j < device4.get<1>()[i].size(); ++j) {
+            EXPECT_DOUBLE_EQ(device4.get<1>()[i][j],
+                             8. + static_cast<double>(j));
+        }
+        EXPECT_EQ(device4.get<3>()[i].size(), CAPACITIES[i] / 2u);
+        for (unsigned int j = 0; j < device4.get<3>()[i].size(); ++j) {
+            EXPECT_EQ(device4.get<3>()[i][j], 9 + static_cast<int>(j));
+        }
+    }
+}


### PR DESCRIPTION
In the 4th step of the #246 saga after #250, #251 and #252, we now arrived at the most complex part of this development. :thinking:

The `vecmem::edm::buffer` type tries to be pretty smart. It would only ever ask for a maximum of 2 allocations.
  - One "big" allocation in the main/device memory, which would hold all of the size, layout and payload data;
  - One optional "small" allocation in host(-accessible) memory, which holds the layout data.

The `vecmem::edm::view` type has a number of views into these memory blocks, but as far as the CUDA/SYCL/HIP runtimes are concerned, these are still single contiguous memory blocks.

The layout of the memory blocks is not super trivial. Maybe easiest to attach here the table that I wrote up for the Doxygen documentation. :thinking:

![image](https://github.com/acts-project/vecmem/assets/30694331/691adedc-5fcc-4d6a-bcb1-0e9674301284)

Note that at this point it is not possible to set up jagged vector variables with different sizes. With the current code the assumption is that all jagged vector variables would have the same internal capacities. This is not a fundamental restriction of the code, it will be possible to implement that sort of flexibility later on, but I just didn't want to complicate the code further with that at this stage.