### PR TITLE
Fix checkout support in CI for Ubuntu 18.04

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -157,6 +157,11 @@ jobs:
 
     name: "container (${{ matrix.BUILD.TYPE }}, ${{ matrix.PLATFORM.NAME }}, C++${{ matrix.PLATFORM.CXX_STANDARD }}, ${{ matrix.PLATFORM.CONTAINER_NAME }}${{ matrix.PLATFORM.NOTES != '' && ', ' || '' }}${{ matrix.PLATFORM.NOTES }})"
 
+    # Hack to continue using checkout (for now) on Ubuntu 18.04.
+    # see: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     # The system to run on.
     runs-on: ubuntu-latest
     container: ${{ matrix.PLATFORM.CONTAINER }}


### PR DESCRIPTION
The combination of us using the past-EoL Ubuntu 18.04 and Microsoft being a bit gung-ho in their changes to GitHub Actions means that Node16, and by extension checkouts@v3 is no longer supported. Since Ubuntu 18.04 doesn't support the newer Node20, we are stuck. Thankfully, we can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` environment variable which is project to keep the CI running until they remove support for Node16 fully.

See #286 for the related CI failure, and https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for the GitHub blog post about this.