### PR TITLE
Add ability to reserve bulk space in device vector

### DIFF
--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -168,6 +168,36 @@ public:
     VECMEM_HOST_AND_DEVICE
     size_type push_back(const_reference value);
 
+    /// Default-construct a given number of elements at the end of the vector.
+    ///
+    /// @note This function runs in Θ(n) time, performing n default
+    /// constructions.
+    VECMEM_HOST_AND_DEVICE size_type bulk_append(size_type n);
+
+    /// Copy-construct a given number of elements at the end of the vector,
+    /// copying the given object.
+    ///
+    /// @note This function runs in Θ(n) time, performing n copy constructions.
+    VECMEM_HOST_AND_DEVICE size_type bulk_append(size_type n,
+                                                 const_reference v);
+
+    /// Reserve a fixed number of slots in the array in a standards-conformant
+    /// way.
+    ///
+    /// @note This function runs in Θ(1) time.
+    ///
+    /// @warning This method is only standards-conformant in C++20 and later.
+    VECMEM_HOST_AND_DEVICE size_type bulk_append_implicit(size_type n);
+
+    /// Reserve a fixed number of slots in the array in a way that technically
+    /// is ill-formed.
+    ///
+    /// @note This function runs in Θ(1) time.
+    ///
+    /// @warning This method requires that the client guarantees that the array
+    /// elements reserved are given a proper lifetime before they are used.
+    VECMEM_HOST_AND_DEVICE size_type bulk_append_implicit_unsafe(size_type n);
+
     /// Remove the last element of the vector (not thread-safe)
     VECMEM_HOST_AND_DEVICE
     size_type pop_back();
@@ -182,6 +212,17 @@ public:
     /// (not thread-safe)
     VECMEM_HOST_AND_DEVICE
     void resize(size_type new_size, const_reference value);
+
+    /// Resize a vector of implicit lifetime types
+    ///
+    /// @note This function runs in Θ(1) time.
+    VECMEM_HOST_AND_DEVICE void resize_implicit(size_type new_size);
+
+    /// Resize a vector in constant time, unsafely deallocating non-implicit
+    /// lifetime types.
+    ///
+    /// @note This function runs in Θ(1) time.
+    VECMEM_HOST_AND_DEVICE void resize_implicit_unsafe(size_type new_size);
 
     /// @}
 

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -276,7 +276,7 @@ VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::bulk_append_implicit(
     // This can only be done on a resizable vector.
     assert(m_size != nullptr);
 
-    static_assert(details::is_implicit_lifetime_v<TYPE>,
+    static_assert(details::is_implicit_lifetime<TYPE>::value,
                   "Type `TYPE` in `device_vector<T>::bulk_append_implicit` is "
                   "not an implicit lifetype type, so slots cannot be safely "
                   "reserved. Note that the definition of implicit lifetimes "
@@ -387,7 +387,7 @@ VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::resize_implicit(
     // This can only be done on a resizable vector.
     assert(m_size != nullptr);
 
-    static_assert(details::is_implicit_lifetime_v<TYPE>,
+    static_assert(details::is_implicit_lifetime<TYPE>::value,
                   "Type `TYPE` in `device_vector<T>::resize_implicit` is not "
                   "an implicit lifetype type, so slots cannot be safely "
                   "reserved. Note that the definition of implicit lifetimes "

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -11,6 +11,8 @@
 
 // System include(s).
 #include <cassert>
+#include <memory>
+#include <type_traits>
 
 namespace vecmem {
 
@@ -226,6 +228,86 @@ VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::push_back(
 }
 
 template <typename TYPE>
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::bulk_append(size_type n)
+    -> size_type {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    static_assert(std::is_default_constructible<TYPE>::value,
+                  "Type `T` in `device_vector<T>::bulk_append` is not a "
+                  "default-constructible type.");
+
+    device_atomic_ref<size_type> asize(*m_size);
+    const size_type index = asize.fetch_add(n);
+    assert((index + n) <= m_capacity);
+
+    for (size_type i = 0; i < n; ++i) {
+        construct(index + i, value_type());
+    }
+
+    return index;
+}
+
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::bulk_append(size_type n,
+                                                             const_reference v)
+    -> size_type {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    static_assert(std::is_copy_constructible<TYPE>::value,
+                  "Type `TYPE` in device_vector<T>::bulk_append(SIZE, TYPE)` "
+                  "must be copy-constructible.");
+
+    device_atomic_ref<size_type> asize(*m_size);
+    const size_type index = asize.fetch_add(n);
+    assert((index + n) <= m_capacity);
+
+    for (size_type i = 0; i < n; ++i) {
+        construct(index + i, value_type(v));
+    }
+
+    return index;
+}
+
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::bulk_append_implicit(
+    size_type n) -> size_type {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    static_assert(details::is_implicit_lifetime_v<TYPE>,
+                  "Type `TYPE` in `device_vector<T>::bulk_append_implicit` is "
+                  "not an implicit lifetype type, so slots cannot be safely "
+                  "reserved. Note that the definition of implicit lifetimes "
+                  "differs between C++<=17, C++20, and C++>=23.");
+
+    device_atomic_ref<size_type> asize(*m_size);
+    const size_type index = asize.fetch_add(n);
+    assert((index + n) <= m_capacity);
+
+#if defined(__cpp_lib_start_lifetime_as) && \
+    __cpp_lib_start_lifetime_as >= 202207L
+    std::start_lifetime_as_array<TYPE>(m_ptr[index], n);
+#endif
+
+    return index;
+}
+
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::bulk_append_implicit_unsafe(
+    size_type n) -> size_type {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    device_atomic_ref<size_type> asize(*m_size);
+    const size_type index = asize.fetch_add(n);
+    assert((index + n) <= m_capacity);
+
+    return index;
+}
+
+template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::pop_back() -> size_type {
 
     // This can only be done on a resizable vector.
@@ -296,6 +378,34 @@ VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::resize(size_type new_size,
     }
 
     // Set the new size for the vector.
+    asize.store(new_size);
+}
+
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::resize_implicit(
+    size_type new_size) {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    static_assert(details::is_implicit_lifetime_v<TYPE>,
+                  "Type `TYPE` in `device_vector<T>::resize_implicit` is not "
+                  "an implicit lifetype type, so slots cannot be safely "
+                  "reserved. Note that the definition of implicit lifetimes "
+                  "differs between C++<=17, C++20, and C++>=23.");
+
+    device_atomic_ref<size_type> asize(*m_size);
+    assert(new_size <= m_capacity);
+    asize.store(new_size);
+}
+
+template <typename TYPE>
+VECMEM_HOST_AND_DEVICE void device_vector<TYPE>::resize_implicit_unsafe(
+    size_type new_size) {
+    // This can only be done on a resizable vector.
+    assert(m_size != nullptr);
+
+    device_atomic_ref<size_type> asize(*m_size);
+    assert(new_size <= m_capacity);
     asize.store(new_size);
 }
 

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -135,13 +135,13 @@ using is_implicit_lifetime = std::is_implicit_lifetime<TYPE>;
 // Implementation taken directly from P2674R1.
 template <class TYPE>
 struct is_implicit_lifetime
-    : std::disjunction<
+    : disjunction<
           std::is_scalar<TYPE>, std::is_array<TYPE>, std::is_aggregate<TYPE>,
-          std::conjunction<
+          conjunction<
               std::is_trivially_destructible<TYPE>,
-              std::disjunction<std::is_trivially_default_constructible<TYPE>,
-                               std::is_trivially_copy_constructible<TYPE>,
-                               std::is_trivially_move_constructible<TYPE>>>> {};
+              disjunction<std::is_trivially_default_constructible<TYPE>,
+                          std::is_trivially_copy_constructible<TYPE>,
+                          std::is_trivially_move_constructible<TYPE>>>> {};
 #define VECMEM_HAVE_IS_IMPLICIT_LIFETIME
 #else
 // If we are on such an old version of C++, we're basically in the wild west,

--- a/core/include/vecmem/utils/type_traits.hpp
+++ b/core/include/vecmem/utils/type_traits.hpp
@@ -113,5 +113,45 @@ auto max(T&& t, Ts&&... ts) {
     return std::max(std::forward<T>(t), max(std::forward<Ts>(ts)...));
 }
 
+/// Type trait that indicates whether a given type is an implicit lifetime
+/// type.
+///
+/// @note The definition of "implicit lifetime type" differs a lot across C++
+/// standards, as does the implementation of this type trait. In C++17 and
+/// earlier, the concept of such types did not exist. In C++20, these types
+/// were defined but no type trait for them was available. In C++23, a type
+/// trait is available.
+///
+/// @warning On pre-C++17 translation units, this type trait is always assumed
+/// to be true.
+///
+/// @{
+#if defined(__cpp_lib_is_implicit_lifetime) && \
+    __cpp_lib_is_implicit_lifetime >= 202302L
+template <class TYPE>
+using is_implicit_lifetime = std::is_implicit_lifetime<TYPE>;
+#define VECMEM_HAVE_IS_IMPLICIT_LIFETIME
+#elif defined(__cpp_lib_is_aggregate) && __cpp_lib_is_aggregate >= 201703L
+// Implementation taken directly from P2674R1.
+template <class TYPE>
+struct is_implicit_lifetime
+    : std::disjunction<
+          std::is_scalar<TYPE>, std::is_array<TYPE>, std::is_aggregate<TYPE>,
+          std::conjunction<
+              std::is_trivially_destructible<TYPE>,
+              std::disjunction<std::is_trivially_default_constructible<TYPE>,
+                               std::is_trivially_copy_constructible<TYPE>,
+                               std::is_trivially_move_constructible<TYPE>>>> {};
+#define VECMEM_HAVE_IS_IMPLICIT_LIFETIME
+#else
+// If we are on such an old version of C++, we're basically in the wild west,
+// so we allow the user to do whatever they want.
+template <class TYPE>
+using is_implicit_lifetime = std::true_type;
+#endif
+
+template <class TYPE>
+constexpr bool is_implicit_lifetime_v = is_implicit_lifetime<TYPE>::value;
+/// @}
 }  // namespace details
 }  // namespace vecmem

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -299,16 +299,17 @@ TEST_F(cuda_containers_test, large_buffer) {
 
     // Test a (1D) vector.
     vecmem::data::vector_buffer<unsigned long> buffer1(
-        3, managed_resource, vecmem::data::buffer_type::resizable);
+        100, managed_resource, vecmem::data::buffer_type::resizable);
     m_copy.setup(buffer1);
     largeBufferTransform(buffer1);
-    EXPECT_EQ(m_copy.get_size(buffer1), 1u);
+    EXPECT_EQ(m_copy.get_size(buffer1), 21u);
 
     // Test a (2D) jagged vector.
     vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
-        {3, 3, 3}, managed_resource, nullptr,
+        {100, 100, 100}, managed_resource, nullptr,
         vecmem::data::buffer_type::resizable);
     m_copy.setup(buffer2);
     largeBufferTransform(buffer2);
-    EXPECT_EQ(m_copy.get_sizes(buffer2), std::vector<unsigned int>({0, 1u, 0}));
+    EXPECT_EQ(m_copy.get_sizes(buffer2),
+              std::vector<unsigned int>({0, 21u, 0}));
 }

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -311,5 +311,5 @@ TEST_F(cuda_containers_test, large_buffer) {
     m_copy.setup(buffer2);
     largeBufferTransform(buffer2);
     EXPECT_EQ(m_copy.get_sizes(buffer2),
-              std::vector<unsigned int>({0, 21u, 0}));
+              std::vector<unsigned int>({5u, 21u, 10u}));
 }

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -301,6 +301,10 @@ __global__ void largeBufferTransformKernel(
     vecmem::device_vector<unsigned long> vec(data);
     assert(vec.size() == 0);
     vec.push_back(0);
+    vec.bulk_append(5);
+    vec.bulk_append(5, 2);
+    vec.bulk_append_implicit(5);
+    vec.bulk_append_implicit_unsafe(5);
 }
 
 void largeBufferTransform(vecmem::data::vector_view<unsigned long> data) {
@@ -326,6 +330,10 @@ __global__ void largeBufferTransformKernel(
     assert(vec.size() == 3);
     assert(vec.at(1).size() == 0);
     vec.at(1).push_back(0);
+    vec.at(1).bulk_append(5);
+    vec.at(1).bulk_append(5, 2);
+    vec.at(1).bulk_append_implicit(5);
+    vec.at(1).bulk_append_implicit_unsafe(5);
 }
 
 void largeBufferTransform(

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -329,11 +329,13 @@ __global__ void largeBufferTransformKernel(
     vecmem::jagged_device_vector<unsigned long> vec(data);
     assert(vec.size() == 3);
     assert(vec.at(1).size() == 0);
+    vec.at(0).resize_implicit(5);
     vec.at(1).push_back(0);
     vec.at(1).bulk_append(5);
     vec.at(1).bulk_append(5, 2);
     vec.at(1).bulk_append_implicit(5);
     vec.at(1).bulk_append_implicit_unsafe(5);
+    vec.at(2).resize_implicit_unsafe(10);
 }
 
 void largeBufferTransform(

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -259,5 +259,5 @@ TEST_F(hip_containers_test, large_buffer) {
     m_copy.setup(buffer2);
     largeBufferTransform(buffer2);
     EXPECT_EQ(m_copy.get_sizes(buffer2),
-              std::vector<unsigned int>({0, 21u, 0}));
+              std::vector<unsigned int>({5u, 21u, 10u}));
 }

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -335,3 +335,61 @@ void arrayTransform(
     VECMEM_HIP_ERROR_CHECK(hipGetLastError());
     VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
 }
+
+/// Kernel making a trivial use of the resizable vector that it receives
+__global__ void largeBufferTransformKernel(
+    vecmem::data::vector_view<unsigned long> data) {
+
+    // Add one element to the vector in just the first thread
+    const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i != 0) {
+        return;
+    }
+    vecmem::device_vector<unsigned long> vec(data);
+    assert(vec.size() == 0);
+    vec.push_back(0);
+    vec.bulk_append(5);
+    vec.bulk_append(5, 2);
+    vec.bulk_append_implicit(5);
+    vec.bulk_append_implicit_unsafe(5);
+}
+
+void largeBufferTransform(vecmem::data::vector_view<unsigned long> data) {
+
+    // Launch the kernel.
+    hipLaunchKernelGGL(largeBufferTransformKernel, 1, 1, 0, nullptr, data);
+
+    // Check whether it succeeded to run.
+    VECMEM_HIP_ERROR_CHECK(hipGetLastError());
+    VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+}
+
+/// Kernel making a trivial use of the resizable jagged vector that it receives
+__global__ void largeBufferTransformKernel(
+    vecmem::data::jagged_vector_view<unsigned long> data) {
+
+    // Add one element to the vector in just the first thread
+    const std::size_t i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i != 0) {
+        return;
+    }
+    vecmem::jagged_device_vector<unsigned long> vec(data);
+    assert(vec.size() == 3);
+    assert(vec.at(1).size() == 0);
+    vec.at(1).push_back(0);
+    vec.at(1).bulk_append(5);
+    vec.at(1).bulk_append(5, 2);
+    vec.at(1).bulk_append_implicit(5);
+    vec.at(1).bulk_append_implicit_unsafe(5);
+}
+
+void largeBufferTransform(
+    vecmem::data::jagged_vector_view<unsigned long> data) {
+
+    // Launch the kernel.
+    hipLaunchKernelGGL(largeBufferTransformKernel, 1, 1, 0, nullptr, data);
+
+    // Check whether it succeeded to run.
+    VECMEM_HIP_ERROR_CHECK(hipGetLastError());
+    VECMEM_HIP_ERROR_CHECK(hipDeviceSynchronize());
+}

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -376,11 +376,13 @@ __global__ void largeBufferTransformKernel(
     vecmem::jagged_device_vector<unsigned long> vec(data);
     assert(vec.size() == 3);
     assert(vec.at(1).size() == 0);
+    vec.at(0).resize_implicit(5);
     vec.at(1).push_back(0);
     vec.at(1).bulk_append(5);
     vec.at(1).bulk_append(5, 2);
     vec.at(1).bulk_append_implicit(5);
     vec.at(1).bulk_append_implicit_unsafe(5);
+    vec.at(2).resize_implicit_unsafe(10);
 }
 
 void largeBufferTransform(

--- a/tests/hip/test_hip_containers_kernels.hpp
+++ b/tests/hip/test_hip_containers_kernels.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,3 +47,9 @@ void fillTransform(vecmem::data::jagged_vector_view<int> vec);
 /// Function transforming the elements of an array of vectors
 void arrayTransform(
     vecmem::static_array<vecmem::data::vector_view<int>, 4> data);
+
+/// Function performing a trivial operation on a "large" vector buffer
+void largeBufferTransform(vecmem::data::vector_view<unsigned long> data);
+
+/// Function performing a trivial operation on a "large" jagged vector buffer
+void largeBufferTransform(vecmem::data::jagged_vector_view<unsigned long> data);

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -575,15 +575,18 @@ TEST_F(sycl_containers_test, large_buffer) {
                     vecmem::jagged_device_vector<unsigned long> vec(data);
                     assert(vec.size() == 3);
                     assert(vec.at(1).size() == 0);
+                    vec.at(0).resize_implicit(5);
                     vec.at(1).push_back(0);
                     vec.at(1).bulk_append(5);
                     vec.at(1).bulk_append(5, 2);
                     vec.at(1).bulk_append_implicit(5);
                     vec.at(1).bulk_append_implicit_unsafe(5);
+                    vec.at(2).resize_implicit_unsafe(10);
                 });
         })
         .wait_and_throw();
 
     // Check the results.
-    EXPECT_EQ(copy.get_sizes(buffer2), std::vector<unsigned int>({0, 21u, 0}));
+    EXPECT_EQ(copy.get_sizes(buffer2),
+              std::vector<unsigned int>({5u, 21u, 10u}));
 }

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,7 +12,9 @@
 #include "vecmem/containers/array.hpp"
 #include "vecmem/containers/const_device_array.hpp"
 #include "vecmem/containers/const_device_vector.hpp"
+#include "vecmem/containers/data/jagged_vector_buffer.hpp"
 #include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/jagged_device_vector.hpp"
 #include "vecmem/containers/static_array.hpp"
 #include "vecmem/containers/vector.hpp"
 #include "vecmem/memory/atomic.hpp"
@@ -507,4 +509,81 @@ TEST_F(sycl_containers_test, array_memory) {
     EXPECT_EQ(vec_array.at(2).at(1), 16);
     EXPECT_EQ(vec_array.at(2).at(2), 18);
     EXPECT_EQ(vec_array.at(3).size(), 0u);
+}
+
+/// Test buffers with "large" elements (for which alignment becomes important)
+TEST_F(sycl_containers_test, large_buffer) {
+
+    // Create the SYCL queue that we'll be using in the test.
+    cl::sycl::queue queue;
+
+    // The memory resource(s).
+    vecmem::sycl::shared_memory_resource shared_resource{&queue};
+
+    // Helper object for performing memory copies.
+    vecmem::sycl::copy copy(&queue);
+
+    // Test a (1D) vector.
+    vecmem::data::vector_buffer<unsigned long> buffer1(
+        100, shared_resource, vecmem::data::buffer_type::resizable);
+    copy.setup(buffer1);
+
+    // Run a kernel that enlarges the (1D) buffer.
+    queue
+        .submit([&buffer1](cl::sycl::handler& h) {
+            h.parallel_for<class BufferResize>(
+                cl::sycl::range<1>(1),
+                [data = vecmem::get_data(buffer1)](cl::sycl::item<1> id) {
+                    // Check if anything needs to be done.
+                    if (id[0] != 0) {
+                        return;
+                    }
+
+                    // Perform the resize operations.
+                    vecmem::device_vector<unsigned long> vec(data);
+                    assert(vec.size() == 0);
+                    vec.push_back(0);
+                    vec.bulk_append(5);
+                    vec.bulk_append(5, 2);
+                    vec.bulk_append_implicit(5);
+                    vec.bulk_append_implicit_unsafe(5);
+                });
+        })
+        .wait_and_throw();
+
+    // Check the results.
+    EXPECT_EQ(copy.get_size(buffer1), 21u);
+
+    // Test a (2D) jagged vector.
+    vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
+        {100, 100, 100}, shared_resource, nullptr,
+        vecmem::data::buffer_type::resizable);
+    copy.setup(buffer2);
+
+    // Run a kernel that enlarges the (jagged) buffer.
+    queue
+        .submit([&buffer2](cl::sycl::handler& h) {
+            h.parallel_for<class JaggedBufferResize>(
+                cl::sycl::range<1>(1),
+                [data = vecmem::get_data(buffer2)](cl::sycl::item<1> id) {
+                    // Check if anything needs to be done.
+                    if (id[0] != 0) {
+                        return;
+                    }
+
+                    // Perform the resize operations.
+                    vecmem::jagged_device_vector<unsigned long> vec(data);
+                    assert(vec.size() == 3);
+                    assert(vec.at(1).size() == 0);
+                    vec.at(1).push_back(0);
+                    vec.at(1).bulk_append(5);
+                    vec.at(1).bulk_append(5, 2);
+                    vec.at(1).bulk_append_implicit(5);
+                    vec.at(1).bulk_append_implicit_unsafe(5);
+                });
+        })
+        .wait_and_throw();
+
+    // Check the results.
+    EXPECT_EQ(copy.get_sizes(buffer2), std::vector<unsigned int>({0, 21u, 0}));
 }


### PR DESCRIPTION
A very common pattern in massively parallel computing is to reserve space for an entire thread block at once and to insert those values later. This commit adds a `reserve` and `reserve_unsafe` method to `device_vector`, which allows clients to do this.

The semantics of `reserve` are fully compliant with the C++ standard starting from C++20; C++ standards below that will work just fine. Any program which calls this function and compiles should be well formed, as defined in P0593R6 and P2590R2.

The `reserve_unsafe` method does the same, but _technically_ leaves the program in an ill-defined state. Note that this form of ill-defined memory has been used for donkeys years and is actually safe. It's just technically not standards compliant.