### PR TITLE
Synchronized Memory Resource, main branch (2023.12.27.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -137,6 +137,9 @@ vecmem_add_library( vecmem_core core
    # Terminal memory resource.
    "src/memory/terminal_memory_resource.cpp"
    "include/vecmem/memory/terminal_memory_resource.hpp"
+   # Synchronized memory resource.
+   "src/memory/synchronized_memory_resource.cpp"
+   "include/vecmem/memory/synchronized_memory_resource.hpp"
    # Utilities.
    "include/vecmem/utils/copy.hpp"
    "include/vecmem/utils/impl/copy.ipp"

--- a/core/include/vecmem/memory/synchronized_memory_resource.hpp
+++ b/core/include/vecmem/memory/synchronized_memory_resource.hpp
@@ -1,0 +1,76 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/memory/memory_resource.hpp"
+#include "vecmem/vecmem_core_export.hpp"
+
+// System include(s).
+#include <functional>
+#include <mutex>
+
+namespace vecmem {
+
+/// A memory resource that synchronizes the operations of an upstream resource
+///
+/// This memory resource is a wrapper around another memory resource that
+/// synchronizes all operations of the upstream resource. This is useful for
+/// memory resources that are themselves not thread-safe, but need to be used in
+/// a multi-threaded environment.
+///
+class synchronized_memory_resource final : public memory_resource {
+
+public:
+    /// Constructor around an upstream memory resource
+    VECMEM_CORE_EXPORT
+    synchronized_memory_resource(memory_resource& upstream);
+    /// Move constructor
+    VECMEM_CORE_EXPORT
+    synchronized_memory_resource(synchronized_memory_resource&& parent);
+    /// Copy constructor
+    VECMEM_CORE_EXPORT
+    synchronized_memory_resource(const synchronized_memory_resource& parent);
+
+    /// Destructor
+    VECMEM_CORE_EXPORT
+    virtual ~synchronized_memory_resource();
+
+    /// Move assignment operator
+    VECMEM_CORE_EXPORT
+    synchronized_memory_resource& operator=(synchronized_memory_resource&& rhs);
+    /// Copy assignment operator
+    VECMEM_CORE_EXPORT
+    synchronized_memory_resource& operator=(
+        const synchronized_memory_resource& rhs);
+
+private:
+    /// @name Function(s) implementing @c vecmem::memory_resource
+    /// @{
+
+    /// Allocate memory with one of the underlying resources
+    VECMEM_CORE_EXPORT
+    virtual void* do_allocate(std::size_t, std::size_t) override final;
+    /// De-allocate a previously allocated memory block
+    VECMEM_CORE_EXPORT
+    virtual void do_deallocate(void* p, std::size_t,
+                               std::size_t) override final;
+    /// Compare the equality of @c *this memory resource with another
+    VECMEM_CORE_EXPORT
+    virtual bool do_is_equal(
+        const memory_resource& other) const noexcept override final;
+
+    /// @}
+
+    /// The upstream memory resource
+    std::reference_wrapper<memory_resource> m_upstream;
+    /// The mutex to synchronize the upstream memory resource's operations
+    std::mutex m_mutex;
+
+};  // class synchronized_memory_resource
+
+}  // namespace vecmem

--- a/core/src/memory/synchronized_memory_resource.cpp
+++ b/core/src/memory/synchronized_memory_resource.cpp
@@ -1,0 +1,75 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/memory/synchronized_memory_resource.hpp"
+
+namespace vecmem {
+
+synchronized_memory_resource::synchronized_memory_resource(
+    memory_resource& upstream)
+    : m_upstream(upstream) {}
+
+synchronized_memory_resource::synchronized_memory_resource(
+    synchronized_memory_resource&& parent)
+    : m_upstream(std::move(parent.m_upstream)) {}
+
+synchronized_memory_resource::synchronized_memory_resource(
+    const synchronized_memory_resource& parent)
+    : m_upstream(parent.m_upstream) {}
+
+synchronized_memory_resource::~synchronized_memory_resource() = default;
+
+synchronized_memory_resource& synchronized_memory_resource::operator=(
+    synchronized_memory_resource&& rhs) {
+
+    if (this != &rhs) {
+        m_upstream = std::move(rhs.m_upstream);
+    }
+    return *this;
+}
+
+synchronized_memory_resource& synchronized_memory_resource::operator=(
+    const synchronized_memory_resource& rhs) {
+
+    if (this != &rhs) {
+        m_upstream = rhs.m_upstream;
+    }
+    return *this;
+}
+
+void* synchronized_memory_resource::do_allocate(std::size_t bytes,
+                                                std::size_t alignment) {
+
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    return m_upstream.get().allocate(bytes, alignment);
+}
+
+void synchronized_memory_resource::do_deallocate(void* p, std::size_t bytes,
+                                                 std::size_t alignment) {
+
+    const std::lock_guard<std::mutex> lock(m_mutex);
+    m_upstream.get().deallocate(p, bytes, alignment);
+}
+
+bool synchronized_memory_resource::do_is_equal(
+    const memory_resource& other) const noexcept {
+
+    // Check if the other resource is also a synchronized resource.
+    const synchronized_memory_resource* otherSynchronized =
+        dynamic_cast<const synchronized_memory_resource*>(&other);
+    if (otherSynchronized) {
+        // If so, check if the underlying resources are equal.
+        return m_upstream.get().is_equal(otherSynchronized->m_upstream.get());
+    } else {
+        // If not, check if the underlying resource is equal to the other
+        // resource.
+        return m_upstream.get().is_equal(other);
+    }
+}
+
+}  // namespace vecmem

--- a/tests/core/test_core_memory_resources.cpp
+++ b/tests/core/test_core_memory_resources.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -21,6 +21,7 @@
 #include "vecmem/memory/host_memory_resource.hpp"
 #include "vecmem/memory/identity_memory_resource.hpp"
 #include "vecmem/memory/instrumenting_memory_resource.hpp"
+#include "vecmem/memory/synchronized_memory_resource.hpp"
 #include "vecmem/memory/terminal_memory_resource.hpp"
 
 // GoogleTest include(s).
@@ -38,6 +39,9 @@ static vecmem::arena_memory_resource arena_resource(host_resource, 20000,
                                                     10000000);
 static vecmem::instrumenting_memory_resource instrumenting_resource(
     host_resource);
+static vecmem::synchronized_memory_resource synchronized_resource(
+    host_resource);
+
 static vecmem::identity_memory_resource identity_resource(host_resource);
 static vecmem::conditional_memory_resource conditional_resource(
     host_resource, [](std::size_t, std::size_t) { return true; });
@@ -53,6 +57,8 @@ static vecmem::choice_memory_resource choice_resource(
 static vecmem::debug_memory_resource debug_host_resource(host_resource);
 static vecmem::debug_memory_resource debug_binary_resource(binary_resource);
 static vecmem::debug_memory_resource debug_arena_resource(arena_resource);
+static vecmem::debug_memory_resource debug_synchronized_resource(
+    synchronized_resource);
 
 // Set up the test name generating helper object.
 static vecmem::testing::memory_resource_name_gen name_gen(
@@ -61,6 +67,7 @@ static vecmem::testing::memory_resource_name_gen name_gen(
      {&contiguous_resource, "contiguous_resource"},
      {&arena_resource, "arena_resource"},
      {&instrumenting_resource, "instrumenting_resource"},
+     {&synchronized_resource, "synchronized_resource"},
      {&identity_resource, "identity_resource"},
      {&conditional_resource, "conditional_resource"},
      {&coalescing_resource_1, "coalescing_resource_1"},
@@ -68,43 +75,48 @@ static vecmem::testing::memory_resource_name_gen name_gen(
      {&choice_resource, "choice_resource"},
      {&debug_host_resource, "debug_host_resource"},
      {&debug_binary_resource, "debug_binary_resource"},
-     {&debug_arena_resource, "debug_arena_resource"}});
+     {&debug_arena_resource, "debug_arena_resource"},
+     {&debug_synchronized_resource, "debug_synchronized_resource"}});
 
 // Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_basic,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
-                    &instrumenting_resource, &identity_resource,
-                    &conditional_resource, &coalescing_resource_1,
-                    &coalescing_resource_2, &choice_resource,
-                    &debug_host_resource, &debug_binary_resource,
-                    &debug_arena_resource),
+                    &instrumenting_resource, &synchronized_resource,
+                    &identity_resource, &conditional_resource,
+                    &coalescing_resource_1, &coalescing_resource_2,
+                    &choice_resource, &debug_host_resource,
+                    &debug_binary_resource, &debug_arena_resource,
+                    &debug_synchronized_resource),
     name_gen);
 
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_host_accessible,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
-                    &instrumenting_resource, &identity_resource,
-                    &conditional_resource, &coalescing_resource_1,
-                    &coalescing_resource_2, &choice_resource,
-                    &debug_host_resource, &debug_binary_resource,
-                    &debug_arena_resource),
+                    &instrumenting_resource, &synchronized_resource,
+                    &identity_resource, &conditional_resource,
+                    &coalescing_resource_1, &coalescing_resource_2,
+                    &choice_resource, &debug_host_resource,
+                    &debug_binary_resource, &debug_arena_resource,
+                    &debug_synchronized_resource),
     name_gen);
 
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_stress,
     testing::Values(&host_resource, &binary_resource, &arena_resource,
-                    &instrumenting_resource, &identity_resource,
-                    &conditional_resource, &coalescing_resource_1,
-                    &coalescing_resource_2, &choice_resource,
-                    &debug_host_resource, &debug_binary_resource,
-                    &debug_arena_resource),
+                    &instrumenting_resource, &synchronized_resource,
+                    &identity_resource, &conditional_resource,
+                    &coalescing_resource_1, &coalescing_resource_2,
+                    &choice_resource, &debug_host_resource,
+                    &debug_binary_resource, &debug_arena_resource,
+                    &debug_synchronized_resource),
     name_gen);
 
 INSTANTIATE_TEST_SUITE_P(
     core_memory_resource_tests, memory_resource_test_alignment,
-    testing::Values(&host_resource, &instrumenting_resource, &identity_resource,
+    testing::Values(&host_resource, &instrumenting_resource,
+                    &synchronized_resource, &identity_resource,
                     &conditional_resource, &coalescing_resource_1,
                     &coalescing_resource_2, &choice_resource,
-                    &debug_host_resource),
+                    &debug_host_resource, &debug_synchronized_resource),
     name_gen);


### PR DESCRIPTION
After #259, this is "the other" memory resource that I want to steal from the [Thrust memory resources](https://github.com/NVIDIA/cccl/tree/main/thrust/thrust/mr).

In Thrust there is an "unsynchronized" (thread-unsafe) and "synchronized" (thread-safe) version of every memory resource. They need to do that (in the end...), because [thrust::mr::memory_resource](https://github.com/NVIDIA/cccl/blob/main/thrust/thrust/mr/memory_resource.h) is templated. But since [std::pmr::memory_resource](https://en.cppreference.com/w/cpp/memory/memory_resource) is not, instead of adding a "thread-safe wrapper" around all of our currently thread-unsafe memory resources, we can also do what this PR does. Just add a single `vecmem::synchronized_memory_resource` that makes sure that all allocations and de-allocations happen one-at-a-time for its upstream memory resource.

The code is trivially simple in the end, but I think it could be useful in a couple of cases. 🤔

Note that Thrust also provides a "thread local version" of every one of its memory resources. But that I don't want to copy for our project. 🤔 `thread_local` is a bit heavy. So I want to leave it up to the frameworks using our memory resources, to deal with instantiating multiple memory resource objects for their multiple threads. As the frameworks themselves should be able to do it much more efficiently. (At least with [TBB](https://github.com/oneapi-src/oneTBB) this can be done more efficiently than with `thread_local`.)