### PR TITLE
Move `vecmem::memory_order` into its own header

### DIFF
--- a/core/include/vecmem/memory/device_atomic_ref.hpp
+++ b/core/include/vecmem/memory/device_atomic_ref.hpp
@@ -7,8 +7,8 @@
  */
 #pragma once
 
-// System include(s).
-#include <atomic>
+// vecmem includes
+#include "vecmem/memory/memory_order.hpp"
 
 namespace vecmem {
 
@@ -24,10 +24,6 @@ enum class device_address_space { global = 0, local = 1 };
 #include <CL/sycl.hpp>
 
 namespace vecmem {
-
-/// Define @c vecmem::memory_order as @c sycl::memory_order
-using memory_order = ::sycl::memory_order;
-
 namespace details {
 template <device_address_space address>
 struct sycl_address_space {};
@@ -64,10 +60,6 @@ using device_atomic_ref =
        (!defined(SYCL_LANGUAGE_VERSION)) && __cpp_lib_atomic_ref)
 
 namespace vecmem {
-
-/// Define @c vecmem::memory_order as @c std::memory_order
-using memory_order = std::memory_order;
-
 /// @c vecmem::atomic_ref equals @c std::atomic_ref in host code with C++20
 template <typename T, device_address_space = device_address_space::global>
 using device_atomic_ref = std::atomic_ref<T>;
@@ -83,17 +75,6 @@ using device_atomic_ref = std::atomic_ref<T>;
 #include <type_traits>
 
 namespace vecmem {
-
-/// Custom (dummy) definition for the memory order
-enum class memory_order {
-    relaxed = 0,
-    consume = 1,
-    acquire = 2,
-    release = 3,
-    acq_rel = 4,
-    seq_cst = 5
-};
-
 /// Class providing atomic operations for the VecMem code
 ///
 /// It is only meant to be used with primitive types. Ones that CUDA, HIP and

--- a/core/include/vecmem/memory/impl/device_atomic_ref.ipp
+++ b/core/include/vecmem/memory/impl/device_atomic_ref.ipp
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+// vecmem includes
+#include "vecmem/memory/memory_order.hpp"
+
 // HIP include
 #if defined(__HIP_DEVICE_COMPILE__)
 #include <hip/hip_runtime.h>

--- a/core/include/vecmem/memory/memory_order.hpp
+++ b/core/include/vecmem/memory/memory_order.hpp
@@ -1,0 +1,42 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && \
+    defined(VECMEM_HAVE_SYCL_ATOMIC_REF)
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+namespace vecmem {
+/// Define @c vecmem::memory_order as @c sycl::memory_order
+using memory_order = ::sycl::memory_order;
+}  // namespace vecmem
+#elif ((!defined(__CUDA_ARCH__)) && (!defined(__HIP_DEVICE_COMPILE__)) &&    \
+       (!defined(CL_SYCL_LANGUAGE_VERSION)) &&                               \
+       (!defined(SYCL_LANGUAGE_VERSION)) && defined(__cpp_lib_atomic_ref) && \
+       __cpp_lib_atomic_ref >= 201806L)
+// System include(s).
+#include <atomic>
+
+namespace vecmem {
+using memory_order = std::memory_order;
+}
+#else
+namespace vecmem {
+/// Custom (dummy) definition for the memory order
+enum class memory_order {
+    relaxed = 0,
+    consume = 1,
+    acquire = 2,
+    release = 3,
+    acq_rel = 4,
+    seq_cst = 5
+};
+}  // namespace vecmem
+#endif


### PR DESCRIPTION
This commit moves `vecmem::memory_order` into its own header in order to avoid circular dependencies in #275 and #276.