### PR TITLE
Windows CI Fix, main branch (2024.06.11.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -309,6 +309,12 @@ if( VECMEM_HAVE_STD_ALIGNED_ALLOC )
    target_compile_definitions( vecmem_core
       PRIVATE VECMEM_HAVE_STD_ALIGNED_ALLOC )
 endif()
+
+# This is a (hopefully) temporary workaround for fixing the CI builds on
+# Windows. See https://github.com/actions/runner-images/issues/10004 for more
+# details.
+target_compile_definitions( vecmem_core
+   PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR )
 
 # Test the public headers of vecmem::core.
 if( BUILD_TESTING AND VECMEM_BUILD_TESTING )


### PR DESCRIPTION
As discussed in https://github.com/actions/runner-images/issues/10004, CI jobs on Windows started misbehaving recently. This is a work-around for the issue, adding `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` as a definition to `vecmem::core`. (To allow it to use [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex) correctly on Windows.)