### PR TITLE
get_size(...) for SoA Containers, main branch (2024.09.20.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -178,6 +178,11 @@ public:
             from,
         edm::host<edm::schema<VARTYPES...>>& to,
         type::copy_type cptype = type::unknown) const;
+
+    /// Get the (outer) size of a resizable SoA container
+    template <typename... VARTYPES>
+    typename edm::view<edm::schema<VARTYPES...>>::size_type get_size(
+        const edm::view<edm::schema<VARTYPES...>>& data) const;
 
     /// @}
 

--- a/tests/common/soa_copy_tests.ipp
+++ b/tests/common/soa_copy_tests.ipp
@@ -52,6 +52,9 @@ void soa_copy_tests_base<CONTAINER>::host_to_fixed_device_to_host_direct() {
                 vecmem::copy::type::host_to_device)
         ->wait();
 
+    // Check the size of the device buffer.
+    EXPECT_EQ(input.size(), main_copy().get_size(device_buffer));
+
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};
 
@@ -134,6 +137,9 @@ void soa_copy_tests_base<CONTAINER>::host_to_resizable_device_to_host() {
                 vecmem::copy::type::host_to_device)
         ->wait();
 
+    // Check the size of the device buffer.
+    EXPECT_EQ(input.size(), main_copy().get_size(device_buffer));
+
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};
 
@@ -166,6 +172,9 @@ void soa_copy_tests_base<
                 vecmem::copy::type::host_to_device)
         ->wait();
 
+    // Check the size of the device buffer.
+    EXPECT_EQ(input.size(), main_copy().get_size(device_buffer1));
+
     // Create the (resizable) device buffer.
     typename CONTAINER::buffer device_buffer2;
     vecmem::testing::make_buffer(device_buffer2, main_mr(), host_mr(),
@@ -175,6 +184,9 @@ void soa_copy_tests_base<
     main_copy()(device_buffer1, device_buffer2,
                 vecmem::copy::type::device_to_device)
         ->wait();
+
+    // Check the size of the device buffer.
+    EXPECT_EQ(input.size(), main_copy().get_size(device_buffer2));
 
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};


### PR DESCRIPTION
Introduced `vecmem::copy::get_size` for SoA containers. This will be necessary in order to use such containers in the [traccc](https://github.com/acts-project/traccc) algorithms for the EDM.

@stephenswat will have already heard about the issues I've been having with MSVC trying to be too smart with this code...