### PR TITLE
Const-ness Fixes, main branch (2023.12.17.)

### DIFF
--- a/core/include/vecmem/edm/container.hpp
+++ b/core/include/vecmem/edm/container.hpp
@@ -42,8 +42,10 @@ struct container {
     /// Host container type
     using host = interface_type<vecmem::edm::host<schema_type> >;
 
-    /// Data type
+    /// (Non-const) Data type
     using data = vecmem::edm::data<schema_type>;
+    /// (Const) Data type
+    using const_data = vecmem::edm::data<const_schema_type>;
 
     /// Buffer type
     using buffer = vecmem::edm::buffer<schema_type>;

--- a/core/include/vecmem/edm/data.hpp
+++ b/core/include/vecmem/edm/data.hpp
@@ -59,6 +59,11 @@ public:
 
     /// Default constructor
     data() = default;
+    /// Move constructor
+    data(data&&) = default;
+
+    /// Move assignment operator
+    data& operator=(data&&) = default;
 
     /// Constructor for the data object
     ///

--- a/tests/common/soa_copy_tests.ipp
+++ b/tests/common/soa_copy_tests.ipp
@@ -33,7 +33,8 @@ void soa_copy_tests_base<CONTAINER>::host_to_fixed_device_to_host_direct(
     device_cp.setup(device_buffer);
 
     // Copy the data to the device.
-    device_cp(vecmem::get_data(input), device_buffer,
+    const typename CONTAINER::data input_data = vecmem::get_data(input);
+    device_cp(vecmem::get_data(input_data), device_buffer,
               vecmem::copy::type::host_to_device);
 
     // Create the target host container.
@@ -125,7 +126,8 @@ void soa_copy_tests_base<CONTAINER>::host_to_resizable_device_to_host(
     device_cp.setup(device_buffer);
 
     // Copy the data to the device.
-    device_cp(vecmem::get_data(input), device_buffer,
+    const typename CONTAINER::data input_data = vecmem::get_data(input);
+    device_cp(vecmem::get_data(input_data), device_buffer,
               vecmem::copy::type::host_to_device);
 
     // Create the target host container.


### PR DESCRIPTION
Unfortunately as soon as I tried to integrate `v1.1.0` into [tracccc](https://github.com/acts-project/traccc), I found a mistake in the code. 😦

https://github.com/acts-project/vecmem/blob/v1.1.0/core/include/vecmem/utils/impl/copy.ipp#L525-L529

That code should've been like the one written here:

https://github.com/acts-project/vecmem/blob/v1.1.0/core/include/vecmem/utils/impl/copy.ipp#L459-L463

But at this point I decided that I would rather re-work the const-correctness in `vecmem::copy` a bit more deeply. 🤔 Since these `static_assert`-s have given me too much grief during the SoA code development. And I was also reminded during that development that all our view types have to support non-const to const conversions themselves anyway.

So in this update `vecmem::copy` operations are always explicitly going from constant to non-constant types. The "from" and "to" types are no longer two separate template types. So when the user would provide two non-const views, the conversion would happen in the view's constructor.

While doing this, I also noticed that:
  - `vecmem::edm::container` didn't have a `const_data` type;
  - `vecmem::edm::data` didn't have a move constructor or move assignment operator.

While not absolutely related to the rest of the update, I chose to fix those here as well. Mainly because the `vecmem::edm::container` fix made it easier to test the changes made in `vecmem::copy`. :wink:

P.S. And yes, I tested that [tracccc](https://github.com/acts-project/traccc) builds successfully with this update. 😛