### PR TITLE
Make atomic reference constructor explicit

### DIFF
--- a/core/include/vecmem/memory/device_atomic_ref.hpp
+++ b/core/include/vecmem/memory/device_atomic_ref.hpp
@@ -115,7 +115,7 @@ public:
 
     /// Constructor, with a pointer to the managed variable
     VECMEM_HOST_AND_DEVICE
-    device_atomic_ref(reference ref);
+    explicit device_atomic_ref(reference ref);
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE
     device_atomic_ref(const device_atomic_ref& parent);


### PR DESCRIPTION
Right now, the constructor `device_atomic_ref(T&)` is implicit, which does not match the definition provided in C++20. While this seems harmless, it can break code that relies on this implicit conversion if it switches to using `std::atomic_ref`, which vecmem may decide to do if C++20 is enabled. This commit makes the constructor explicit so it matches the definitions in the STL.