### PR TITLE
Revert "Windows CI Fix, main branch (2024.06.11.)"

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -316,12 +316,6 @@ if( VECMEM_HAVE_STD_ALIGNED_ALLOC )
       PRIVATE VECMEM_HAVE_STD_ALIGNED_ALLOC )
 endif()
 
-# This is a (hopefully) temporary workaround for fixing the CI builds on
-# Windows. See https://github.com/actions/runner-images/issues/10004 for more
-# details.
-target_compile_definitions( vecmem_core
-   PRIVATE _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR )
-
 # Test the public headers of vecmem::core.
 if( BUILD_TESTING AND VECMEM_BUILD_TESTING )
    file( GLOB_RECURSE vecmem_core_public_headers


### PR DESCRIPTION
Reverts acts-project/vecmem#279.

The claim in https://github.com/actions/runner-images/issues/10004 is that the GitHub Windows runners are now back to not needing this workaround anymore. So, let's see...