### PR TITLE
External Updates, main branch (2024.08.09.)

### DIFF
--- a/benchmarks/googlebenchmark/CMakeLists.txt
+++ b/benchmarks/googlebenchmark/CMakeLists.txt
@@ -8,18 +8,23 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
-# Silence FetchContent warnings with CMake >=3.24.
+# Silence various FetchContent warnings up to CMake 3.30.X.
 if( POLICY CMP0135 )
    cmake_policy( SET CMP0135 NEW )
+endif()
+if( POLICY CMP0169 )
+   cmake_policy( SET CMP0169 OLD )
 endif()
 
 # Tell the user what's happening.
 message( STATUS "Building Google Benchmark as part of the VecMem project" )
 
 # Declare where to get googlebenchmark from.
-FetchContent_Declare( googlebenchmark
-   URL "https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz"
-   URL_MD5 "8c33c51f9b7154e6c290df3750081c87" )
+set( VECMEM_BENCHMARK_SOURCE
+   "URL;https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz;URL_MD5;8c33c51f9b7154e6c290df3750081c87"
+   CACHE STRING "Source for GoogleBenchmark, when built as part of VecMem" )
+mark_as_advanced( VECMEM_BENCHMARK_SOURCE )
+FetchContent_Declare( googlebenchmark ${VECMEM_BENCHMARK_SOURCE} )
 
 # Option(s) used in the build of Google Benchmark.
 set( BENCHMARK_ENABLE_TESTING OFF CACHE BOOL

--- a/tests/googletest/CMakeLists.txt
+++ b/tests/googletest/CMakeLists.txt
@@ -8,18 +8,23 @@
 cmake_minimum_required( VERSION 3.11 )
 include( FetchContent )
 
-# Silence FetchContent warnings with CMake >=3.24.
+# Silence various FetchContent warnings up to CMake 3.30.X.
 if( POLICY CMP0135 )
    cmake_policy( SET CMP0135 NEW )
+endif()
+if( POLICY CMP0169 )
+   cmake_policy( SET CMP0169 OLD )
 endif()
 
 # Tell the user what's happening.
 message( STATUS "Building GoogleTest as part of the VecMem project" )
 
 # Declare where to get GoogleTest from.
-FetchContent_Declare( GoogleTest
-   URL "https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz"
-   URL_MD5 "c8340a482851ef6a3fe618a082304cfc" )
+set( VECMEM_GOOGLETEST_SOURCE
+   "URL;https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz;URL_MD5;7e11f6cfcf6498324ac82d567dcb891e"
+   CACHE STRING "Source for GoogleTest, when built as part of VecMem" )
+mark_as_advanced( VECMEM_GOOGLETEST_SOURCE )
+FetchContent_Declare( GoogleTest ${VECMEM_GOOGLETEST_SOURCE} )
 
 # Options used in the build of GoogleTest.
 set( BUILD_GMOCK FALSE CACHE BOOL "Turn off the build of GMock" )


### PR DESCRIPTION
This all was primarily meant to fix some warnings that showed up while building GoogleTest with oneAPI 2024.2. Unfortunately it's exactly that issue that it doesn't fix...

I did the following:
  - Added a setting for [CMP0169](https://cmake.org/cmake/help/latest/policy/CMP0169.html) to teach CMake 3.30.X to configure the code without warnings.
    * I decided not to use the `NEW` behaviour of this policy at this time. The thing that we do in the code, that we include GoogleTest and GoogleBenchmark with `EXCLUDE_FROM_ALL`, is only possible to do using `FetchContent_MakeAvailable(...)` starting with CMake 3.28. (https://cmake.org/cmake/help/latest/module/FetchContent.html#command:fetchcontent_makeavailable) And I don't want to require that as the minimum CMake version (yet).
  - Introduced `VECMEM_GOOGLETEST_SOURCE` and `VECMEM_BENCHMARK_SOURCE` to allow client code to override the version of these externals used by the project.
    * In sync with how we do this in all of the other R&D projects as well.
  - Updated the version of GoogleTest to the current latest one.

Unfortunately that last step didn't have the desired effect. :frowning: I still see:

```
[  0%] Building CXX object _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
cd /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-build/googletest && /home/krasznaa/software/intel/oneapi-2024.2.1/compiler/2024.2/bin/compiler/clang++ -DGTEST_CREATE_SHARED_LIBRARY=1 -Dgtest_EXPORTS -I/home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/include -I/home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest -O2 -g -DNDEBUG -std=c++17 -fPIC -Wall -Wshadow -Wconversion -Wundef -Wno-implicit-float-size-conversion -ffp-model=precise -DGTEST_HAS_PTHREAD=1 -fexceptions -W -Wpointer-arith -Wreturn-type -Wcast-qual -Wwrite-strings -Wswitch -Wunused-parameter -Wcast-align -Winline -Wredundant-decls -MD -MT _deps/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o -MF CMakeFiles/gtest.dir/src/gtest-all.cc.o.d -o CMakeFiles/gtest.dir/src/gtest-all.cc.o -c /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest-all.cc
In file included from /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest-all.cc:38:
In file included from /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/include/gtest/gtest.h:55:
In file included from /usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/memory:66:
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tempbuf.h:263:8: warning: 'get_temporary_buffer<testing::TestInfo *>' is deprecated [-Wdeprecated-declarations]
  263 |                 std::get_temporary_buffer<value_type>(_M_original_len));
      |                      ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:4996:15: note: in instantiation of member function 'std::_Temporary_buffer<__gnu_cxx::__normal_iterator<testing::TestInfo **, std::vector<testing::TestInfo *>>, testing::TestInfo *>::_Temporary_buffer' requested here
 4996 |       _TmpBuf __buf(__first, (__last - __first + 1) / 2);
      |               ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:5070:23: note: in instantiation of function template specialization 'std::__stable_sort<__gnu_cxx::__normal_iterator<testing::TestInfo **, std::vector<testing::TestInfo *>>, __gnu_cxx::__ops::_Iter_comp_iter<(lambda at /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest.cc:3009:20)>>' requested here
 5070 |       _GLIBCXX_STD_A::__stable_sort(__first, __last,
      |                       ^
/home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest.cc:3008:8: note: in instantiation of function template specialization 'std::stable_sort<__gnu_cxx::__normal_iterator<testing::TestInfo **, std::vector<testing::TestInfo *>>, (lambda at /home/krasznaa/ATLAS/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest.cc:3009:20)>' requested here
 3008 |   std::stable_sort(test_info_list_.begin(), test_info_list_.end(),
      |        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_tempbuf.h:99:5: note: 'get_temporary_buffer<testing::TestInfo *>' has been explicitly marked deprecated here
   99 |     _GLIBCXX17_DEPRECATED
      |     ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/x86_64-linux-gnu/c++/12/bits/c++config.h:119:34: note: expanded from macro '_GLIBCXX17_DEPRECATED'
  119 | # define _GLIBCXX17_DEPRECATED [[__deprecated__]]
      |                                  ^
1 warning generated.
[100%] Linking CXX shared library ../../../lib/libgtest.so
```

This comes from a pretty innocent-looking piece of code in GoogleTest. (https://github.com/google/googletest/blob/v1.15.2/googletest/src/gtest.cc#L3008-L3015) So by now I'm back to suspecting soemthing going wrong in oneAPI... :thinking: