### PR TITLE
Introduce doxygen-awesome-css, main branch (2024.06.08.)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2023 CERN for the benefit of the ACTS project
+# (c) 2023-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -36,18 +36,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v5
       - name: Build Doxygen
         run: |
           sudo apt-get install -y cmake doxygen
-          cmake -S ${{ github.workspace }} -B build
+          cmake -DVECMEM_BUILD_DOCS=TRUE -S ${{ github.workspace }} -B build
           cmake --build build --target vecmem_docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'build/html'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,9 +60,14 @@ endif()
 # Set up the packaging of the project.
 include( vecmem-packaging )
 
-# Set up Doxygen documentation creation for the project.
-find_package( Doxygen )
-if( DOXYGEN_FOUND )
+# Set up Doxygen documentation creation for the project, if requested.
+if( VECMEM_BUILD_DOCS )
+
+   # This requires / uses Doxygen and doxygen-awesome-css.
+   find_package( Doxygen REQUIRED )
+   add_subdirectory( cmake/doxygen-awesome-css )
+
+   # Set up how to build the Doxygen documentation.
    set( DOXYGEN_JAVADOC_AUTOBRIEF TRUE )
    set( DOXYGEN_USE_MDFILE_AS_MAINPAGE
       "${CMAKE_CURRENT_SOURCE_DIR}/README.md" )
@@ -81,6 +86,13 @@ if( DOXYGEN_FOUND )
       "${CMAKE_CURRENT_SOURCE_DIR}/tests"
       "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks"
       "${CMAKE_CURRENT_SOURCE_DIR}/build" )
+   set( DOXYGEN_GENERATE_TREEVIEW FALSE )
+   set( DOXYGEN_DISABLE_INDEX FALSE )
+   set( DOXYGEN_FULL_SIDEBAR FALSE )
+   set( DOXYGEN_HTML_EXTRA_STYLESHEET
+      "${doxygenawesomecss_SOURCE_DIR}/doxygen-awesome.css" )
+
+   # Set up the "vecmem_docs" target.
    doxygen_add_docs( vecmem_docs
       "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Generating Doxygen pages" )

--- a/cmake/doxygen-awesome-css/CMakeLists.txt
+++ b/cmake/doxygen-awesome-css/CMakeLists.txt
@@ -1,0 +1,29 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# CMake include(s).
+cmake_minimum_required( VERSION 3.11 )
+include( FetchContent )
+
+# Silence FetchContent warnings with CMake >=3.24.
+if( POLICY CMP0135 )
+   cmake_policy( SET CMP0135 NEW )
+endif()
+
+# Tell the user what's happening.
+message( STATUS
+   "Downloading doxygen-awesome-css as part of the VecMem project" )
+
+# Declare where to get doxygen-awesome-css from.
+FetchContent_Declare( DoxygenAwesomeCss
+   URL "https://github.com/jothepro/doxygen-awesome-css/archive/refs/tags/v2.3.3.tar.gz"
+   URL_MD5 "9b7a51265777e340561f6254421c107d" )
+
+# Make it awailable in the build directory.
+set( CMAKE_FOLDER "vecmem/externals" )
+FetchContent_MakeAvailable( DoxygenAwesomeCss )
+set( doxygenawesomecss_SOURCE_DIR "${doxygenawesomecss_SOURCE_DIR}"
+   PARENT_SCOPE )

--- a/cmake/doxygen-awesome-css/README.md
+++ b/cmake/doxygen-awesome-css/README.md
@@ -1,0 +1,1 @@
+# Download instructions for doxygen-awesome-css

--- a/cmake/vecmem-options.cmake
+++ b/cmake/vecmem-options.cmake
@@ -58,3 +58,6 @@ option( VECMEM_FAIL_ON_WARNINGS
 # Decide whether runtime asynchronous synhronization errors should be fatal.
 option( VECMEM_FAIL_ON_ASYNC_ERRORS
    "Make the build fail on asynchronous synchronization errors" FALSE )
+
+# Build the project's documentation.
+option( VECMEM_BUILD_DOCS "Build the project's documentation" OFF )


### PR DESCRIPTION
I was told about [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css) last week by @EdwardMoyse. And then he even went ahead with introducing it into [atlas/athena](https://gitlab.cern.ch/atlas/athena) in https://gitlab.cern.ch/atlas/athena/-/merge_requests/72075. So I thought I should do it for our repository as well. :wink:

What this setup brings is to switch from this sort of documentation pages:

![image](https://github.com/acts-project/vecmem/assets/30694331/5d1dd7a0-a071-44d7-abfd-42f561b67443)
![image](https://github.com/acts-project/vecmem/assets/30694331/3c3db3e5-63e7-4b6e-b152-0ee933a14371)
![image](https://github.com/acts-project/vecmem/assets/30694331/e4b970fe-9605-4cad-bb8f-41a14802c66a)

, to a look like:

![image](https://github.com/acts-project/vecmem/assets/30694331/a27be385-a6d0-4536-98f1-d633fe4bb0db)
![image](https://github.com/acts-project/vecmem/assets/30694331/639c2586-3d7b-46df-8c83-8b5850947ac0)
![image](https://github.com/acts-project/vecmem/assets/30694331/fe36e9c7-d73a-4fda-8184-9c02e6d7715f)

Now... I personally use a dark theme, that's why all the pages show up like this. But they should by default adapt to the viewer's preference I believe. Plus, the claim is that the pages should show up a lot better on phones/tablets. Though this latter I didn't try so far.

I'm actually open to a discussion about this. How do you guys feel about this sort of a look? :thinking: