### PR TITLE
EDM Device Test Fix, main branch (2024.02.05.)

### DIFF
--- a/tests/cuda/test_cuda_edm.cpp
+++ b/tests/cuda/test_cuda_edm.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,14 +19,14 @@
 #include <gtest/gtest.h>
 
 /// Host memory resource to use in the tests.
-static vecmem::cuda::host_memory_resource host_mr;
+static vecmem::cuda::host_memory_resource cuda_host_mr;
 /// Device memory resource to use in the tests.
-static vecmem::cuda::device_memory_resource device_mr;
+static vecmem::cuda::device_memory_resource cuda_device_mr;
 /// Managed memory resource to use in the tests.
-static vecmem::cuda::managed_memory_resource managed_mr;
+static vecmem::cuda::managed_memory_resource cuda_managed_mr;
 
 /// Synchronous device copy object to use in the tests.
-static vecmem::cuda::copy copy;
+static vecmem::cuda::copy cuda_copy;
 
 /// Pointer to the function filling a simple SoA container on a CUDA device.
 static void* cudaSimpleFillPtr = reinterpret_cast<void*>(&cudaSimpleFill);
@@ -39,11 +39,13 @@ static void* cudaJaggedFillPtr = reinterpret_cast<void*>(&cudaJaggedFill);
 static void* cudaJaggedModifyPtr = reinterpret_cast<void*>(&cudaJaggedModify);
 
 // Instantiate the test suites.
-INSTANTIATE_TEST_SUITE_P(
-    cuda_soa_device_tests_simple, soa_device_tests_simple,
-    testing::Values(std::tie(host_mr, device_mr, managed_mr, copy,
-                             cudaSimpleFillPtr, cudaSimpleModifyPtr)));
-INSTANTIATE_TEST_SUITE_P(
-    cuda_soa_device_tests_jagged, soa_device_tests_jagged,
-    testing::Values(std::tie(host_mr, device_mr, managed_mr, copy,
-                             cudaJaggedFillPtr, cudaJaggedModifyPtr)));
+INSTANTIATE_TEST_SUITE_P(cuda_soa_device_tests_simple, soa_device_tests_simple,
+                         testing::Values(std::tie(cuda_host_mr, cuda_device_mr,
+                                                  cuda_managed_mr, cuda_copy,
+                                                  cudaSimpleFillPtr,
+                                                  cudaSimpleModifyPtr)));
+INSTANTIATE_TEST_SUITE_P(cuda_soa_device_tests_jagged, soa_device_tests_jagged,
+                         testing::Values(std::tie(cuda_host_mr, cuda_device_mr,
+                                                  cuda_managed_mr, cuda_copy,
+                                                  cudaJaggedFillPtr,
+                                                  cudaJaggedModifyPtr)));

--- a/tests/hip/test_hip_edm.cpp
+++ b/tests/hip/test_hip_edm.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,12 +18,12 @@
 #include <gtest/gtest.h>
 
 /// Host memory resource to use in the tests.
-static vecmem::hip::host_memory_resource host_mr;
+static vecmem::hip::host_memory_resource hip_host_mr;
 /// Device memory resource to use in the tests.
-static vecmem::hip::device_memory_resource device_mr;
+static vecmem::hip::device_memory_resource hip_device_mr;
 
 /// Synchronous device copy object to use in the tests.
-static vecmem::hip::copy copy;
+static vecmem::hip::copy hip_copy;
 
 /// Pointer to the function filling a simple SoA container on a HIP device.
 static void* hipSimpleFillPtr = reinterpret_cast<void*>(&hipSimpleFill);
@@ -36,11 +36,11 @@ static void* hipJaggedFillPtr = reinterpret_cast<void*>(&hipJaggedFill);
 static void* hipJaggedModifyPtr = reinterpret_cast<void*>(&hipJaggedModify);
 
 // Instantiate the test suites.
-INSTANTIATE_TEST_SUITE_P(hip_soa_device_tests_simple, soa_device_tests_simple,
-                         testing::Values(std::tie(host_mr, device_mr, host_mr,
-                                                  copy, hipSimpleFillPtr,
-                                                  hipSimpleModifyPtr)));
-INSTANTIATE_TEST_SUITE_P(hip_soa_device_tests_jagged, soa_device_tests_jagged,
-                         testing::Values(std::tie(host_mr, device_mr, host_mr,
-                                                  copy, hipJaggedFillPtr,
-                                                  hipJaggedModifyPtr)));
+INSTANTIATE_TEST_SUITE_P(
+    hip_soa_device_tests_simple, soa_device_tests_simple,
+    testing::Values(std::tie(hip_host_mr, hip_device_mr, hip_host_mr, hip_copy,
+                             hipSimpleFillPtr, hipSimpleModifyPtr)));
+INSTANTIATE_TEST_SUITE_P(
+    hip_soa_device_tests_jagged, soa_device_tests_jagged,
+    testing::Values(std::tie(hip_host_mr, hip_device_mr, hip_host_mr, hip_copy,
+                             hipJaggedFillPtr, hipJaggedModifyPtr)));

--- a/tests/sycl/test_sycl_edm.sycl
+++ b/tests/sycl/test_sycl_edm.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,14 +28,14 @@
 static cl::sycl::queue queue;
 
 /// Host memory resource to use in the tests.
-static vecmem::sycl::host_memory_resource host_mr{&queue};
+static vecmem::sycl::host_memory_resource sycl_host_mr{&queue};
 /// Device memory resource to use in the tests.
-static vecmem::sycl::device_memory_resource device_mr{&queue};
+static vecmem::sycl::device_memory_resource sycl_device_mr{&queue};
 /// Shared memory resource to use in the tests.
-static vecmem::sycl::shared_memory_resource shared_mr{&queue};
+static vecmem::sycl::shared_memory_resource sycl_shared_mr{&queue};
 
 /// Synchronous device copy object to use in the tests.
-static vecmem::sycl::copy copy{&queue};
+static vecmem::sycl::copy sycl_copy{&queue};
 
 /// Fill a simple SoA container with some data.
 void syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
@@ -109,10 +109,12 @@ static void* syclJaggedModifyPtr = reinterpret_cast<void*>(&syclJaggedModify);
 
 // Instantiate the test suites.
 INSTANTIATE_TEST_SUITE_P(sycl_soa_device_tests_simple, soa_device_tests_simple,
-                         testing::Values(std::tie(host_mr, device_mr, shared_mr,
-                                                  copy, syclSimpleFillPtr,
+                         testing::Values(std::tie(sycl_host_mr, sycl_device_mr,
+                                                  sycl_shared_mr, sycl_copy,
+                                                  syclSimpleFillPtr,
                                                   syclSimpleModifyPtr)));
 INSTANTIATE_TEST_SUITE_P(sycl_soa_device_tests_jagged, soa_device_tests_jagged,
-                         testing::Values(std::tie(host_mr, device_mr, shared_mr,
-                                                  copy, syclJaggedFillPtr,
+                         testing::Values(std::tie(sycl_host_mr, sycl_device_mr,
+                                                  sycl_shared_mr, sycl_copy,
+                                                  syclJaggedFillPtr,
                                                   syclJaggedModifyPtr)));


### PR DESCRIPTION
Fixed "variable shadowing" warnings coming from MSVC. Things like:

```
[ 93%] Building CXX object tests/cuda/CMakeFiles/vecmem_test_cuda.dir/test_cuda_edm.cpp.obj
test_cuda_edm.cpp
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(19): warning C4459: declaration of 'host_mr' hides global declaration
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\cuda\test_cuda_edm.cpp(22): note: see declaration of 'host_mr'
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(19): note: the template instantiation context (the oldest one first) is
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(135): note: see reference to class template instantiation 'soa_device_tests_base<vecmem::testing::simple_soa_container>' being compiled
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(16): note: while compiling class template member function 'void soa_device_tests_base<vecmem::testing::simple_soa_container>::modify_managed(const soa_device_test_parameters &)'
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(137): note: see the first reference to 'soa_device_tests_base<vecmem::testing::simple_soa_container>::modify_managed' in 'soa_device_tests_simple_modify_managed_Test::TestBody'
...
```

And:

```
[100%] Building SYCL object tests/sycl/CMakeFiles/vecmem_test_sycl.dir/test_sycl_edm.sycl.obj
In file included from C:\Users\krasz\ATLAS\vecmem\vecmem\tests\sycl\test_sycl_edm.sycl:13:
In file included from C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.hpp:53:
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(19,30): warning: declaration shadows a variable in
      the global namespace [-Wshadow]
   19 |     vecmem::memory_resource& host_mr = std::get<0>(params);
      |                              ^
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\sycl\test_sycl_edm.sycl(31,43): note: previous declaration is here
   31 | static vecmem::sycl::host_memory_resource host_mr{&queue};
      |                                           ^
In file included from C:\Users\krasz\ATLAS\vecmem\vecmem\tests\sycl\test_sycl_edm.sycl:13:
In file included from C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.hpp:53:
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\common\soa_device_tests.ipp(53,30): warning: declaration shadows a variable in
      the global namespace [-Wshadow]
   53 |     vecmem::memory_resource& host_mr = std::get<0>(params);
      |                              ^
C:\Users\krasz\ATLAS\vecmem\vecmem\tests\sycl\test_sycl_edm.sycl(31,43): note: previous declaration is here
   31 | static vecmem::sycl::host_memory_resource host_mr{&queue};
      |                                           ^
...
```

Since these only show up with CUDA and SYCL on Windows, the CI is blind to it. The HIP tests are not processed by MSVC ever, but it would've been silly not updating that code as well. 🤔