### PR TITLE
SoA Device Test Improvements, main branch (2024.02.28.)

### DIFF
--- a/tests/common/soa_device_tests.ipp
+++ b/tests/common/soa_device_tests.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,8 +18,8 @@ void soa_device_tests_base<CONTAINER>::modify_managed(
     // Extract the needed parameters.
     vecmem::memory_resource& host_mr = std::get<0>(params);
     vecmem::memory_resource& managed_mr = std::get<2>(params);
-    void (*device_modify)(typename CONTAINER::view) =
-        reinterpret_cast<void (*)(typename CONTAINER::view)>(
+    bool (*device_modify)(typename CONTAINER::view) =
+        reinterpret_cast<bool (*)(typename CONTAINER::view)>(
             std::get<5>(params));
 
     // Create two host containers in host and managed memory.
@@ -38,7 +38,9 @@ void soa_device_tests_base<CONTAINER>::modify_managed(
     }
 
     // Run a kernel that executes the modify function on the second container.
-    (*device_modify)(vecmem::get_data(container2));
+    if ((*device_modify)(vecmem::get_data(container2)) == false) {
+        GTEST_SKIP();
+    }
 
     // Compare the two.
     vecmem::testing::compare(vecmem::get_data(container1),
@@ -53,8 +55,8 @@ void soa_device_tests_base<CONTAINER>::modify_device(
     vecmem::memory_resource& host_mr = std::get<0>(params);
     vecmem::memory_resource& device_mr = std::get<1>(params);
     vecmem::copy& copy = std::get<3>(params);
-    void (*device_modify)(typename CONTAINER::view) =
-        reinterpret_cast<void (*)(typename CONTAINER::view)>(
+    bool (*device_modify)(typename CONTAINER::view) =
+        reinterpret_cast<bool (*)(typename CONTAINER::view)>(
             std::get<5>(params));
 
     // Create a host container in host memory as a start.
@@ -79,7 +81,9 @@ void soa_device_tests_base<CONTAINER>::modify_device(
     }
 
     // Run a kernel that executes the modify function on the device buffer.
-    (*device_modify)(buffer);
+    if ((*device_modify)(buffer) == false) {
+        GTEST_SKIP();
+    }
 
     // Copy the data back to the host.
     typename CONTAINER::host container2{host_mr};
@@ -98,8 +102,8 @@ void soa_device_tests_base<CONTAINER>::fill_device(
     vecmem::memory_resource& host_mr = std::get<0>(params);
     vecmem::memory_resource& device_mr = std::get<1>(params);
     vecmem::copy& copy = std::get<3>(params);
-    void (*device_fill)(typename CONTAINER::view) =
-        reinterpret_cast<void (*)(typename CONTAINER::view)>(
+    bool (*device_fill)(typename CONTAINER::view) =
+        reinterpret_cast<bool (*)(typename CONTAINER::view)>(
             std::get<4>(params));
 
     // Create a host buffer, and fill it.
@@ -119,7 +123,9 @@ void soa_device_tests_base<CONTAINER>::fill_device(
     copy.setup(buffer2);
 
     // Run a kernel that fills the buffer.
-    (*device_fill)(buffer2);
+    if ((*device_fill)(buffer2) == false) {
+        GTEST_SKIP();
+    }
 
     // Copy the device buffer back to the host.
     typename CONTAINER::buffer buffer3;

--- a/tests/cuda/test_cuda_edm_kernels.cu
+++ b/tests/cuda/test_cuda_edm_kernels.cu
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -24,7 +24,7 @@ __global__ void cudaSimpleFillKernel(
     vecmem::testing::fill(i, device);
 }
 
-void cudaSimpleFill(vecmem::testing::simple_soa_container::view view) {
+bool cudaSimpleFill(vecmem::testing::simple_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -34,6 +34,7 @@ void cudaSimpleFill(vecmem::testing::simple_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    return true;
 }
 
 __global__ void cudaJaggedFillKernel(
@@ -47,7 +48,7 @@ __global__ void cudaJaggedFillKernel(
     vecmem::testing::fill(i, device);
 }
 
-void cudaJaggedFill(vecmem::testing::jagged_soa_container::view view) {
+bool cudaJaggedFill(vecmem::testing::jagged_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -57,6 +58,7 @@ void cudaJaggedFill(vecmem::testing::jagged_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    return true;
 }
 
 __global__ void cudaSimpleModifyKernel(
@@ -70,7 +72,7 @@ __global__ void cudaSimpleModifyKernel(
     vecmem::testing::modify(i, device);
 }
 
-void cudaSimpleModify(vecmem::testing::simple_soa_container::view view) {
+bool cudaSimpleModify(vecmem::testing::simple_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -80,6 +82,7 @@ void cudaSimpleModify(vecmem::testing::simple_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    return true;
 }
 
 __global__ void cudaJaggedModifyKernel(
@@ -93,7 +96,7 @@ __global__ void cudaJaggedModifyKernel(
     vecmem::testing::modify(i, device);
 }
 
-void cudaJaggedModify(vecmem::testing::jagged_soa_container::view view) {
+bool cudaJaggedModify(vecmem::testing::jagged_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -103,4 +106,5 @@ void cudaJaggedModify(vecmem::testing::jagged_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());
     VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());
+    return true;
 }

--- a/tests/cuda/test_cuda_edm_kernels.hpp
+++ b/tests/cuda/test_cuda_edm_kernels.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,13 +11,13 @@
 #include "../common/simple_soa_container.hpp"
 
 /// Fill a simple SoA container with some data.
-void cudaSimpleFill(vecmem::testing::simple_soa_container::view view);
+bool cudaSimpleFill(vecmem::testing::simple_soa_container::view view);
 
 /// Fill a jagged SoA container with some data.
-void cudaJaggedFill(vecmem::testing::jagged_soa_container::view view);
+bool cudaJaggedFill(vecmem::testing::jagged_soa_container::view view);
 
 /// Modify data in a simple SoA container.
-void cudaSimpleModify(vecmem::testing::simple_soa_container::view view);
+bool cudaSimpleModify(vecmem::testing::simple_soa_container::view view);
 
 /// Modify data in a jagged SoA container.
-void cudaJaggedModify(vecmem::testing::jagged_soa_container::view view);
+bool cudaJaggedModify(vecmem::testing::jagged_soa_container::view view);

--- a/tests/hip/test_hip_edm_kernels.hip
+++ b/tests/hip/test_hip_edm_kernels.hip
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,7 +27,7 @@ __global__ void hipSimpleFillKernel(
     vecmem::testing::fill(i, device);
 }
 
-void hipSimpleFill(vecmem::testing::simple_soa_container::view view) {
+bool hipSimpleFill(vecmem::testing::simple_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -37,6 +37,7 @@ void hipSimpleFill(vecmem::testing::simple_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+    return true;
 }
 
 __global__ void hipJaggedFillKernel(
@@ -50,7 +51,7 @@ __global__ void hipJaggedFillKernel(
     vecmem::testing::fill(i, device);
 }
 
-void hipJaggedFill(vecmem::testing::jagged_soa_container::view view) {
+bool hipJaggedFill(vecmem::testing::jagged_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -60,6 +61,7 @@ void hipJaggedFill(vecmem::testing::jagged_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+    return true;
 }
 
 __global__ void hipSimpleModifyKernel(
@@ -73,7 +75,7 @@ __global__ void hipSimpleModifyKernel(
     vecmem::testing::modify(i, device);
 }
 
-void hipSimpleModify(vecmem::testing::simple_soa_container::view view) {
+bool hipSimpleModify(vecmem::testing::simple_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -83,6 +85,7 @@ void hipSimpleModify(vecmem::testing::simple_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+    return true;
 }
 
 __global__ void hipJaggedModifyKernel(
@@ -96,7 +99,7 @@ __global__ void hipJaggedModifyKernel(
     vecmem::testing::modify(i, device);
 }
 
-void hipJaggedModify(vecmem::testing::jagged_soa_container::view view) {
+bool hipJaggedModify(vecmem::testing::jagged_soa_container::view view) {
 
     // Launch the kernel.
     const unsigned int blockSize = 256;
@@ -106,4 +109,5 @@ void hipJaggedModify(vecmem::testing::jagged_soa_container::view view) {
     // Check whether it succeeded to run.
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+    return true;
 }

--- a/tests/hip/test_hip_edm_kernels.hpp
+++ b/tests/hip/test_hip_edm_kernels.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,13 +11,13 @@
 #include "../common/simple_soa_container.hpp"
 
 /// Fill a simple SoA container with some data.
-void hipSimpleFill(vecmem::testing::simple_soa_container::view view);
+bool hipSimpleFill(vecmem::testing::simple_soa_container::view view);
 
 /// Fill a jagged SoA container with some data.
-void hipJaggedFill(vecmem::testing::jagged_soa_container::view view);
+bool hipJaggedFill(vecmem::testing::jagged_soa_container::view view);
 
 /// Modify data in a simple SoA container.
-void hipSimpleModify(vecmem::testing::simple_soa_container::view view);
+bool hipSimpleModify(vecmem::testing::simple_soa_container::view view);
 
 /// Modify data in a jagged SoA container.
-void hipJaggedModify(vecmem::testing::jagged_soa_container::view view);
+bool hipJaggedModify(vecmem::testing::jagged_soa_container::view view);

--- a/tests/sycl/test_sycl_edm.sycl
+++ b/tests/sycl/test_sycl_edm.sycl
@@ -38,7 +38,7 @@ static vecmem::sycl::shared_memory_resource sycl_shared_mr{&queue};
 static vecmem::sycl::copy sycl_copy{&queue};
 
 /// Fill a simple SoA container with some data.
-void syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
+bool syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
 
     queue
         .submit([&view](cl::sycl::handler& h) {
@@ -50,10 +50,16 @@ void syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
                 });
         })
         .wait_and_throw();
+    return true;
 }
 
 /// Fill a jagged SoA container with some data.
-void syclJaggedFill(vecmem::testing::jagged_soa_container::view view) {
+bool syclJaggedFill(vecmem::testing::jagged_soa_container::view view) {
+
+    // Skip test if FP64 instructions are not available on the device.
+    if (queue.get_device().has(cl::sycl::aspect::fp64) == false) {
+        return false;
+    }
 
     queue
         .submit([&view](cl::sycl::handler& h) {
@@ -65,10 +71,11 @@ void syclJaggedFill(vecmem::testing::jagged_soa_container::view view) {
                 });
         })
         .wait_and_throw();
+    return true;
 }
 
 /// Modify data in a simple SoA container.
-void syclSimpleModify(vecmem::testing::simple_soa_container::view view) {
+bool syclSimpleModify(vecmem::testing::simple_soa_container::view view) {
 
     queue
         .submit([&view](cl::sycl::handler& h) {
@@ -80,10 +87,16 @@ void syclSimpleModify(vecmem::testing::simple_soa_container::view view) {
                 });
         })
         .wait_and_throw();
+    return true;
 }
 
 /// Modify data in a jagged SoA container.
-void syclJaggedModify(vecmem::testing::jagged_soa_container::view view) {
+bool syclJaggedModify(vecmem::testing::jagged_soa_container::view view) {
+
+    // Skip test if FP64 instructions are not available on the device.
+    if (queue.get_device().has(cl::sycl::aspect::fp64) == false) {
+        return false;
+    }
 
     queue
         .submit([&view](cl::sycl::handler& h) {
@@ -95,6 +108,7 @@ void syclJaggedModify(vecmem::testing::jagged_soa_container::view view) {
                 });
         })
         .wait_and_throw();
+    return true;
 }
 
 /// Pointer to the function filling a simple SoA container on a SYCL device.


### PR DESCRIPTION
Skip some SoA tests on devices with no FP64 support.

The device tests with `vecmem::testing::jagged_soa_container` require the device to be able to execute FP64 operations. (Since the SoA container has a jagged vector of doubles.) Which is not the case for absolutely every SYCL device that we test. So on those these tests should just be skipped.

I considered removing the FP64 instructions from the test. But in the end decided that doing some tests with FP64 values was still worth it. To test for some possible alignment issues in the SoA code. So just skipping these tests all together on devices with no FP64 support seemed better than making the tests less thorough on all devices.

Unfortunately implementing this was a bit of a hassle. :frowning: As it turns out, one can only use `GTEST_SKIP()` in the main test body. You cannot just use that macro inside of a function that gets called as part of the test. :frowning: So I decided to add a simple `bool` return value to all language-specific functions, and let the main test body call `GTEST_SKIP()` based on those return values. :thinking: