### PR TITLE
Add Copy for SoA Containers, main branch (2023.12.10.)

### DIFF
--- a/core/include/vecmem/edm/details/host_traits.hpp
+++ b/core/include/vecmem/edm/details/host_traits.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 // Local include(s).
+#include "vecmem/containers/details/resize_jagged_vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/edm/details/schema_traits.hpp"
@@ -135,8 +136,11 @@ void host_resize(std::tuple<typename host_type<VARTYPES>::type...>& data,
                  std::size_t size, std::index_sequence<INDEX, Is...>) {
 
     // Resize this variable.
-    if constexpr (type::details::is_vector<typename std::tuple_element<
-                      INDEX, std::tuple<VARTYPES...>>::type>::value) {
+    if constexpr (type::details::is_jagged_vector_v<typename std::tuple_element<
+                      INDEX, std::tuple<VARTYPES...>>::type>) {
+        vecmem::details::resize_jagged_vector(std::get<INDEX>(data), size);
+    } else if constexpr (type::details::is_vector_v<typename std::tuple_element<
+                             INDEX, std::tuple<VARTYPES...>>::type>) {
         std::get<INDEX>(data).resize(size);
     }
     // Terminate, or continue.

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,6 +12,8 @@
 #include "vecmem/containers/data/jagged_vector_view.hpp"
 #include "vecmem/containers/data/vector_buffer.hpp"
 #include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/edm/host.hpp"
+#include "vecmem/edm/view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/utils/abstract_event.hpp"
 #include "vecmem/vecmem_core_export.hpp"
@@ -146,6 +148,32 @@ public:
 
     /// @}
 
+    /// @name SoA container handling functions
+    /// @{
+
+    /// Set up the internal state of a buffer correctly on a device
+    template <typename SCHEMA>
+    event_type setup(edm::view<SCHEMA> data) const;
+
+    /// Set all bytes of the container to some value
+    template <typename... VARTYPES>
+    event_type memset(edm::view<edm::schema<VARTYPES...>> data,
+                      int value) const;
+
+    /// Copy between two views
+    template <typename... VARTYPES1, typename... VARTYPES2>
+    event_type operator()(const edm::view<edm::schema<VARTYPES1...>>& from,
+                          edm::view<edm::schema<VARTYPES2...>> to,
+                          type::copy_type cptype = type::unknown) const;
+
+    /// Copy from a view, into a host container
+    template <typename... VARTYPES1, typename... VARTYPES2>
+    event_type operator()(const edm::view<edm::schema<VARTYPES1...>>& from,
+                          edm::host<edm::schema<VARTYPES2...>>& to,
+                          type::copy_type cptype = type::unknown) const;
+
+    /// @}
+
 protected:
     /// Perform a "low level" memory copy
     virtual void do_copy(std::size_t size, const void* from, void* to,
@@ -176,6 +204,31 @@ private:
     template <typename TYPE>
     static bool is_contiguous(const data::vector_view<TYPE>* data,
                               std::size_t size);
+    /// Implementation for the variadic @c memset function
+    template <typename... VARTYPES, std::size_t INDEX, std::size_t... Is>
+    void memset_impl(edm::view<edm::schema<VARTYPES...>> data, int value,
+                     std::index_sequence<INDEX, Is...>) const;
+    /// Implementation for setting the sizes of an SoA container
+    template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+              std::size_t... Is>
+    void resize_impl(const edm::view<edm::schema<VARTYPES1...>>& from,
+                     edm::host<edm::schema<VARTYPES2...>>& to,
+                     type::copy_type cptype,
+                     std::index_sequence<INDEX, Is...>) const;
+    /// Implementation for the variadic @c copy function (for the sizes)
+    template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+              std::size_t... Is>
+    void copy_sizes_impl(const edm::view<edm::schema<VARTYPES1...>>& from,
+                         edm::view<edm::schema<VARTYPES2...>> to,
+                         type::copy_type cptype,
+                         std::index_sequence<INDEX, Is...>) const;
+    /// Implementation for the variadic @c copy function (for the payload)
+    template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+              std::size_t... Is>
+    void copy_payload_impl(const edm::view<edm::schema<VARTYPES1...>>& from,
+                           edm::view<edm::schema<VARTYPES2...>> to,
+                           type::copy_type cptype,
+                           std::index_sequence<INDEX, Is...>) const;
 
 };  // class copy
 

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -10,6 +10,7 @@
 // VecMem include(s).
 #include "vecmem/containers/details/resize_jagged_vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
+#include "vecmem/edm/details/schema_traits.hpp"
 #include "vecmem/memory/host_memory_resource.hpp"
 #include "vecmem/utils/debug.hpp"
 #include "vecmem/utils/type_traits.hpp"
@@ -20,6 +21,7 @@
 #include <numeric>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -373,13 +375,14 @@ copy::event_type copy::set_sizes(
          i < data.size(); ++i) {
         if (data.host_ptr()[i].size_ptr() == nullptr) {
             perform_copy = false;
-        } else if (perform_copy == true) {
+            if (data.host_ptr()[i].capacity() != sizes[i]) {
+                throw std::runtime_error(
+                    "Non-resizable jaggged vector does not match the requested "
+                    "size");
+            }
+        } else if (perform_copy == false) {
             throw std::runtime_error(
                 "Inconsistent target jagged vector view received for resizing");
-        } else if (data.host_ptr()[i].capacity() != sizes[i]) {
-            throw std::runtime_error(
-                "Non-resizable jaggged vector does not match the requested "
-                "size");
         }
     }
     // If no copy is necessary, we're done.
@@ -393,6 +396,138 @@ copy::event_type copy::set_sizes(
 
     // Return a new event.
     return create_event();
+}
+
+template <typename SCHEMA>
+copy::event_type copy::setup(edm::view<SCHEMA> data) const {
+
+    // For empty containers nothing needs to be done.
+    if (data.capacity() == 0) {
+        return vecmem::copy::create_event();
+    }
+
+    // Copy the data layout to the device, if needed.
+    if (data.layout().ptr() != data.host_layout().ptr()) {
+        operator()(data.host_layout(), data.layout(), type::unknown);
+    }
+
+    // Initialize the "size variable(s)" correctly on the buffer.
+    if (data.size().ptr() != nullptr) {
+        memset(data.size(), 0);
+    }
+    VECMEM_DEBUG_MSG(3,
+                     "Prepared an SoA container of capacity %u "
+                     "for use on a device (layout: {%u, %p}, size: {%u, %p})",
+                     data.capacity(), data.layout().size(),
+                     static_cast<void*>(data.layout().ptr()),
+                     data.size().size(), static_cast<void*>(data.size().ptr()));
+
+    // Return a new event.
+    return create_event();
+}
+
+template <typename... VARTYPES>
+copy::event_type copy::memset(edm::view<edm::schema<VARTYPES...>> data,
+                              int value) const {
+
+    // For buffers, we can do this in one go.
+    if (data.payload().ptr() != nullptr) {
+        memset(data.payload(), value);
+    } else {
+        // Do the operation using the helper function, recursively.
+        memset_impl(data, value, std::index_sequence_for<VARTYPES...>{});
+    }
+
+    // Return a new event.
+    return create_event();
+}
+
+template <typename... VARTYPES1, typename... VARTYPES2>
+copy::event_type copy::operator()(
+    const edm::view<edm::schema<VARTYPES1...>>& from_view,
+    edm::view<edm::schema<VARTYPES2...>> to_view,
+    type::copy_type cptype) const {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(sizeof...(VARTYPES1) == sizeof...(VARTYPES2),
+                  "Can only use compatible types in the copy");
+    static_assert(
+        std::conjunction_v<std::is_same<VARTYPES1, VARTYPES2>...> ||
+            std::conjunction_v<
+                edm::type::details::is_same_nc<VARTYPES1, VARTYPES2>...>,
+        "Can only use compatible types in the copy");
+
+    // First, handle the simple case, when both views have a contiguous memory
+    // layout.
+    if ((from_view.payload().ptr() != nullptr) &&
+        (to_view.payload().ptr() != nullptr) &&
+        (from_view.payload().size() == to_view.payload().size())) {
+
+        // If the "common size" is zero, we're done.
+        if (from_view.payload().size() == 0) {
+            return vecmem::copy::create_event();
+        }
+
+        // Let the user know what's happening.
+        VECMEM_DEBUG_MSG(2, "Performing simple SoA copy of %u bytes",
+                         from_view.payload().size());
+
+        // Copy the payload with a single copy operation.
+        operator()(from_view.payload(), to_view.payload(), cptype);
+
+        // If the target view is resizable, set its size.
+        if (to_view.size().ptr() != nullptr) {
+            // If the source is also resizable, the situation should be simple.
+            if (from_view.size().ptr() != nullptr) {
+                // Check that the sizes are the same.
+                if (from_view.size().size() != to_view.size().size()) {
+                    throw std::runtime_error(
+                        "Copying between inconsistent containers");
+                }
+                // Perform a dumb copy.
+                operator()(from_view.size(), to_view.size(), cptype);
+            } else {
+                // If not, then copy the size(s) recursively.
+                copy_sizes_impl(from_view, to_view, cptype,
+                                std::index_sequence_for<VARTYPES1...>{});
+            }
+        }
+
+        // Create a synhronization event.
+        return create_event();
+    }
+
+    // If not, then do an un-optimized copy, variable-by-variable.
+    copy_payload_impl(from_view, to_view, cptype,
+                      std::index_sequence_for<VARTYPES1...>{});
+
+    // Return a new event.
+    return create_event();
+}
+
+template <typename... VARTYPES1, typename... VARTYPES2>
+copy::event_type copy::operator()(
+    const edm::view<edm::schema<VARTYPES1...>>& from_view,
+    edm::host<edm::schema<VARTYPES2...>>& to_vec,
+    type::copy_type cptype) const {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(sizeof...(VARTYPES1) == sizeof...(VARTYPES2),
+                  "Can only use compatible types in the copy");
+    static_assert(std::is_same<edm::schema<VARTYPES1...>,
+                               edm::schema<VARTYPES2...>>::value ||
+                      details::is_same_nc<edm::schema<VARTYPES1...>,
+                                          edm::schema<VARTYPES2...>>::value,
+                  "Can only use compatible types in the copy");
+
+    // Resize the output object to the correct size(s).
+    resize_impl(from_view, to_vec, cptype,
+                std::index_sequence_for<VARTYPES1...>{});
+
+    // Perform the memory copy.
+    return operator()(from_view, vecmem::get_data(to_vec), cptype);
 }
 
 template <typename TYPE1, typename TYPE2>
@@ -541,6 +676,218 @@ bool copy::is_contiguous(const data::vector_view<TYPE>* data,
         ptr = data[i].ptr();
     }
     return true;
+}
+
+template <typename... VARTYPES, std::size_t INDEX, std::size_t... Is>
+void copy::memset_impl(edm::view<edm::schema<VARTYPES...>> data, int value,
+                       std::index_sequence<INDEX, Is...>) const {
+
+    // Scalars do not have their own dedicated @c memset functions.
+    if constexpr (edm::type::details::is_scalar<typename std::tuple_element<
+                      INDEX, std::tuple<VARTYPES...>>::type>::value) {
+        do_memset(sizeof(typename std::tuple_element<
+                         INDEX, std::tuple<VARTYPES...>>::type::type),
+                  data.template get<INDEX>(), value);
+    } else {
+        // But vectors and jagged vectors do.
+        memset(data.template get<INDEX>(), value);
+    }
+    // Recurse into the next variable.
+    if constexpr (sizeof...(Is) > 0) {
+        memset_impl(data, value, std::index_sequence<Is...>{});
+    }
+}
+
+template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+          std::size_t... Is>
+void copy::resize_impl(const edm::view<edm::schema<VARTYPES1...>>& from_view,
+                       edm::host<edm::schema<VARTYPES2...>>& to_vec,
+                       [[maybe_unused]] type::copy_type cptype,
+                       std::index_sequence<INDEX, Is...>) const {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(sizeof...(VARTYPES1) == sizeof...(VARTYPES2),
+                  "Can only use compatible types in the copy");
+    static_assert(std::is_same<edm::schema<VARTYPES1...>,
+                               edm::schema<VARTYPES2...>>::value ||
+                      details::is_same_nc<edm::schema<VARTYPES1...>,
+                                          edm::schema<VARTYPES2...>>::value,
+                  "Can only use compatible types in the copy");
+    // The target is a host container, so the copy type can't be anything
+    // targeting a device.
+    assert((cptype == type::device_to_host) || (cptype == type::host_to_host) ||
+           (cptype == type::unknown));
+
+    // First, handle containers with no jagged vectors in them.
+    if constexpr ((std::disjunction_v<
+                       edm::type::details::is_jagged_vector<VARTYPES1>...> ==
+                   false) &&
+                  (std::disjunction_v<
+                       edm::type::details::is_jagged_vector<VARTYPES2>...> ==
+                   false)) {
+        // The single size of the source container.
+        typename edm::view<edm::schema<VARTYPES1...>>::size_type size =
+            from_view.capacity();
+        // If the container is resizable, take its size.
+        if (from_view.size().ptr() != nullptr) {
+            assert(
+                from_view.size().size() ==
+                sizeof(
+                    typename edm::view<edm::schema<VARTYPES1...>>::size_type));
+            do_copy(
+                sizeof(
+                    typename edm::view<edm::schema<VARTYPES1...>>::size_type),
+                from_view.size().ptr(), &size, cptype);
+            create_event()->wait();
+        }
+        // Resize the target container.
+        VECMEM_DEBUG_MSG(4, "Resizing a (non-jagged) container to size %u",
+                         size);
+        to_vec.resize(size);
+    } else {
+        // Resize vector and jagged vector variables one by one. Note that
+        // evaluation order matters here. Since all jagged vectors are vectors,
+        // but not all vectors are jagged vectors. ;-)
+        if constexpr (edm::type::details::is_jagged_vector<
+                          typename std::tuple_element<
+                              INDEX, std::tuple<VARTYPES1...>>::type>::value) {
+            // Get the sizes of this jagged vector.
+            auto sizes = get_sizes(from_view.template get<INDEX>());
+            // Set the "outer size" of the jagged vector.
+            VECMEM_DEBUG_MSG(
+                4, "Resizing jagged vector variable at index %lu to size %lu",
+                INDEX, sizes.size());
+            details::resize_jagged_vector(to_vec.template get<INDEX>(),
+                                          sizes.size());
+            // Set the "inner sizes" of the jagged vector.
+            for (std::size_t i = 0; i < sizes.size(); ++i) {
+                to_vec.template get<INDEX>()[i].resize(sizes[i]);
+            }
+        } else if constexpr (edm::type::details::is_vector<
+                                 typename std::tuple_element<
+                                     INDEX,
+                                     std::tuple<VARTYPES1...>>::type>::value) {
+            // Get the size of this vector.
+            auto size = get_size(from_view.template get<INDEX>());
+            // Resize the target vector.
+            VECMEM_DEBUG_MSG(4,
+                             "Resizing vector variable at index %lu to size %u",
+                             INDEX, size);
+            to_vec.template get<INDEX>().resize(size);
+        }
+        // Call this function recursively.
+        if constexpr (sizeof...(Is) > 0) {
+            resize_impl(from_view, to_vec, cptype,
+                        std::index_sequence<Is...>{});
+        }
+    }
+}
+
+template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+          std::size_t... Is>
+void copy::copy_sizes_impl(
+    const edm::view<edm::schema<VARTYPES1...>>& from_view,
+    edm::view<edm::schema<VARTYPES2...>> to_view,
+    [[maybe_unused]] type::copy_type cptype,
+    std::index_sequence<INDEX, Is...>) const {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(sizeof...(VARTYPES1) == sizeof...(VARTYPES2),
+                  "Can only use compatible types in the copy");
+    static_assert(std::is_same<edm::schema<VARTYPES1...>,
+                               edm::schema<VARTYPES2...>>::value ||
+                      details::is_same_nc<edm::schema<VARTYPES1...>,
+                                          edm::schema<VARTYPES2...>>::value,
+                  "Can only use compatible types in the copy");
+
+    // This should only be called for a resizable target container, with
+    // a non-resizable source container.
+    assert(to_view.size().ptr() != nullptr);
+    assert(from_view.size().ptr() == nullptr);
+
+    // First, handle containers with no jagged vectors in them.
+    if constexpr ((std::disjunction_v<
+                       edm::type::details::is_jagged_vector<VARTYPES1>...> ==
+                   false) &&
+                  (std::disjunction_v<
+                       edm::type::details::is_jagged_vector<VARTYPES2>...> ==
+                   false)) {
+        // Size of the source container.
+        typename edm::view<edm::schema<VARTYPES1...>>::size_type size =
+            from_view.capacity();
+        // Choose the copy type.
+        type::copy_type size_cptype = type::unknown;
+        switch (cptype) {
+            case type::host_to_device:
+            case type::device_to_device:
+                size_cptype = type::host_to_device;
+                break;
+            case type::host_to_host:
+            case type::device_to_host:
+                size_cptype = type::host_to_host;
+                break;
+            default:
+                break;
+        }
+        // Set the size of the target container.
+        do_copy(
+            sizeof(typename edm::view<edm::schema<VARTYPES2...>>::size_type),
+            &size, to_view.size().ptr(), size_cptype);
+    } else {
+        // For the jagged vector case we recursively copy the sizes of every
+        // jagged vector variable. The rest of the variables are not resizable
+        // in such a container, so they are ignored here.
+        if constexpr (edm::type::details::is_jagged_vector<
+                          typename std::tuple_element<
+                              INDEX, std::tuple<VARTYPES1...>>::type>::value) {
+            // Copy the sizes for this variable.
+            const auto sizes = get_sizes(from_view.template get<INDEX>());
+            set_sizes(sizes, to_view.template get<INDEX>());
+        }
+        // Call this function recursively.
+        if constexpr (sizeof...(Is) > 0) {
+            copy_sizes_impl(from_view, to_view, cptype,
+                            std::index_sequence<Is...>{});
+        }
+    }
+}
+
+template <typename... VARTYPES1, typename... VARTYPES2, std::size_t INDEX,
+          std::size_t... Is>
+void copy::copy_payload_impl(
+    const edm::view<edm::schema<VARTYPES1...>>& from_view,
+    edm::view<edm::schema<VARTYPES2...>> to_view, type::copy_type cptype,
+    std::index_sequence<INDEX, Is...>) const {
+
+    // The input and output types are allowed to be different, but only by
+    // const-ness.
+    static_assert(sizeof...(VARTYPES1) == sizeof...(VARTYPES2),
+                  "Can only use compatible types in the copy");
+    static_assert(std::is_same<edm::schema<VARTYPES1...>,
+                               edm::schema<VARTYPES2...>>::value ||
+                      details::is_same_nc<edm::schema<VARTYPES1...>,
+                                          edm::schema<VARTYPES2...>>::value,
+                  "Can only use compatible types in the copy");
+
+    // Scalars do not have their own dedicated @c copy functions.
+    if constexpr (edm::type::details::is_scalar<typename std::tuple_element<
+                      INDEX, std::tuple<VARTYPES1...>>::type>::value) {
+        do_copy(sizeof(typename std::tuple_element<
+                       INDEX, std::tuple<VARTYPES1...>>::type::type),
+                from_view.template get<INDEX>(), to_view.template get<INDEX>(),
+                cptype);
+    } else {
+        // But vectors and jagged vectors do.
+        operator()(from_view.template get<INDEX>(),
+                   to_view.template get<INDEX>(), cptype);
+    }
+    // Recurse into the next variable.
+    if constexpr (sizeof...(Is) > 0) {
+        copy_payload_impl(from_view, to_view, cptype,
+                          std::index_sequence<Is...>{});
+    }
 }
 
 }  // namespace vecmem

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -27,4 +27,5 @@ vecmem_add_test( core
    "test_core_edm_device.cpp"
    "test_core_edm_host.cpp"
    "test_core_edm_view.cpp"
+   "test_core_edm_copy.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )

--- a/tests/core/test_core_edm_copy.cpp
+++ b/tests/core/test_core_edm_copy.cpp
@@ -1,0 +1,279 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/edm/buffer.hpp"
+#include "vecmem/edm/device.hpp"
+#include "vecmem/edm/host.hpp"
+#include "vecmem/memory/host_memory_resource.hpp"
+#include "vecmem/utils/copy.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+/// Test case for the EDM code
+class core_edm_copy_test : public testing::Test {
+
+protected:
+    /// Schema without any jagged vectors.
+    using simple_schema = vecmem::edm::schema<
+        vecmem::edm::type::scalar<int>, vecmem::edm::type::vector<float>,
+        vecmem::edm::type::scalar<double>, vecmem::edm::type::vector<double>,
+        vecmem::edm::type::vector<int>>;
+    /// Constant schema without any jagged vectors.
+    using simple_const_schema =
+        vecmem::edm::details::add_const_t<simple_schema>;
+
+    /// Schema with some jagged vectors.
+    using jagged_schema =
+        vecmem::edm::schema<vecmem::edm::type::vector<float>,
+                            vecmem::edm::type::jagged_vector<double>,
+                            vecmem::edm::type::scalar<int>,
+                            vecmem::edm::type::jagged_vector<int>>;
+    /// Constant schema with some jagged vectors.
+    using jagged_const_schema =
+        vecmem::edm::details::add_const_t<jagged_schema>;
+
+    /// Fill a host container with some data.
+    void fill(vecmem::edm::host<simple_schema>& c) const {
+        c.resize(3);
+        c.get<0>() = 1;
+        c.get<1>() = {2.f, 3.f, 4.f};
+        c.get<2>() = 5.;
+        c.get<3>() = {6., 7., 8.};
+        c.get<4>() = {9, 10, 11};
+    }
+    /// Fill a host container with some data.
+    void fill(vecmem::edm::host<jagged_schema>& c) const {
+        c.resize(3);
+        c.get<0>() = {1.f, 2.f, 3.f};
+        c.get<1>()[0] = {4., 5.};
+        c.get<1>()[1] = {};
+        c.get<1>()[2] = {6., 7., 8.};
+        c.get<2>() = 9;
+        c.get<3>()[0] = {10, 11};
+        c.get<3>()[1] = {};
+        c.get<3>()[2] = {12, 13, 14};
+    }
+    /// Compare two containers.
+    void compare(const vecmem::edm::view<simple_const_schema>& c1,
+                 const vecmem::edm::view<simple_const_schema>& c2) const {
+        // Create device containers.
+        const vecmem::edm::device<simple_const_schema> d1{c1};
+        const vecmem::edm::device<simple_const_schema> d2{c2};
+        // Compare them.
+        EXPECT_EQ(d1.get<0>(), d2.get<0>());
+        ASSERT_EQ(d1.get<1>().size(), d2.get<1>().size());
+        for (unsigned int i = 0; i < d1.get<1>().size(); ++i) {
+            EXPECT_FLOAT_EQ(d1.get<1>()[i], d2.get<1>()[i]);
+        }
+        EXPECT_DOUBLE_EQ(d1.get<2>(), d2.get<2>());
+        ASSERT_EQ(d1.get<3>().size(), d2.get<3>().size());
+        for (unsigned int i = 0; i < d1.get<3>().size(); ++i) {
+            EXPECT_DOUBLE_EQ(d1.get<3>()[i], d2.get<3>()[i]);
+        }
+        ASSERT_EQ(d1.get<4>().size(), d2.get<4>().size());
+        for (unsigned int i = 0; i < d1.get<4>().size(); ++i) {
+            EXPECT_EQ(d1.get<4>()[i], d2.get<4>()[i]);
+        }
+    }
+    /// Compare two containers.
+    void compare(const vecmem::edm::view<jagged_const_schema>& c1,
+                 const vecmem::edm::view<jagged_const_schema>& c2) const {
+        // Create device containers.
+        const vecmem::edm::device<jagged_const_schema> d1{c1};
+        const vecmem::edm::device<jagged_const_schema> d2{c2};
+        // Compare them.
+        ASSERT_EQ(d1.get<0>().size(), d2.get<0>().size());
+        for (unsigned int i = 0; i < d1.get<0>().size(); ++i) {
+            EXPECT_FLOAT_EQ(d1.get<0>()[i], d2.get<0>()[i]);
+        }
+        ASSERT_EQ(d1.get<1>().size(), d2.get<1>().size());
+        for (unsigned int i = 0; i < d1.get<1>().size(); ++i) {
+            ASSERT_EQ(d1.get<1>()[i].size(), d2.get<1>()[i].size());
+            for (unsigned int j = 0; j < d1.get<1>()[i].size(); ++j) {
+                EXPECT_DOUBLE_EQ(d1.get<1>()[i][j], d2.get<1>()[i][j]);
+            }
+        }
+        EXPECT_EQ(d1.get<2>(), d2.get<2>());
+        ASSERT_EQ(d1.get<3>().size(), d2.get<3>().size());
+        for (unsigned int i = 0; i < d1.get<3>().size(); ++i) {
+            ASSERT_EQ(d1.get<3>()[i].size(), d2.get<3>()[i].size());
+            for (unsigned int j = 0; j < d1.get<3>()[i].size(); ++j) {
+                EXPECT_EQ(d1.get<3>()[i][j], d2.get<3>()[i][j]);
+            }
+        }
+    }
+
+    /// Memory resource for the test(s)
+    vecmem::host_memory_resource m_resource;
+    /// Helper object for the memory copies.
+    vecmem::copy m_copy;
+
+};  // class core_edm_copy_test
+
+TEST_F(core_edm_copy_test, host_to_host_simple) {
+
+    vecmem::edm::host<simple_schema> c1{m_resource};
+    vecmem::edm::host<simple_schema> c2{m_resource};
+
+    fill(c1);
+    m_copy(vecmem::get_data(c1), c2);
+    compare(vecmem::get_data(c1), vecmem::get_data(c2));
+}
+
+TEST_F(core_edm_copy_test, host_to_host_jagged) {
+
+    vecmem::edm::host<jagged_schema> c1{m_resource};
+    vecmem::edm::host<jagged_schema> c2{m_resource};
+
+    fill(c1);
+    m_copy(vecmem::get_data(c1), c2, vecmem::copy::type::host_to_host);
+    compare(vecmem::get_data(c1), vecmem::get_data(c2));
+}
+
+TEST_F(core_edm_copy_test, host_to_fixed_device_simple) {
+
+    vecmem::edm::host<simple_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<simple_schema> buffer{
+        static_cast<vecmem::edm::buffer<jagged_schema>::size_type>(host.size()),
+        m_resource, vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer);
+
+    m_copy(vecmem::get_data(host), buffer, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer));
+}
+
+TEST_F(core_edm_copy_test, host_to_fixed_device_jagged) {
+
+    vecmem::edm::host<jagged_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<jagged_schema> buffer{
+        std::vector<std::size_t>{2, 0, 3}, m_resource, nullptr,
+        vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer);
+
+    m_copy(vecmem::get_data(host), buffer, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer));
+}
+
+TEST_F(core_edm_copy_test, host_to_resizable_device_simple) {
+
+    vecmem::edm::host<simple_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<simple_schema> buffer{
+        10u, m_resource, vecmem::data::buffer_type::resizable};
+    m_copy.setup(buffer);
+
+    m_copy(vecmem::get_data(host), buffer, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer));
+}
+
+TEST_F(core_edm_copy_test, host_to_resizable_device_jagged) {
+
+    vecmem::edm::host<jagged_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<jagged_schema> buffer{
+        std::vector<std::size_t>{5, 5, 5}, m_resource, nullptr,
+        vecmem::data::buffer_type::resizable};
+    m_copy.setup(buffer);
+
+    m_copy(vecmem::get_data(host), buffer, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer));
+}
+
+TEST_F(core_edm_copy_test, host_to_device_to_fixed_device_simple) {
+
+    vecmem::edm::host<simple_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<simple_schema> buffer1{
+        static_cast<vecmem::edm::buffer<jagged_schema>::size_type>(host.size()),
+        m_resource, vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer1);
+
+    vecmem::edm::buffer<simple_schema> buffer2{
+        static_cast<vecmem::edm::buffer<jagged_schema>::size_type>(host.size()),
+        m_resource, vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer2);
+
+    m_copy(vecmem::get_data(host), buffer1, vecmem::copy::type::host_to_host);
+    m_copy(buffer1, buffer2, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer2));
+}
+
+TEST_F(core_edm_copy_test, host_to_device_to_fixed_device_jagged) {
+
+    vecmem::edm::host<jagged_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<jagged_schema> buffer1{
+        std::vector<std::size_t>{2, 0, 3}, m_resource, nullptr,
+        vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer1);
+
+    vecmem::edm::buffer<jagged_schema> buffer2{
+        std::vector<std::size_t>{2, 0, 3}, m_resource, nullptr,
+        vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer2);
+
+    m_copy(vecmem::get_data(host), buffer1, vecmem::copy::type::host_to_host);
+    m_copy(buffer1, buffer2, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer2));
+}
+
+TEST_F(core_edm_copy_test, host_to_device_to_resizable_device_simple) {
+
+    vecmem::edm::host<simple_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<simple_schema> buffer1{
+        static_cast<vecmem::edm::buffer<jagged_schema>::size_type>(host.size()),
+        m_resource, vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer1);
+
+    vecmem::edm::buffer<simple_schema> buffer2{
+        10u, m_resource, vecmem::data::buffer_type::resizable};
+    m_copy.setup(buffer2);
+
+    m_copy(vecmem::get_data(host), buffer1, vecmem::copy::type::host_to_host);
+    m_copy(buffer1, buffer2, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer2));
+}
+
+TEST_F(core_edm_copy_test, host_to_device_to_resizable_device_jagged) {
+
+    vecmem::edm::host<jagged_schema> host{m_resource};
+    fill(host);
+
+    vecmem::edm::buffer<jagged_schema> buffer1{
+        std::vector<std::size_t>{2, 0, 3}, m_resource, nullptr,
+        vecmem::data::buffer_type::fixed_size};
+    m_copy.setup(buffer1);
+
+    vecmem::edm::buffer<jagged_schema> buffer2{
+        std::vector<std::size_t>{5, 5, 5}, m_resource, nullptr,
+        vecmem::data::buffer_type::resizable};
+    m_copy.setup(buffer2);
+
+    m_copy(vecmem::get_data(host), buffer1, vecmem::copy::type::host_to_host);
+    m_copy(buffer1, buffer2, vecmem::copy::type::host_to_host);
+
+    compare(vecmem::get_data(host), vecmem::get_data(buffer2));
+}


### PR DESCRIPTION
In the 5th step of the #246 saga.

Taught `vecmem::copy` about the `vecmem::edm` types.

At the same time fixed a logic bug in `vecmem::copy::set_sizes` (noticed this one while making a mistake in the testing code...), and made `vecmem::edm::host::resize` a bit smarter. (Making sure that jagged vectors would be set up with the correct memory resource after the resize.)

Note that not everything is implemented for the SoA types yet. Generic `vecmem::copy::get_sizes` and `vecmem::copy::set_sizes` functions should still be added later on. I just couldn't come up with a good API for them yet. (Similar to how `vecmem::edm::buffer` cannot be set up yet for jagged vector variables of differing inner sizes.)