### PR TITLE
Increase the robustness of `device_atomic_ref`

### DIFF
--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -9,7 +9,10 @@ include( vecmem-compiler-options-cpp )
 
 # Test all of the core library's features.
 vecmem_add_test( core
-   "test_core_allocator.cpp" "test_core_array.cpp" "test_core_containers.cpp"
+   "test_core_allocator.cpp"
+   "test_core_array.cpp"
+   "test_core_atomic_ref.cpp"
+   "test_core_containers.cpp"
    "test_core_contiguous_memory_resource.cpp" "test_core_copy.cpp"
    "test_core_device_containers.cpp" "test_core_memory_resources.cpp"
    "test_core_static_vector.cpp" "test_core_vector.cpp"

--- a/tests/core/test_core_atomic_ref.cpp
+++ b/tests/core/test_core_atomic_ref.cpp
@@ -1,0 +1,106 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/memory/device_atomic_ref.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+TEST(core_device_atomic_test, atomic_operator_equals) {
+    int i = 0;
+    vecmem::device_atomic_ref<int> a(i);
+    a = 5;
+    ASSERT_EQ(a.load(), 5);
+}
+
+TEST(core_device_atomic_test, atomic_load) {
+    int i = 17;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 17);
+}
+
+TEST(core_device_atomic_test, atomic_compare_exchange_strong) {
+    int i = 0, zero = 0, five = 5;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_TRUE(a.compare_exchange_strong(zero, 5));
+    ASSERT_EQ(zero, 0);
+    ASSERT_FALSE(a.compare_exchange_strong(zero, 5));
+    ASSERT_EQ(zero, 5);
+    ASSERT_TRUE(a.compare_exchange_strong(five, 0));
+    ASSERT_EQ(five, 5);
+    ASSERT_FALSE(a.compare_exchange_strong(five, 0));
+    ASSERT_EQ(five, 0);
+}
+
+TEST(core_device_atomic_test, atomic_store) {
+    int i = 0;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0);
+    a.store(5);
+    ASSERT_EQ(a.load(), 5);
+}
+
+TEST(core_device_atomic_test, atomic_exchange) {
+    int i = 0;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0);
+    ASSERT_EQ(a.exchange(5), 0);
+    ASSERT_EQ(a.load(), 5);
+    ASSERT_EQ(a.exchange(3), 5);
+    ASSERT_EQ(a.load(), 3);
+}
+
+TEST(core_device_atomic_test, atomic_fetch_add) {
+    int i = 0;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0);
+    ASSERT_EQ(a.fetch_add(5), 0);
+    ASSERT_EQ(a.load(), 5);
+    ASSERT_EQ(a.fetch_add(3), 5);
+    ASSERT_EQ(a.load(), 8);
+}
+
+TEST(core_device_atomic_test, atomic_fetch_sub) {
+    int i = 0;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0);
+    ASSERT_EQ(a.fetch_sub(5), 0);
+    ASSERT_EQ(a.load(), -5);
+    ASSERT_EQ(a.fetch_sub(3), -5);
+    ASSERT_EQ(a.load(), -8);
+}
+
+TEST(core_device_atomic_test, atomic_fetch_and) {
+    int i = 0b0101;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0b0101);
+    ASSERT_EQ(a.fetch_and(0b1100), 0b0101);
+    ASSERT_EQ(a.load(), 0b0100);
+    ASSERT_EQ(a.fetch_and(0b0000), 0b0100);
+    ASSERT_EQ(a.load(), 0b0000);
+}
+
+TEST(core_device_atomic_test, atomic_fetch_or) {
+    int i = 0b0101;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0b0101);
+    ASSERT_EQ(a.fetch_or(0b1100), 0b0101);
+    ASSERT_EQ(a.load(), 0b1101);
+    ASSERT_EQ(a.fetch_or(0b0000), 0b1101);
+    ASSERT_EQ(a.load(), 0b1101);
+}
+
+TEST(core_device_atomic_test, atomic_fetch_xor) {
+    int i = 0b0101;
+    vecmem::device_atomic_ref<int> a(i);
+    ASSERT_EQ(a.load(), 0b0101);
+    ASSERT_EQ(a.fetch_xor(0b1100), 0b0101);
+    ASSERT_EQ(a.load(), 0b1001);
+    ASSERT_EQ(a.fetch_xor(0b0000), 0b1001);
+    ASSERT_EQ(a.load(), 0b1001);
+}

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -38,6 +38,7 @@ set_target_properties( vecmem_testing_cuda_main PROPERTIES
 
 # Test all of the CUDA library's features.
 vecmem_add_test( cuda
+   "test_cuda_atomic_ref.cu"
    "test_cuda_memory_resources.cpp"
    "test_cuda_containers.cpp" "test_cuda_containers_kernels.cuh"
    "test_cuda_containers_kernels.cu"

--- a/tests/cuda/test_cuda_atomic_ref.cu
+++ b/tests/cuda/test_cuda_atomic_ref.cu
@@ -1,0 +1,169 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "../../cuda/src/utils/cuda_error_handling.hpp"
+#include "vecmem/memory/device_atomic_ref.hpp"
+
+// GoogleTest include(s).
+#include <gtest/gtest.h>
+
+#define CUDA_ASSERT_TRUE(o, v) \
+    do {                       \
+        *out &= (!!v);         \
+    } while (0)
+#define CUDA_ASSERT_FALSE(o, v) \
+    do {                        \
+        *out &= (!v);           \
+    } while (0)
+#define CUDA_ASSERT_EQ(o, i, j) \
+    do {                        \
+        *out &= (i == j);       \
+    } while (0)
+
+#define CUDA_TEST(s, n, k)                                              \
+    TEST(s, n) {                                                        \
+        bool *b, out;                                                   \
+        int* i;                                                         \
+        VECMEM_CUDA_ERROR_CHECK(cudaMalloc(&b, sizeof(bool)));          \
+        VECMEM_CUDA_ERROR_CHECK(cudaMalloc(&i, sizeof(int)));           \
+        VECMEM_CUDA_ERROR_CHECK(cudaMemset(b, 1, sizeof(bool)));        \
+        k<<<1, 1>>>(b, i);                                              \
+        VECMEM_CUDA_ERROR_CHECK(cudaGetLastError());                    \
+        VECMEM_CUDA_ERROR_CHECK(cudaDeviceSynchronize());               \
+        VECMEM_CUDA_ERROR_CHECK(                                        \
+            cudaMemcpy(&out, b, sizeof(bool), cudaMemcpyDeviceToHost)); \
+        ASSERT_TRUE(out);                                               \
+        VECMEM_CUDA_ERROR_CHECK(cudaFree(b));                           \
+        VECMEM_CUDA_ERROR_CHECK(cudaFree(i));                           \
+    }
+
+__global__ void atomic_ref_operator_equals_kernel(bool* out, int* i) {
+    *i = 0;
+    vecmem::device_atomic_ref<int> a(*i);
+    a = 5;
+    CUDA_ASSERT_EQ(out, a.load(), 5);
+}
+
+CUDA_TEST(cuda_device_atomic_test, atomic_operator_equals,
+          atomic_ref_operator_equals_kernel);
+
+__global__ void atomic_ref_load_kernel(bool* out, int* i) {
+    *i = 17;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 17);
+}
+
+CUDA_TEST(cuda_device_atomic_test, atomic_load, atomic_ref_load_kernel);
+
+__global__ void atomic_ref_compare_exchange_strong_kernel(bool* out, int* i) {
+    *i = 0;
+    int zero = 0, five = 5;
+    vecmem::device_atomic_ref<int> a(*i);
+    // This passes, as i == 0, zero == 0. This will set zero = i = 0 and i = 5;
+    CUDA_ASSERT_TRUE(out, a.compare_exchange_strong(zero, 5));
+    CUDA_ASSERT_EQ(out, zero, 0);
+    // This fails, as i == 5, zero == 0. This will set zero = i = 5;
+    CUDA_ASSERT_FALSE(out, a.compare_exchange_strong(zero, 5));
+    CUDA_ASSERT_EQ(out, zero, 5);
+    // This succeeds, as i == 5, five == 5. This will set five = i = 5 and i =
+    // 0;
+    CUDA_ASSERT_TRUE(out, a.compare_exchange_strong(five, 0));
+    CUDA_ASSERT_EQ(out, five, 5);
+    // This fails, as i == 0, five == 5. This will set five = i = 0;
+    CUDA_ASSERT_FALSE(out, a.compare_exchange_strong(five, 0));
+    CUDA_ASSERT_EQ(out, five, 0);
+}
+
+CUDA_TEST(cuda_device_atomic_test, atomic_compare_exchange_strong,
+          atomic_ref_compare_exchange_strong_kernel);
+
+__global__ void atomic_ref_store_kernel(bool* out, int* i) {
+    *i = 0;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0);
+    a.store(5);
+    CUDA_ASSERT_EQ(out, a.load(), 5);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_store, atomic_ref_store_kernel);
+
+__global__ void atomic_ref_exchange_kernel(bool* out, int* i) {
+    *i = 0;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0);
+    CUDA_ASSERT_EQ(out, a.exchange(5), 0);
+    CUDA_ASSERT_EQ(out, a.load(), 5);
+    CUDA_ASSERT_EQ(out, a.exchange(3), 5);
+    CUDA_ASSERT_EQ(out, a.load(), 3);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_exchange, atomic_ref_exchange_kernel);
+
+__global__ void atomic_ref_fetch_add_kernel(bool* out, int* i) {
+    *i = 0;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0);
+    CUDA_ASSERT_EQ(out, a.fetch_add(5), 0);
+    CUDA_ASSERT_EQ(out, a.load(), 5);
+    CUDA_ASSERT_EQ(out, a.fetch_add(3), 5);
+    CUDA_ASSERT_EQ(out, a.load(), 8);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_fetch_add,
+          atomic_ref_fetch_add_kernel);
+
+__global__ void atomic_ref_fetch_sub_kernel(bool* out, int* i) {
+    *i = 0;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0);
+    CUDA_ASSERT_EQ(out, a.fetch_sub(5), 0);
+    CUDA_ASSERT_EQ(out, a.load(), -5);
+    CUDA_ASSERT_EQ(out, a.fetch_sub(3), -5);
+    CUDA_ASSERT_EQ(out, a.load(), -8);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_fetch_sub,
+          atomic_ref_fetch_sub_kernel);
+
+__global__ void atomic_ref_fetch_and_kernel(bool* out, int* i) {
+    *i = 0b0101;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0b0101);
+    CUDA_ASSERT_EQ(out, a.fetch_and(0b1100), 0b0101);
+    CUDA_ASSERT_EQ(out, a.load(), 0b0100);
+    CUDA_ASSERT_EQ(out, a.fetch_and(0b0000), 0b0100);
+    CUDA_ASSERT_EQ(out, a.load(), 0b0000);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_fetch_and,
+          atomic_ref_fetch_and_kernel);
+
+__global__ void atomic_ref_fetch_or_kernel(bool* out, int* i) {
+    *i = 0b0101;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0b0101);
+    CUDA_ASSERT_EQ(out, a.fetch_or(0b1100), 0b0101);
+    CUDA_ASSERT_EQ(out, a.load(), 0b1101);
+    CUDA_ASSERT_EQ(out, a.fetch_or(0b0000), 0b1101);
+    CUDA_ASSERT_EQ(out, a.load(), 0b1101);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_fetch_or, atomic_ref_fetch_or_kernel);
+
+__global__ void atomic_ref_fetch_xor_kernel(bool* out, int* i) {
+    *i = 0b0101;
+    vecmem::device_atomic_ref<int> a(*i);
+    CUDA_ASSERT_EQ(out, a.load(), 0b0101);
+    CUDA_ASSERT_EQ(out, a.fetch_xor(0b1100), 0b0101);
+    CUDA_ASSERT_EQ(out, a.load(), 0b1001);
+    CUDA_ASSERT_EQ(out, a.fetch_xor(0b0000), 0b1001);
+    CUDA_ASSERT_EQ(out, a.load(), 0b1001);
+}
+
+CUDA_TEST(core_device_atomic_test, atomic_fetch_xor,
+          atomic_ref_fetch_xor_kernel);


### PR DESCRIPTION
While working on https://github.com/acts-project/traccc/pull/595, I found out that the vecmem implementation of atomic CAS is fundamentally broken on CUDA platforms :worried:. Currently, the functionality is `compare_exchange_strong` is broken because it relies on the CUDA `atomicCAS` builtin which functions fundamentally differently from the C++ STL version of the equivalent code. Indeed, the C++ version returns true on a succesful swap and false otherwise. The CUDA version always returns the old value. As such, if the old value is false-like, e.g. 0, the `compare_exchange_strong` function will always appear to fail, even if it succeeded. This commit fixes the above issue.

I also removed the backup implementation of CAS as it was not atomic in any way and was basically lying to users about working atomically :worried:.