### PR TITLE
Add concept for atomic references

### DIFF
--- a/core/include/vecmem/concepts/atomic_ref.hpp
+++ b/core/include/vecmem/concepts/atomic_ref.hpp
@@ -1,0 +1,62 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+#if __cpp_concepts >= 201907L
+#include <concepts>
+
+#include "vecmem/memory/memory_order.hpp"
+#endif
+
+namespace vecmem::concepts {
+#if __cpp_concepts >= 201907L
+/**
+ * @brief Concept to verify that a type functions as an atomic reference.
+ */
+template <typename T>
+concept atomic_ref = requires {
+    typename T::value_type;
+
+    requires requires(const T& r, typename T::value_type v) {
+        { r = v }
+        ->std::same_as<typename T::value_type>;
+    };
+
+    requires requires(const T& r, memory_order o) {
+        { r.load(o) }
+        ->std::same_as<typename T::value_type>;
+    };
+
+    requires requires(const T& r, typename T::value_type v, memory_order o) {
+        { r.store(v, o) }
+        ->std::same_as<void>;
+        { r.exchange(v, o) }
+        ->std::same_as<typename T::value_type>;
+        { r.fetch_add(v, o) }
+        ->std::same_as<typename T::value_type>;
+        { r.fetch_sub(v, o) }
+        ->std::same_as<typename T::value_type>;
+        { r.fetch_and(v, o) }
+        ->std::same_as<typename T::value_type>;
+        { r.fetch_or(v, o) }
+        ->std::same_as<typename T::value_type>;
+        { r.fetch_xor(v, o) }
+        ->std::same_as<typename T::value_type>;
+    };
+
+    requires requires(const T& r, typename T::value_type& e,
+                      typename T::value_type d, memory_order o1,
+                      memory_order o2) {
+        { r.compare_exchange_strong(e, d, o1, o2) }
+        ->std::same_as<bool>;
+        { r.compare_exchange_strong(e, d, o1) }
+        ->std::same_as<bool>;
+    };
+};
+#endif
+}  // namespace vecmem::concepts

--- a/core/include/vecmem/memory/impl/device_atomic_ref.ipp
+++ b/core/include/vecmem/memory/impl/device_atomic_ref.ipp
@@ -7,6 +7,12 @@
  */
 #pragma once
 
+#include <cassert>
+#include <cstring>
+
+// vecmem includes
+#include "vecmem/memory/memory_order.hpp"
+
 // HIP include
 #if defined(__HIP_DEVICE_COMPILE__)
 #include <hip/hip_runtime.h>

--- a/core/include/vecmem/memory/memory_order.hpp
+++ b/core/include/vecmem/memory/memory_order.hpp
@@ -1,0 +1,40 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+// System include(s).
+#include <atomic>
+
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && \
+    defined(VECMEM_HAVE_SYCL_ATOMIC_REF)
+// SYCL include(s).
+#include <CL/sycl.hpp>
+#endif
+
+namespace vecmem {
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && \
+    defined(VECMEM_HAVE_SYCL_ATOMIC_REF)
+/// Define @c vecmem::memory_order as @c sycl::memory_order
+using memory_order = ::sycl::memory_order;
+#elif ((!defined(__CUDA_ARCH__)) && (!defined(__HIP_DEVICE_COMPILE__)) && \
+       (!defined(CL_SYCL_LANGUAGE_VERSION)) &&                            \
+       (!defined(SYCL_LANGUAGE_VERSION)) && __cpp_lib_atomic_ref)
+using memory_order = std::memory_order;
+#else
+/// Custom (dummy) definition for the memory order
+enum class memory_order {
+    relaxed = 0,
+    consume = 1,
+    acquire = 2,
+    release = 3,
+    acq_rel = 4,
+    seq_cst = 5
+};
+#endif
+}  // namespace vecmem


### PR DESCRIPTION
This commit adds a new concept for atomic references and, in order to do so, moves the definition of `memory_order` into a separate file.