### PR TITLE
Symbol Visibility Update, main branch (2024.06.13.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -161,6 +161,12 @@ vecmem_add_library( vecmem_core core
 # Hide the library's symbols by default.
 set_target_properties( vecmem_core PROPERTIES
    CXX_VISIBILITY_PRESET "hidden" )
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag(
+   "-fvisibility-ms-compat" VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+if( VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+   target_compile_options( vecmem_core PRIVATE "-fvisibility-ms-compat" )
+endif()
 
 # Generate a version header for the project.
 configure_file( "cmake/version.hpp.in"

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -46,6 +46,12 @@ target_link_libraries( vecmem_cuda
 # Hide the library's symbols by default.
 set_target_properties( vecmem_cuda PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden" )
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag(
+   "-fvisibility-ms-compat" VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+if( VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+   target_compile_options( vecmem_cuda PRIVATE "-fvisibility-ms-compat" )
+endif()
 
 # Set up whether asynchronous synchronization errors should be fatal.
 if( VECMEM_FAIL_ON_ASYNC_ERRORS )

--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -36,6 +36,12 @@ target_link_libraries( vecmem_hip
 # Hide the library's symbols by default.
 set_target_properties( vecmem_hip PROPERTIES
    CXX_VISIBILITY_PRESET "hidden" )
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag(
+   "-fvisibility-ms-compat" VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+if( VECMEM_HAVE_VISIBILITY_MS_COMPAT )
+   target_compile_options( vecmem_hip PRIVATE "-fvisibility-ms-compat" )
+endif()
 
 # Test the public headers of vecmem::hip.
 if( BUILD_TESTING AND VECMEM_BUILD_TESTING )

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2023 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -39,6 +39,12 @@ target_link_libraries( vecmem_sycl PUBLIC vecmem::core )
 set_target_properties( vecmem_sycl PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden"
    SYCL_VISIBILITY_PRESET "hidden" )
+vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_VISIBILITY_MS_COMPAT
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/empty.sycl"
+   CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fvisibility-ms-compat )
+if( VECMEM_HAVE_SYCL_VISIBILITY_MS_COMPAT )
+   target_compile_options( vecmem_sycl PRIVATE "-fvisibility-ms-compat" )
+endif()
 
 # Set up whether asynchronous synchronization errors should be fatal.
 if( VECMEM_FAIL_ON_ASYNC_ERRORS )

--- a/sycl/cmake/empty.sycl
+++ b/sycl/cmake/empty.sycl
@@ -1,0 +1,13 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+int main() {
+    return 0;
+}

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -31,3 +31,11 @@ vecmem_add_test( core
    "test_core_edm_host.cpp"
    "test_core_edm_view.cpp"
    LINK_LIBRARIES vecmem::core GTest::gtest_main vecmem_testing_common )
+
+# Add UBSAN for the tests, if it's available.
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN )
+   target_compile_options( vecmem_test_core PRIVATE "-fsanitize=undefined" )
+   target_link_options( vecmem_test_core PRIVATE "-fsanitize=undefined" )
+endif()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -56,6 +56,15 @@ vecmem_add_test( cuda
    LINK_LIBRARIES CUDA::cudart vecmem::core vecmem::cuda vecmem_testing_cuda_main
                   vecmem_testing_common )
 
+# Add UBSAN for the tests, if it's available.
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN )
+   target_compile_options( vecmem_test_cuda PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=undefined> )
+   target_link_options( vecmem_test_cuda PRIVATE "-fsanitize=undefined" )
+endif()
+
 # Set up a separate test if the C++17 standard is available for CUDA.
 if( "${CMAKE_CUDA_STANDARD}" VERSION_GREATER_EQUAL "17" )
    vecmem_add_test( cuda_cxx17

--- a/tests/hip/CMakeLists.txt
+++ b/tests/hip/CMakeLists.txt
@@ -27,6 +27,15 @@ vecmem_add_test( hip
    LINK_LIBRARIES HIP::hiprt vecmem::core vecmem::hip GTest::gtest_main
                   vecmem_testing_common )
 
+# Add UBSAN for the tests, if it's available.
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN )
+   target_compile_options( vecmem_test_hip PRIVATE
+      $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=undefined> )
+   target_link_options( vecmem_test_hip PRIVATE "-fsanitize=undefined" )
+endif()
+
 # The executable's source code needs to be built into position independent
 # code in certain HIP + GCC combinations. But not most of them... Still, for
 # the test executable let's just take the hit, and always use PIC.

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_language( SYCL )
 # Project include(s).
 include( vecmem-compiler-options-cpp )
 include( vecmem-compiler-options-sycl )
+include( vecmem-check-sycl-code-compiles )
 
 # Test all of the SYCL library's features.
 vecmem_add_test( sycl
@@ -19,3 +20,14 @@ vecmem_add_test( sycl
    "test_sycl_copy.cpp"
    LINK_LIBRARIES vecmem::core vecmem::sycl GTest::gtest_main
                   vecmem_testing_common )
+
+# Add UBSAN for the tests, if it's available.
+include( CheckCXXCompilerFlag )
+check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
+vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_UBSAN
+   "${CMAKE_CURRENT_SOURCE_DIR}/../../sycl/cmake/empty.sycl"
+   CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fsanitize=undefined )
+if( VECMEM_HAVE_UBSAN AND VECMEM_HAVE_SYCL_UBSAN )
+   target_compile_options( vecmem_test_sycl PRIVATE "-fsanitize=undefined" )
+   target_link_options( vecmem_test_sycl PRIVATE "-fsanitize=undefined" )
+endif()


### PR DESCRIPTION
Added the usage of `-fvisibility-ms-compat` where appropriate. This flag is needed with GCC, and also some versions of Clang to be able to use UBSAN in client projects that want to use VecMem libraries.

Made the unit tests be built with UBSAN enabled, when it's available.