### PR TITLE
Xcode Link Option Update, main branch (2024.03.24.)

### DIFF
--- a/cmake/vecmem-compiler-options-cpp.cmake
+++ b/cmake/vecmem-compiler-options-cpp.cmake
@@ -43,7 +43,10 @@ endif()
 
 # Do not allow symbols to be missing from shared libraries.
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" )
-   vecmem_add_flag( CMAKE_SHARED_LINKER_FLAGS "-Wl,-undefined,error" )
+   # From AppleClang 15 onwards, the default is to fail on undefined symbols.
+   if( "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "15" )
+      vecmem_add_flag( CMAKE_SHARED_LINKER_FLAGS "-Wl,-undefined,error" )
+   endif()
 elseif( ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" ) OR
         ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" ) )
    vecmem_add_flag( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined" )


### PR DESCRIPTION
While trying to build the project with the current latest Xcode version (15.0.0), I bumped into this warning:

![Screenshot 2024-03-24 at 5 34 26 PM](https://github.com/acts-project/vecmem/assets/30694331/99e64276-20aa-4243-a78c-8e52f0feb39c)

Apparently Apple uses a different linker now. 🤔 (https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes) And this new linker treats missing symbols in shared libraries as an error by default. So, since a quick Google search didn't reveal what the new incantation is, I rather just turned off the previous flag for the latest Xcode versions.