### PR TITLE
Add CMake Folders, main branch (2024.03.01.)

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -34,6 +34,8 @@ add_library( vecmem_benchmark_common STATIC
    "common/make_jagged_vector.cpp" )
 target_link_libraries( vecmem_benchmark_common
    PUBLIC vecmem::core )
+set_target_properties( vecmem_benchmark_common PROPERTIES
+   FOLDER "vecmem/benchmarks" )
 
 # Include the library specific tests.
 add_subdirectory(core)

--- a/benchmarks/core/CMakeLists.txt
+++ b/benchmarks/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -21,3 +21,6 @@ target_link_libraries(
     benchmark::benchmark
     benchmark::benchmark_main
 )
+
+set_target_properties( vecmem_benchmark_core PROPERTIES
+   FOLDER "vecmem/benchmarks" )

--- a/benchmarks/cuda/CMakeLists.txt
+++ b/benchmarks/cuda/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -23,3 +23,6 @@ target_link_libraries(
     benchmark::benchmark
     benchmark::benchmark_main
 )
+
+set_target_properties( vecmem_benchmark_cuda PROPERTIES
+   FOLDER "vecmem/benchmarks" )

--- a/benchmarks/googlebenchmark/CMakeLists.txt
+++ b/benchmarks/googlebenchmark/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -29,5 +29,6 @@ set( BENCHMARK_ENABLE_WERROR OFF CACHE BOOL
 
 # Get it into the current directory.
 FetchContent_Populate( googlebenchmark )
+set( CMAKE_FOLDER "vecmem/externals" )
 add_subdirectory( "${googlebenchmark_SOURCE_DIR}"
    "${googlebenchmark_BINARY_DIR}" EXCLUDE_FROM_ALL )

--- a/benchmarks/sycl/CMakeLists.txt
+++ b/benchmarks/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2022 CERN for the benefit of the ACTS project
+# (c) 2022-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -16,3 +16,5 @@ target_link_libraries( vecmem_benchmark_sycl
     PRIVATE vecmem::sycl vecmem_benchmark_common
             benchmark::benchmark benchmark::benchmark_main
 )
+set_target_properties( vecmem_benchmark_sycl PROPERTIES
+   FOLDER "vecmem/benchmarks" )

--- a/cmake/vecmem-functions.cmake
+++ b/cmake/vecmem-functions.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -49,7 +49,9 @@ function( vecmem_add_library fullname basename )
 
    # Make sure that the library is available as "vecmem::${basename}" in every
    # situation.
-   set_target_properties( ${fullname} PROPERTIES EXPORT_NAME ${basename} )
+   set_target_properties( ${fullname} PROPERTIES
+      EXPORT_NAME "${basename}"
+      FOLDER "vecmem" )
    add_library( vecmem::${basename} ALIAS ${fullname} )
 
    # Specify the (SO)VERSION of the library.
@@ -100,7 +102,8 @@ function( vecmem_test_public_headers library )
       target_link_libraries( "test_${_headerNormName}" PRIVATE ${library} )
       set_target_properties( "test_${_headerNormName}" PROPERTIES
          RUNTIME_OUTPUT_DIRECTORY
-         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}" )
+         "${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}"
+         FOLDER "vecmem/tests/header_tests" )
 
    endforeach()
 
@@ -125,6 +128,8 @@ function( vecmem_add_test name )
    if( ARG_LINK_LIBRARIES )
       target_link_libraries( ${test_exe_name} PRIVATE ${ARG_LINK_LIBRARIES} )
    endif()
+   set_target_properties( "vecmem_test_${name}" PROPERTIES
+      FOLDER "vecmem/tests" )
 
    # Discover all of the tests from the execuable, and set them up as individual
    # CTest tests.

--- a/cmake/vecmem-options.cmake
+++ b/cmake/vecmem-options.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2022 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -39,6 +39,9 @@ vecmem_lib_option( HIP "Build the vecmem::hip library" )
 
 # Flag specifying whether SYCL support should be built.
 vecmem_lib_option( SYCL "Build the vecmem::sycl library" )
+
+# Use folders for organizing targets in IDEs.
+set_property( GLOBAL PROPERTY USE_FOLDERS ON )
 
 # Debug message output level in the code.
 set( VECMEM_DEBUG_MSG_LVL 0 CACHE STRING

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library( vecmem_testing_common STATIC
    "common/soa_device_tests.ipp" )
 target_link_libraries( vecmem_testing_common
    PUBLIC vecmem::core GTest::gtest )
+set_target_properties( vecmem_testing_common PROPERTIES
+      FOLDER "vecmem/tests" )
 
 # Include the library specific tests.
 add_subdirectory( core )

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -33,6 +33,9 @@ target_link_libraries(
    vecmem::core
 )
 
+set_target_properties( vecmem_testing_cuda_main PROPERTIES
+   FOLDER "vecmem/tests" )
+
 # Test all of the CUDA library's features.
 vecmem_add_test( cuda
    "test_cuda_memory_resources.cpp"

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -34,6 +34,7 @@ set( CMAKE_MACOSX_RPATH TRUE )
 
 # Get it into the current directory.
 FetchContent_Populate( GoogleTest )
+set( CMAKE_FOLDER "vecmem/externals" )
 add_subdirectory( "${googletest_SOURCE_DIR}" "${googletest_BINARY_DIR}"
    EXCLUDE_FROM_ALL )
 


### PR DESCRIPTION
While debugging #270 I ended up using [Visual Studio](https://visualstudio.microsoft.com/) some fair amount. Which reminded me about a long-standing thing that I always wanted to set up, just never did.

By setting the [FOLDER](https://cmake.org/cmake/help/latest/prop_tgt/FOLDER.html) property on targets, one can make Visual Studio present the project something like this:

![image](https://github.com/acts-project/vecmem/assets/30694331/f4a4b63e-feee-4648-bc05-c280bc9b4c83)

Instead of the single-folder, unorganized mess that it presents by default.

![image](https://github.com/acts-project/vecmem/assets/30694331/0b16908c-57c4-45f0-9bc5-4cc49af83e04)

It's admittedly a small/insignificant thing, but it makes development just a little more convenient.