### PR TITLE
Deduplicate `empty.sycl` file

### DIFF
--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -25,7 +25,7 @@ vecmem_add_test( sycl
 include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
 vecmem_check_sycl_code_compiles( VECMEM_HAVE_SYCL_UBSAN
-   "${CMAKE_CURRENT_SOURCE_DIR}/../../sycl/cmake/empty.sycl"
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/empty_ubsan.sycl"
    CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fsanitize=undefined )
 if( VECMEM_HAVE_UBSAN AND VECMEM_HAVE_SYCL_UBSAN )
    target_compile_options( vecmem_test_sycl PRIVATE "-fsanitize=undefined" )

--- a/tests/sycl/cmake/empty_ubsan.sycl
+++ b/tests/sycl/cmake/empty_ubsan.sycl
@@ -1,0 +1,13 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// SYCL include(s).
+#include <CL/sycl.hpp>
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
The current setup uses `try_compile` on the source file `empty.sycl` twice, which leads to the following error when using Ninja, enabling SYCL, and having the tests enabled:

```
error: sycl/cmake/empty.sycl is defined as an output multiple times
```

This commit takes the path of least resistance and clones the file into `empty_ubsan.sycl` so that these compile tests no longer collide.