### PR TITLE
SoA GCC 11 Fix, main branch (2024.08.13.)

### DIFF
--- a/core/include/vecmem/edm/details/buffer_traits.hpp
+++ b/core/include/vecmem/edm/details/buffer_traits.hpp
@@ -162,7 +162,7 @@ VECMEM_HOST auto make_buffer_views(
     // then only the jagged vectors are resizable, the "normal vectors" are not.
     // But the received "sizes" variable would be hard to set up like that
     // outside of this function, so the logic has to sit here.
-    return make_tuple(buffer_alloc<TYPES>::make_view(
+    return vecmem::make_tuple(buffer_alloc<TYPES>::make_view(
         capacities,
         ((has_jagged_vector && (!std::get<INDICES>(is_jagged_vector)))
              ? nullptr


### PR DESCRIPTION
While working on https://github.com/acts-project/traccc/pull/627, I ran into the following failure with GCC 11:

```
...
[100%] Building CXX object examples/run/cuda/CMakeFiles/traccc_examples_cuda.dir/full_chain_algorithm.cpp.o
In file included from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/impl/buffer.ipp:11,
                 from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/buffer.hpp:271,
                 from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/container.hpp:15,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/core/include/traccc/geometry/detector_description.hpp:18,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp:18,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.hpp:12,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.cpp:9:
/home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/details/buffer_traits.hpp: In instantiation of ‘auto vecmem::edm::details::make_buffer_views(const std::vector<SIZE_TYPE>&, const std::tuple<typename vecmem::edm::details::view_type<TYPES>::size_ptr ...>&, const std::tuple<typename vecmem::edm::details::view_type<TYPES>::layout_ptr ...>&, const std::tuple<typename vecmem::edm::details::view_type<TYPES>::layout_ptr ...>&, const std::tuple<typename vecmem::edm::details::view_type<TYPES>::payload_ptr ...>&, std::index_sequence<_Idx ...>) [with SIZE_TYPE = long unsigned int; TYPES = {vecmem::edm::type::vector<detray::geometry::barcode>, vecmem::edm::type::vector<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > >, vecmem::edm::type::vector<long unsigned int>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<char>, vecmem::edm::type::vector<float>}; long unsigned int ...INDICES = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; std::index_sequence<_Idx ...> = std::integer_sequence<long unsigned int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>]’:
/home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/impl/buffer.ipp:240:76:   required from ‘void vecmem::edm::buffer<vecmem::edm::schema<VARTYPES ...> >::setup_resizable(const std::vector<SIZE_TYPE>&, vecmem::memory_resource&, vecmem::memory_resource*, std::index_sequence<_Ind ...>) [with SIZE_TYPE = long unsigned int; long unsigned int ...INDICES = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}; VARTYPES = {vecmem::edm::type::vector<detray::geometry::barcode>, vecmem::edm::type::vector<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > >, vecmem::edm::type::vector<long unsigned int>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<char>, vecmem::edm::type::vector<float>}; vecmem::memory_resource = std::pmr::memory_resource; std::index_sequence<_Ind ...> = std::integer_sequence<long unsigned int, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9>]’
/home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/impl/buffer.ipp:43:28:   required from ‘vecmem::edm::buffer<vecmem::edm::schema<VARTYPES ...> >::buffer(vecmem::edm::buffer<vecmem::edm::schema<VARTYPES ...> >::size_type, vecmem::memory_resource&, vecmem::data::buffer_type) [with VARTYPES = {vecmem::edm::type::vector<detray::geometry::barcode>, vecmem::edm::type::vector<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > >, vecmem::edm::type::vector<long unsigned int>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<float>, vecmem::edm::type::vector<char>, vecmem::edm::type::vector<float>}; vecmem::edm::buffer<vecmem::edm::schema<VARTYPES ...> >::size_type = unsigned int; vecmem::memory_resource = std::pmr::memory_resource]’
/home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.cpp:49:7:   required from here
/home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/details/buffer_traits.hpp:165:22: error: call of overloaded ‘make_tuple(vecmem::edm::details::view_type<vecmem::edm::type::vector<detray::geometry::barcode> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > > >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<long unsigned int> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<char> >::type, vecmem::edm::details::view_type<vecmem::edm::type::vector<float> >::type)’ is ambiguous
  165 |     return make_tuple(buffer_alloc<TYPES>::make_view(
      |            ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  166 |         capacities,
      |         ~~~~~~~~~~~   
  167 |         ((has_jagged_vector && (!std::get<INDICES>(is_jagged_vector)))
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  168 |              ? nullptr
      |              ~~~~~~~~~
  169 |              : std::get<INDICES>(sizes)),
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  170 |         std::get<INDICES>(layouts), std::get<INDICES>(host_layouts),
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  171 |         std::get<INDICES>(payloads))...);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/utils/tuple.hpp:160,
                 from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/details/device_traits.hpp:14,
                 from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/device.hpp:10,
                 from /home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/edm/container.hpp:10,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/core/include/traccc/geometry/detector_description.hpp:18,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp:18,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.hpp:12,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.cpp:9:
/home/krasznaa/ATLAS/projects/vecmem/vecmem/core/include/vecmem/utils/impl/tuple.ipp:88:1: note: candidate: ‘constexpr vecmem::tuple<typename std::decay<_Elements>::type ...> vecmem::make_tuple(Ts&& ...) [with Ts = {vecmem::data::vector_view<detray::geometry::barcode>, vecmem::data::vector_view<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > >, vecmem::data::vector_view<long unsigned int>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<char>, vecmem::data::vector_view<float>}]’
   88 | make_tuple(Ts &&... args) {
      | ^~~~~~~~~~
In file included from /usr/include/c++/11/bits/unique_ptr.h:37,
                 from /usr/include/c++/11/memory:76,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/device/cuda/include/traccc/cuda/utils/stream.hpp:11,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/device/cuda/include/traccc/cuda/clusterization/clusterization_algorithm.hpp:11,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.hpp:12,
                 from /home/krasznaa/ATLAS/projects/traccc/traccc/examples/run/cuda/full_chain_algorithm.cpp:9:
/usr/include/c++/11/tuple:1605:5: note: candidate: ‘constexpr std::tuple<typename std::__strip_reference_wrapper<typename std::decay<_Elements>::type>::__type ...> std::make_tuple(_Elements&& ...) [with _Elements = {vecmem::data::vector_view<detray::geometry::barcode>, vecmem::data::vector_view<algebra::cmath::transform3<algebra::cmath::matrix::actor<long unsigned int, std::array, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::determinant::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::determinant::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::matrix::inverse::actor<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::matrix::inverse::partial_pivot_lud<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float> >, algebra::cmath::matrix::inverse::hard_coded<long unsigned int, algebra::array::matrix_type, float, algebra::cmath::element_getter<long unsigned int, std::array, float>, 2, 4> >, algebra::cmath::element_getter<long unsigned int, std::array, float>, algebra::cmath::block_getter<long unsigned int, std::array, float> > > >, vecmem::data::vector_view<long unsigned int>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<float>, vecmem::data::vector_view<char>, vecmem::data::vector_view<float>}]’
 1605 |     make_tuple(_Elements&&... __args)
      |     ^~~~~~~~~~
gmake[3]: *** [examples/run/cuda/CMakeFiles/traccc_examples_cuda.dir/build.make:76: examples/run/cuda/CMakeFiles/traccc_examples_cuda.dir/full_chain_algorithm.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:4601: examples/run/cuda/CMakeFiles/traccc_examples_cuda.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:4608: examples/run/cuda/CMakeFiles/traccc_examples_cuda.dir/rule] Error 2
gmake: *** [Makefile:1252: traccc_examples_cuda] Error 2
```

Though interestingly enough Clang did not have any issues with that code. :thinking:

While I consider this a bug in GCC, it's luckily easy enough to work around it. :wink: