### PR TITLE
 Mark copy events as `nodiscard`

### DIFF
--- a/benchmarks/core/benchmark_copy.cpp
+++ b/benchmarks/core/benchmark_copy.cpp
@@ -50,11 +50,11 @@ void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, host_mr);
-    host_copy.setup(dest);
+    host_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        host_copy(source_data, dest);
+        host_copy(source_data, dest)->wait();
     }
 }
 // Set up the benchmark.
@@ -82,11 +82,11 @@ void jaggedVectorKnownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, host_mr);
-    host_copy.setup(dest);
+    host_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        host_copy(source_data, dest, copy::type::host_to_device);
+        host_copy(source_data, dest, copy::type::host_to_device)->wait();
     }
 }
 // Set up the benchmark.
@@ -111,14 +111,14 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, host_mr);
-    host_copy.setup(source);
+    host_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest = make_jagged_vector(sizes, host_mr);
     data::jagged_vector_data<int> dest_data = get_data(dest);
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        host_copy(source, dest_data);
+        host_copy(source, dest_data)->wait();
     }
 }
 // Set up the benchmark.
@@ -143,14 +143,14 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, host_mr);
-    host_copy.setup(source);
+    host_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest = make_jagged_vector(sizes, host_mr);
     data::jagged_vector_data<int> dest_data = get_data(dest);
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        host_copy(source, dest_data, copy::type::device_to_host);
+        host_copy(source, dest_data, copy::type::device_to_host)->wait();
     }
 }
 // Set up the benchmark.

--- a/benchmarks/cuda/benchmark_copy.cpp
+++ b/benchmarks/cuda/benchmark_copy.cpp
@@ -54,11 +54,11 @@ void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    cuda_copy.setup(dest);
+    cuda_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source_data, dest);
+        cuda_copy(source_data, dest)->wait();
     }
 }
 // Set up the benchmark.
@@ -87,11 +87,11 @@ void jaggedVectorKnownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    cuda_copy.setup(dest);
+    cuda_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source_data, dest, copy::type::host_to_device);
+        cuda_copy(source_data, dest, copy::type::host_to_device)->wait();
     }
 }
 // Set up the benchmark.
@@ -116,7 +116,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    cuda_copy.setup(source);
+    cuda_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -124,7 +124,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source, dest_data);
+        cuda_copy(source, dest_data)->wait();
     }
 }
 // Set up the benchmark.
@@ -149,7 +149,7 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    cuda_copy.setup(source);
+    cuda_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -157,7 +157,7 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        cuda_copy(source, dest_data, copy::type::device_to_host);
+        cuda_copy(source, dest_data, copy::type::device_to_host)->wait();
     }
 }
 // Set up the benchmark.

--- a/benchmarks/sycl/benchmark_copy.cpp
+++ b/benchmarks/sycl/benchmark_copy.cpp
@@ -57,11 +57,11 @@ void jaggedVectorUnknownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    sycl_copy.setup(dest);
+    sycl_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        sycl_copy(source_data, dest);
+        sycl_copy(source_data, dest)->wait();
     }
 }
 // Set up the benchmark.
@@ -90,11 +90,11 @@ void jaggedVectorKnownHtoDCopy(::benchmark::State& state) {
     const data::jagged_vector_data<int> source_data = get_data(source);
     // Create the "destination buffer".
     data::jagged_vector_buffer<int> dest(sizes, device_mr, &host_mr);
-    sycl_copy.setup(dest);
+    sycl_copy.setup(dest)->wait();
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        sycl_copy(source_data, dest, copy::type::host_to_device);
+        sycl_copy(source_data, dest, copy::type::host_to_device)->wait();
     }
 }
 // Set up the benchmark.
@@ -119,7 +119,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    sycl_copy.setup(source);
+    sycl_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -127,7 +127,7 @@ void jaggedVectorUnknownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        sycl_copy(source, dest_data);
+        sycl_copy(source, dest_data)->wait();
     }
 }
 // Set up the benchmark.
@@ -152,7 +152,7 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Create the "source buffer".
     data::jagged_vector_buffer<int> source(sizes, device_mr, &host_mr);
-    sycl_copy.setup(source);
+    sycl_copy.setup(source)->wait();
     // Create the "destination vector".
     jagged_vector<int> dest =
         vecmem::benchmark::make_jagged_vector(sizes, host_mr);
@@ -160,7 +160,7 @@ void jaggedVectorKnownDtoHCopy(::benchmark::State& state) {
 
     // Perform the copy benchmark.
     for (auto _ : state) {
-        sycl_copy(source, dest_data, copy::type::device_to_host);
+        sycl_copy(source, dest_data, copy::type::device_to_host)->wait();
     }
 }
 // Set up the benchmark.

--- a/core/include/vecmem/utils/attributes.hpp
+++ b/core/include/vecmem/utils/attributes.hpp
@@ -1,0 +1,19 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2021-2023 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+#pragma once
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(nodiscard) >= 201603L
+#define VECMEM_NODISCARD [[nodiscard]]
+#else
+#define VECMEM_NODISCARD
+#endif
+#else
+#define VECMEM_NODISCARD
+#endif

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -17,6 +17,7 @@
 #include "vecmem/edm/view.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/utils/abstract_event.hpp"
+#include "vecmem/utils/attributes.hpp"
 #include "vecmem/vecmem_core_export.hpp"
 
 // System include(s).
@@ -75,11 +76,12 @@ public:
 
     /// Set up the internal state of a vector buffer correctly on a device
     template <typename TYPE>
-    event_type setup(data::vector_view<TYPE> data) const;
+    VECMEM_NODISCARD event_type setup(data::vector_view<TYPE> data) const;
 
     /// Set all bytes of the vector to some value
     template <typename TYPE>
-    event_type memset(data::vector_view<TYPE> data, int value) const;
+    VECMEM_NODISCARD event_type memset(data::vector_view<TYPE> data,
+                                       int value) const;
 
     /// Copy a 1-dimensional vector to the specified memory resource
     template <typename TYPE>
@@ -89,15 +91,17 @@ public:
 
     /// Copy a 1-dimensional vector's data between two existing memory blocks
     template <typename TYPE>
-    event_type operator()(const data::vector_view<std::add_const_t<TYPE>>& from,
-                          data::vector_view<TYPE> to,
-                          type::copy_type cptype = type::unknown) const;
+    VECMEM_NODISCARD event_type
+    operator()(const data::vector_view<std::add_const_t<TYPE>>& from,
+               data::vector_view<TYPE> to,
+               type::copy_type cptype = type::unknown) const;
 
     /// Copy a 1-dimensional vector's data into a vector object
     template <typename TYPE, typename ALLOC>
-    event_type operator()(const data::vector_view<std::add_const_t<TYPE>>& from,
-                          std::vector<TYPE, ALLOC>& to,
-                          type::copy_type cptype = type::unknown) const;
+    VECMEM_NODISCARD event_type
+    operator()(const data::vector_view<std::add_const_t<TYPE>>& from,
+               std::vector<TYPE, ALLOC>& to,
+               type::copy_type cptype = type::unknown) const;
 
     /// Helper function for getting the size of a resizable 1D buffer
     template <typename TYPE>
@@ -111,11 +115,13 @@ public:
 
     /// Copy the internal state of a jagged vector buffer to the target device
     template <typename TYPE>
-    event_type setup(data::jagged_vector_view<TYPE> data) const;
+    VECMEM_NODISCARD event_type
+    setup(data::jagged_vector_view<TYPE> data) const;
 
     /// Set all bytes of the jagged vector to some value
     template <typename TYPE>
-    event_type memset(data::jagged_vector_view<TYPE> data, int value) const;
+    VECMEM_NODISCARD event_type memset(data::jagged_vector_view<TYPE> data,
+                                       int value) const;
 
     /// Copy a jagged vector to the specified memory resource
     template <typename TYPE>
@@ -126,17 +132,17 @@ public:
 
     /// Copy a jagged vector's data between two existing allocations
     template <typename TYPE>
-    event_type operator()(
-        const data::jagged_vector_view<std::add_const_t<TYPE>>& from,
-        data::jagged_vector_view<TYPE> to,
-        type::copy_type cptype = type::unknown) const;
+    VECMEM_NODISCARD event_type
+    operator()(const data::jagged_vector_view<std::add_const_t<TYPE>>& from,
+               data::jagged_vector_view<TYPE> to,
+               type::copy_type cptype = type::unknown) const;
 
     /// Copy a jagged vector's data into a vector object
     template <typename TYPE, typename ALLOC1, typename ALLOC2>
-    event_type operator()(
-        const data::jagged_vector_view<std::add_const_t<TYPE>>& from,
-        std::vector<std::vector<TYPE, ALLOC2>, ALLOC1>& to,
-        type::copy_type cptype = type::unknown) const;
+    VECMEM_NODISCARD event_type
+    operator()(const data::jagged_vector_view<std::add_const_t<TYPE>>& from,
+               std::vector<std::vector<TYPE, ALLOC2>, ALLOC1>& to,
+               type::copy_type cptype = type::unknown) const;
 
     /// Helper function for getting the sizes of a resizable jagged vector
     template <typename TYPE>
@@ -145,7 +151,7 @@ public:
 
     /// Helper function for setting the sizes of a resizable jagged vector
     template <typename TYPE>
-    event_type set_sizes(
+    VECMEM_NODISCARD event_type set_sizes(
         const std::vector<typename data::vector_view<TYPE>::size_type>& sizes,
         data::jagged_vector_view<TYPE> data) const;
 
@@ -156,16 +162,16 @@ public:
 
     /// Set up the internal state of a buffer correctly on a device
     template <typename SCHEMA>
-    event_type setup(edm::view<SCHEMA> data) const;
+    VECMEM_NODISCARD event_type setup(edm::view<SCHEMA> data) const;
 
     /// Set all bytes of the container to some value
     template <typename... VARTYPES>
-    event_type memset(edm::view<edm::schema<VARTYPES...>> data,
-                      int value) const;
+    VECMEM_NODISCARD event_type memset(edm::view<edm::schema<VARTYPES...>> data,
+                                       int value) const;
 
     /// Copy between two views
     template <typename... VARTYPES>
-    event_type operator()(
+    VECMEM_NODISCARD event_type operator()(
         const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
             from,
         edm::view<edm::schema<VARTYPES...>> to,
@@ -173,7 +179,7 @@ public:
 
     /// Copy from a view, into a host container
     template <typename... VARTYPES, template <typename> class INTERFACE>
-    event_type operator()(
+    VECMEM_NODISCARD event_type operator()(
         const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
             from,
         edm::host<edm::schema<VARTYPES...>, INTERFACE>& to,
@@ -193,7 +199,7 @@ protected:
     /// Perform a "low level" memory filling operation
     virtual void do_memset(std::size_t size, void* ptr, int value) const;
     /// Create an event for synchronization
-    virtual event_type create_event() const;
+    VECMEM_NODISCARD virtual event_type create_event() const;
 
 private:
     /// Implementation for the 1D vector copy operator

--- a/tests/common/copy_tests.ipp
+++ b/tests/common/copy_tests.ipp
@@ -260,10 +260,12 @@ TEST_P(copy_tests, mismatched_vector_buffer) {
 
     // Verify that data cannot be copied around like this.
     EXPECT_THROW(main_copy()(host_buffer1, device_buffer2,
-                             vecmem::copy::type::host_to_device),
+                             vecmem::copy::type::host_to_device)
+                     ->wait(),
                  std::exception);
     EXPECT_THROW(main_copy()(device_buffer2, host_buffer3,
-                             vecmem::copy::type::device_to_host),
+                             vecmem::copy::type::device_to_host)
+                     ->wait(),
                  std::exception);
 
     // Create resizable device and host buffers, which are (progressively)
@@ -297,7 +299,8 @@ TEST_P(copy_tests, mismatched_vector_buffer) {
 
     // Verify that data cannot be copied around like this.
     EXPECT_THROW(main_copy()(host_buffer1, device_buffer4,
-                             vecmem::copy::type::host_to_device),
+                             vecmem::copy::type::host_to_device)
+                     ->wait(),
                  std::exception);
 }
 
@@ -467,10 +470,12 @@ TEST_P(copy_tests, mismatched_jagged_vector_buffer) {
 
     // Verify that data cannot be copied around like this.
     EXPECT_THROW(main_copy()(host_buffer1, device_buffer2,
-                             vecmem::copy::type::host_to_device),
+                             vecmem::copy::type::host_to_device)
+                     ->wait(),
                  std::exception);
     EXPECT_THROW(main_copy()(device_buffer2, host_buffer3,
-                             vecmem::copy::type::device_to_host),
+                             vecmem::copy::type::device_to_host)
+                     ->wait(),
                  std::exception);
 
     // Create resizable device and host buffers, which are (progressively)
@@ -506,7 +511,8 @@ TEST_P(copy_tests, mismatched_jagged_vector_buffer) {
 
     // Verify that data cannot be copied around like this.
     EXPECT_THROW(main_copy()(host_buffer1, device_buffer4,
-                             vecmem::copy::type::host_to_device),
+                             vecmem::copy::type::host_to_device)
+                     ->wait(),
                  std::exception);
 }
 

--- a/tests/common/soa_device_tests.ipp
+++ b/tests/common/soa_device_tests.ipp
@@ -69,9 +69,10 @@ void soa_device_tests_base<CONTAINER>::modify_device(
     typename CONTAINER::buffer buffer;
     vecmem::testing::make_buffer(buffer, device_mr, host_mr,
                                  vecmem::data::buffer_type::fixed_size);
-    copy.setup(buffer);
+    copy.setup(buffer)->wait();
     copy(vecmem::get_data(container1), buffer,
-         vecmem::copy::type::host_to_device);
+         vecmem::copy::type::host_to_device)
+        ->wait();
 
     // Modify the container in host memory, using a simple for loop.
     auto data1 = vecmem::get_data(container1);
@@ -87,7 +88,7 @@ void soa_device_tests_base<CONTAINER>::modify_device(
 
     // Copy the data back to the host.
     typename CONTAINER::host container2{host_mr};
-    copy(buffer, container2);
+    copy(buffer, container2)->wait();
 
     // Compare the two.
     vecmem::testing::compare(vecmem::get_data(container1),
@@ -110,7 +111,7 @@ void soa_device_tests_base<CONTAINER>::fill_device(
     typename CONTAINER::buffer buffer1;
     vecmem::testing::make_buffer(buffer1, host_mr, host_mr,
                                  vecmem::data::buffer_type::resizable);
-    copy.setup(buffer1);
+    copy.setup(buffer1)->wait();
     typename CONTAINER::device device1{buffer1};
     for (unsigned int i = 0; i < device1.capacity(); ++i) {
         vecmem::testing::fill(i, device1);
@@ -120,7 +121,7 @@ void soa_device_tests_base<CONTAINER>::fill_device(
     typename CONTAINER::buffer buffer2;
     vecmem::testing::make_buffer(buffer2, device_mr, host_mr,
                                  vecmem::data::buffer_type::resizable);
-    copy.setup(buffer2);
+    copy.setup(buffer2)->wait();
 
     // Run a kernel that fills the buffer.
     if ((*device_fill)(buffer2) == false) {
@@ -131,8 +132,8 @@ void soa_device_tests_base<CONTAINER>::fill_device(
     typename CONTAINER::buffer buffer3;
     vecmem::testing::make_buffer(buffer3, host_mr, host_mr,
                                  vecmem::data::buffer_type::resizable);
-    copy.setup(buffer3);
-    copy(buffer2, buffer3, vecmem::copy::type::device_to_host);
+    copy.setup(buffer3)->wait();
+    copy(buffer2, buffer3, vecmem::copy::type::device_to_host)->wait();
 
     // Compare the two containers.
     vecmem::testing::compare(buffer1, buffer3);

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -85,7 +85,7 @@ TEST_F(core_device_container_test, vector_buffer) {
 
     // Create an "owning copy" of the host vector's memory.
     vecmem::data::vector_buffer<int> device_data(host_data.size(), m_resource);
-    m_copy(vecmem::get_data(host_vector), device_data);
+    m_copy(vecmem::get_data(host_vector), device_data)->wait();
 
     // Do some basic tests.
     EXPECT_EQ(device_data.size(), host_vector.size());
@@ -150,9 +150,9 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
     static constexpr buffer_size_type BUFFER_SIZE = 100;
     vecmem::data::vector_buffer<int> resizable_buffer(
         BUFFER_SIZE, m_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(resizable_buffer);
+    m_copy.setup(resizable_buffer)->wait();
     EXPECT_EQ(resizable_buffer.capacity(), BUFFER_SIZE);
-    m_copy(vecmem::get_data(host_vector), resizable_buffer);
+    m_copy(vecmem::get_data(host_vector), resizable_buffer)->wait();
     EXPECT_EQ(resizable_buffer.size(), host_vector.size());
 
     // Create a "device vector" on top of that resizable data.
@@ -240,7 +240,7 @@ TEST_F(core_device_container_test, resizable_vector_buffer) {
 
     // Copy the modified data back into the "host vector", and check if that
     // succeeded.
-    m_copy(resizable_buffer, host_vector);
+    m_copy(resizable_buffer, host_vector)->wait();
     EXPECT_EQ(host_vector.size(), 34);
     for (std::size_t i = 0; i < 29; ++i) {
         EXPECT_EQ(host_vector[i], 123);
@@ -287,7 +287,7 @@ TEST_F(core_device_container_test, resizable_vector_buffer_nontrivial) {
     static constexpr buffer_size_type BUFFER_SIZE = 100;
     vecmem::data::vector_buffer<nontrivial_class> resizable_buffer(
         BUFFER_SIZE, m_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(resizable_buffer);
+    m_copy.setup(resizable_buffer)->wait();
     EXPECT_EQ(resizable_buffer.capacity(), BUFFER_SIZE);
     EXPECT_EQ(resizable_buffer.size(), 0);
 
@@ -366,7 +366,7 @@ TEST_F(core_device_container_test, resizable_jagged_vector_buffer) {
     vecmem::data::jagged_vector_buffer<int> jagged_buffer(
         std::vector<std::size_t>({0, 16, 10, 15, 8, 3, 0, 0, 55, 2}),
         m_resource, nullptr, vecmem::data::buffer_type::resizable);
-    m_copy.setup(jagged_buffer);
+    m_copy.setup(jagged_buffer)->wait();
 
     // Create a device vector on top of the buffer.
     vecmem::jagged_device_vector<int> device_vec(jagged_buffer);
@@ -426,7 +426,7 @@ TEST_F(core_device_container_test, conversions) {
     // Create a dummy vector buffer.
     vecmem::data::vector_buffer<int> buffer1d1{
         10, m_resource, vecmem::data::buffer_type::resizable};
-    m_copy.setup(buffer1d1);
+    m_copy.setup(buffer1d1)->wait();
 
     // Check that some conversions compile and work correctly.
     vecmem::data::vector_view<int> view1d1 = buffer1d1;
@@ -459,7 +459,7 @@ TEST_F(core_device_container_test, conversions) {
     vecmem::data::jagged_vector_buffer<int> buffer2d1(
         std::vector<std::size_t>({0, 16, 10, 15, 8, 3, 0, 0, 55, 2}),
         m_resource, nullptr, vecmem::data::buffer_type::resizable);
-    m_copy.setup(buffer2d1);
+    m_copy.setup(buffer2d1)->wait();
 
     // Check that some conversions compile and work correctly.
     vecmem::data::jagged_vector_view<int> view2d1 = buffer2d1;

--- a/tests/core/test_core_edm_buffer.cpp
+++ b/tests/core/test_core_edm_buffer.cpp
@@ -116,7 +116,7 @@ TEST_F(core_edm_buffer_test, get_data) {
     // Construct a resizable, simple buffer.
     vecmem::edm::buffer<simple_schema> buffer2{
         CAPACITY, m_resource, vecmem::data::buffer_type::resizable};
-    m_copy.memset(buffer2.size(), 0);
+    m_copy.memset(buffer2.size(), 0)->wait();
 
     // Make views of it.
     vecmem::edm::view<simple_schema> view4 = vecmem::get_data(buffer2);
@@ -196,7 +196,7 @@ TEST_F(core_edm_buffer_test, get_data) {
     // Construct a resizable, jagged buffer.
     vecmem::edm::buffer<jagged_schema> buffer4{
         CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
-    m_copy.memset(buffer4.size(), 0);
+    m_copy.memset(buffer4.size(), 0)->wait();
 
     // Make views of it.
     vecmem::edm::view<jagged_schema> view10 = vecmem::get_data(buffer4);
@@ -283,7 +283,7 @@ TEST_F(core_edm_buffer_test, device) {
     // Construct a resizable, simple buffer.
     vecmem::edm::buffer<simple_schema> buffer2{
         CAPACITY, m_resource, vecmem::data::buffer_type::resizable};
-    m_copy.memset(buffer2.size(), 0);
+    m_copy.memset(buffer2.size(), 0)->wait();
 
     // Make a device container on top of it.
     vecmem::edm::device<simple_schema, interface> device2{buffer2};
@@ -366,7 +366,7 @@ TEST_F(core_edm_buffer_test, device) {
     // Construct a resizable, jagged buffer.
     vecmem::edm::buffer<jagged_schema> buffer4{
         CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
-    m_copy.memset(buffer4.size(), 0);
+    m_copy.memset(buffer4.size(), 0)->wait();
 
     // Make a device container on top of it.
     vecmem::edm::device<jagged_schema, interface> device4{buffer4};

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -139,7 +139,7 @@ TEST_F(core_jagged_vector_view_test, filter) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         {10, 10, 10, 10, 10, 10}, m_mem, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Fill the jagged vector buffer with just the odd elements.
     vecmem::jagged_device_vector device_vec(output_data);
@@ -153,7 +153,7 @@ TEST_F(core_jagged_vector_view_test, filter) {
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 6);
@@ -178,14 +178,14 @@ TEST_F(core_jagged_vector_view_test, empty) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, m_mem, nullptr, vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     vecmem::jagged_device_vector device_vec(output_data);
     EXPECT_EQ(device_vec.size(), 0);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 0);
@@ -198,14 +198,14 @@ TEST_F(core_jagged_vector_view_test, empty_fixed) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, m_mem, nullptr, vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     vecmem::jagged_device_vector device_vec(output_data);
     EXPECT_EQ(device_vec.size(), 0);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 0);
@@ -219,14 +219,14 @@ TEST_F(core_jagged_vector_view_test, sizeless) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), m_mem, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     vecmem::jagged_device_vector device_vec(output_data);
     EXPECT_EQ(device_vec.size(), 3);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);
@@ -243,14 +243,14 @@ TEST_F(core_jagged_vector_view_test, sizeless_fixed) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), m_mem, nullptr,
         vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     vecmem::jagged_device_vector device_vec(output_data);
     EXPECT_EQ(device_vec.size(), 3);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);

--- a/tests/cuda/test_cuda_containers.cpp
+++ b/tests/cuda/test_cuda_containers.cpp
@@ -89,7 +89,8 @@ TEST_F(cuda_containers_test, explicit_memory) {
                               vecmem::copy::type::host_to_device),
                     m_copy.to(vecmem::get_data(inputvec), device_resource),
                     outputvecdevice);
-    m_copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host);
+    m_copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host)
+        ->wait();
 
     // Check the output.
     EXPECT_EQ(inputvec.size(), outputvec.size());
@@ -183,7 +184,7 @@ TEST_F(cuda_containers_test, atomic_device_memory) {
     atomicTransform(ITERATIONS, vec_on_device);
 
     // Copy it back to the host.
-    m_copy(vec_on_device, vec);
+    m_copy(vec_on_device, vec)->wait();
 
     // Check the output.
     for (int value : vec) {
@@ -215,7 +216,7 @@ TEST_F(cuda_containers_test, atomic_local_ref) {
     atomicLocalRef(NUMBLOCKS, BLOCKSIZE, device_buffer);
 
     // Copy data back to the host.
-    m_copy(device_buffer, host_vector);
+    m_copy(device_buffer, host_vector)->wait();
 
     // Check the output.
     for (std::size_t i = 0; i < NUMBLOCKS; ++i) {
@@ -241,14 +242,14 @@ TEST_F(cuda_containers_test, extendable_memory) {
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
         device_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(output_buffer);
+    m_copy.setup(output_buffer)->wait();
 
     // Run the filtering kernel.
     filterTransform(vecmem::get_data(input), output_buffer);
 
     // Copy the output into the host's memory.
     vecmem::vector<int> output(&host_resource);
-    m_copy(output_buffer, output);
+    m_copy(output_buffer, output)->wait();
 
     // Check its contents.
     EXPECT_EQ(output.size(), 89);
@@ -300,7 +301,7 @@ TEST_F(cuda_containers_test, large_buffer) {
     // Test a (1D) vector.
     vecmem::data::vector_buffer<unsigned long> buffer1(
         100, managed_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(buffer1);
+    m_copy.setup(buffer1)->wait();
     largeBufferTransform(buffer1);
     EXPECT_EQ(m_copy.get_size(buffer1), 21u);
 
@@ -308,7 +309,7 @@ TEST_F(cuda_containers_test, large_buffer) {
     vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
         {100, 100, 100}, managed_resource, nullptr,
         vecmem::data::buffer_type::resizable);
-    m_copy.setup(buffer2);
+    m_copy.setup(buffer2)->wait();
     largeBufferTransform(buffer2);
     EXPECT_EQ(m_copy.get_sizes(buffer2),
               std::vector<unsigned int>({5u, 21u, 10u}));

--- a/tests/hip/test_hip_containers.cpp
+++ b/tests/hip/test_hip_containers.cpp
@@ -85,7 +85,8 @@ TEST_F(hip_containers_test, device_memory) {
                               vecmem::copy::type::host_to_device),
                     m_copy.to(vecmem::get_data(inputvec), device_resource),
                     outputvecdevice);
-    m_copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host);
+    m_copy(outputvecdevice, outputvechost, vecmem::copy::type::device_to_host)
+        ->wait();
 
     // Check the output.
     EXPECT_EQ(inputvec.size(), outputvec.size());
@@ -132,7 +133,7 @@ TEST_F(hip_containers_test, atomic_device_memory) {
     atomicTransform(ITERATIONS, vec_on_device);
 
     // Copy it back to the host.
-    m_copy(vec_on_device, vec);
+    m_copy(vec_on_device, vec)->wait();
 
     // Check the output.
     for (int value : vec) {
@@ -164,7 +165,7 @@ TEST_F(hip_containers_test, atomic_local_ref) {
     atomicLocalRef(NUMBLOCKS, BLOCKSIZE, device_buffer);
 
     // Copy data back to the host.
-    m_copy(device_buffer, host_vector);
+    m_copy(device_buffer, host_vector)->wait();
 
     // Check the output.
     for (std::size_t i = 0; i < NUMBLOCKS; ++i) {
@@ -189,14 +190,14 @@ TEST_F(hip_containers_test, extendable_memory) {
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
         device_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(output_buffer);
+    m_copy.setup(output_buffer)->wait();
 
     // Run the filtering kernel.
     filterTransform(vecmem::get_data(input), output_buffer);
 
     // Copy the output into the host's memory.
     vecmem::vector<int> output(&host_resource);
-    m_copy(output_buffer, output);
+    m_copy(output_buffer, output)->wait();
 
     // Check its contents.
     EXPECT_EQ(output.size(), 89);
@@ -248,7 +249,7 @@ TEST_F(hip_containers_test, large_buffer) {
     // Test a (1D) vector.
     vecmem::data::vector_buffer<unsigned long> buffer1(
         100, managed_resource, vecmem::data::buffer_type::resizable);
-    m_copy.setup(buffer1);
+    m_copy.setup(buffer1)->wait();
     largeBufferTransform(buffer1);
     EXPECT_EQ(m_copy.get_size(buffer1), 21u);
 
@@ -256,7 +257,7 @@ TEST_F(hip_containers_test, large_buffer) {
     vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
         {100, 100, 100}, managed_resource, nullptr,
         vecmem::data::buffer_type::resizable);
-    m_copy.setup(buffer2);
+    m_copy.setup(buffer2)->wait();
     largeBufferTransform(buffer2);
     EXPECT_EQ(m_copy.get_sizes(buffer2),
               std::vector<unsigned int>({5u, 21u, 10u}));

--- a/tests/hip/test_hip_jagged_containers.cpp
+++ b/tests/hip/test_hip_jagged_containers.cpp
@@ -96,7 +96,7 @@ TEST_F(hip_jagged_containers_test, set_in_kernel) {
     vecmem::hip::device_memory_resource device_resource;
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         output_data_host, device_resource, &m_mem);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Run the linear transformation.
     linearTransform(copy.to(vecmem::get_data(m_constants), device_resource,
@@ -105,7 +105,8 @@ TEST_F(hip_jagged_containers_test, set_in_kernel) {
                             vecmem::copy::type::host_to_device),
                     output_data_device);
     copy(output_data_device, output_data_host,
-         vecmem::copy::type::device_to_host);
+         vecmem::copy::type::device_to_host)
+        ->wait();
 
     // Check the results.
     EXPECT_EQ(output[0][0], 214);
@@ -146,13 +147,13 @@ TEST_F(hip_jagged_containers_test, set_in_contiguous_kernel) {
     vecmem::hip::device_memory_resource device_resource;
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         output_data_host, device_resource, &m_mem);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Run the linear transformation.
     linearTransform(copy.to(vecmem::get_data(m_constants), device_resource),
                     copy.to(vecmem::get_data(input), device_resource, &m_mem),
                     output_data_device);
-    copy(output_data_device, output_data_host);
+    copy(output_data_device, output_data_host)->wait();
 
     // Check the results.
     EXPECT_EQ(output[0][0], 214);
@@ -184,14 +185,14 @@ TEST_F(hip_jagged_containers_test, filter) {
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         {10, 10, 10, 10, 10, 10}, device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Run the filtering.
     filterTransform(vecmem::get_data(m_vec), 5, output_data_device);
 
     // Copy the filtered output back into the host's memory.
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data_device, output);
+    copy(output_data_device, output)->wait();
 
     // Check the output. Note that the order of elements in the "inner vectors"
     // is not fixed. And for the single-element and empty vectors I just decided
@@ -224,14 +225,14 @@ TEST_F(hip_jagged_containers_test, zero_capacity) {
     vecmem::data::jagged_vector_buffer<int> managed_data(
         {0, 1, 200, 1, 100, 2}, m_mem, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(managed_data);
+    copy.setup(managed_data)->wait();
 
     // Run the vector filling.
     fillTransform(managed_data);
 
     // Get the data into a host vector.
     vecmem::jagged_vector<int> host_vector(&m_mem);
-    copy(managed_data, host_vector);
+    copy(managed_data, host_vector)->wait();
 
     // Check the contents of the vector.
     EXPECT_EQ(host_vector.size(), 6);
@@ -246,13 +247,13 @@ TEST_F(hip_jagged_containers_test, zero_capacity) {
     vecmem::data::jagged_vector_buffer<int> device_data(
         {0, 1, 200, 1, 100, 2}, device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(device_data);
+    copy.setup(device_data)->wait();
 
     // Run the vector filling.
     fillTransform(device_data);
 
     // Get the data into the host vector.
-    copy(device_data, host_vector);
+    copy(device_data, host_vector)->wait();
 
     // Check the contents of the vector.
     EXPECT_EQ(host_vector.size(), 6);
@@ -274,7 +275,7 @@ TEST_F(hip_jagged_containers_test, empty) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, device_resource, &m_mem, vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
@@ -294,11 +295,11 @@ TEST_F(hip_jagged_containers_test, empty_fixed) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, device_resource, &m_mem, vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 0);
@@ -315,14 +316,14 @@ TEST_F(hip_jagged_containers_test, sizeless) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     fillTransform(output_data);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);
@@ -342,14 +343,14 @@ TEST_F(hip_jagged_containers_test, sizeless_fixed) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), device_resource, &m_mem,
         vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     fillTransform(output_data);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);
@@ -369,14 +370,14 @@ TEST_F(hip_jagged_containers_test, partially_sizeless) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         {10, 0, 10, 0, 10, 0}, device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     fillTransform(output_data);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 6);
@@ -399,15 +400,15 @@ TEST_F(hip_jagged_containers_test, partially_sizeless_fixed) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         {10, 0, 10, 0, 10, 0}, device_resource, &m_mem,
         vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
-    copy.memset(output_data, 0);
+    copy.setup(output_data)->wait();
+    copy.memset(output_data, 0)->wait();
 
     // Run the vector filling.
     fillTransform(output_data);
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 6);

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -407,7 +407,7 @@ TEST_F(sycl_containers_test, extendable_memory) {
     vecmem::data::vector_buffer<int> output_buffer(
         static_cast<vecmem::data::vector_buffer<int>::size_type>(input.size()),
         device_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(output_buffer);
+    copy.setup(output_buffer)->wait();
 
     // Run a kernel that filters the elements of the input vector.
     queue
@@ -440,7 +440,7 @@ TEST_F(sycl_containers_test, extendable_memory) {
 
     // Copy the output into the host's memory.
     vecmem::vector<int> output(&host_resource);
-    copy(output_buffer, output);
+    copy(output_buffer, output)->wait();
 
     // Check its contents.
     EXPECT_EQ(output.size(), static_cast<vecmem::vector<int>::size_type>(89));
@@ -526,7 +526,7 @@ TEST_F(sycl_containers_test, large_buffer) {
     // Test a (1D) vector.
     vecmem::data::vector_buffer<unsigned long> buffer1(
         100, shared_resource, vecmem::data::buffer_type::resizable);
-    copy.setup(buffer1);
+    copy.setup(buffer1)->wait();
 
     // Run a kernel that enlarges the (1D) buffer.
     queue
@@ -558,7 +558,7 @@ TEST_F(sycl_containers_test, large_buffer) {
     vecmem::data::jagged_vector_buffer<unsigned long> buffer2(
         {100, 100, 100}, shared_resource, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(buffer2);
+    copy.setup(buffer2)->wait();
 
     // Run a kernel that enlarges the (jagged) buffer.
     queue

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -250,7 +250,7 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
     vecmem::sycl::device_memory_resource device_resource(&m_queue);
     vecmem::data::jagged_vector_buffer<int> output_data_device(
         output_data_host, device_resource, &host_resource);
-    copy.setup(output_data_device);
+    copy.setup(output_data_device)->wait();
 
     // Run the linear transformation.
     m_queue
@@ -277,7 +277,8 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
 
     // Copy the data back to the host.
     copy(output_data_device, output_data_host,
-         vecmem::copy::type::device_to_host);
+         vecmem::copy::type::device_to_host)
+        ->wait();
 
     // Check the results.
     EXPECT_EQ(output[0][0], 214);
@@ -460,7 +461,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
     vecmem::data::jagged_vector_buffer<int> managed_data(
         {0, 1, 200, 1, 100, 2}, m_mem, nullptr,
         vecmem::data::buffer_type::resizable);
-    copy.setup(managed_data);
+    copy.setup(managed_data)->wait();
 
     // Run the vector filling.
     m_queue
@@ -475,7 +476,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
 
     // Get the data into a host vector.
     vecmem::jagged_vector<int> host_vector(&m_mem);
-    copy(managed_data, host_vector);
+    copy(managed_data, host_vector)->wait();
 
     // Check the contents of the vector.
     EXPECT_EQ(host_vector.size(), 6u);
@@ -490,7 +491,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
     vecmem::data::jagged_vector_buffer<int> device_data(
         {0, 1, 200, 1, 100, 2}, device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(device_data);
+    copy.setup(device_data)->wait();
 
     // Run the vector filling.
     m_queue
@@ -504,7 +505,7 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
         .wait_and_throw();
 
     // Get the data into the host vector.
-    copy(device_data, host_vector);
+    copy(device_data, host_vector)->wait();
 
     // Check the contents of the vector.
     EXPECT_EQ(host_vector.size(), 6u);
@@ -526,7 +527,7 @@ TEST_F(sycl_jagged_containers_test, empty) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, device_resource, &m_mem, vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
@@ -546,11 +547,11 @@ TEST_F(sycl_jagged_containers_test, empty_fixed) {
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
         {}, device_resource, &m_mem, vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 0);
@@ -567,7 +568,7 @@ TEST_F(sycl_jagged_containers_test, sizeless) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     m_queue
@@ -582,7 +583,7 @@ TEST_F(sycl_jagged_containers_test, sizeless) {
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);
@@ -602,7 +603,7 @@ TEST_F(sycl_jagged_containers_test, sizeless_fixed) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         std::vector<std::size_t>(3, 0), device_resource, &m_mem,
         vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     m_queue
@@ -617,7 +618,7 @@ TEST_F(sycl_jagged_containers_test, sizeless_fixed) {
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 3);
@@ -637,7 +638,7 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         {10, 0, 10, 0, 10, 0}, device_resource, &m_mem,
         vecmem::data::buffer_type::resizable);
-    copy.setup(output_data);
+    copy.setup(output_data)->wait();
 
     // Run the vector filling.
     m_queue
@@ -652,7 +653,7 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless) {
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 6);
@@ -675,8 +676,8 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless_fixed) {
     vecmem::data::jagged_vector_buffer<int> output_data(
         {10, 0, 10, 0, 10, 0}, device_resource, &m_mem,
         vecmem::data::buffer_type::fixed_size);
-    copy.setup(output_data);
-    copy.memset(output_data, 0);
+    copy.setup(output_data)->wait();
+    copy.memset(output_data, 0)->wait();
 
     // Run the vector filling.
     m_queue
@@ -691,7 +692,7 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless_fixed) {
 
     // Copy the filtered output back into a "host object".
     vecmem::jagged_vector<int> output(&m_mem);
-    copy(output_data, output);
+    copy(output_data, output)->wait();
 
     // Check the output.
     EXPECT_EQ(output.size(), 6);


### PR DESCRIPTION
Currently, there is no compile-time mechanism to ensure that copy objects are properly handled, i.e. either waited for or ignored. This commit adds the `nodiscard` attribute to methods of the copy objects which return events to ensure that the compiler will issue a warning if the object is ignored.