### PR TITLE
SoA Proxy, main branch (2024.09.25.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ if( VECMEM_BUILD_DOCS )
       "${CMAKE_CURRENT_SOURCE_DIR}/cuda/include"
       "${CMAKE_CURRENT_SOURCE_DIR}/hip/include"
       "${CMAKE_CURRENT_SOURCE_DIR}/sycl/include" )
+   set( DOXYGEN_PREDEFINED
+      "__cplusplus=201700L" )
    set( DOXYGEN_EXCLUDE
       "${CMAKE_CURRENT_SOURCE_DIR}/tests"
       "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks"

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -21,7 +21,7 @@ namespace vecmem {
 
 // Forward declaration(s).
 namespace edm {
-template <typename T>
+template <typename T, template <typename> class I>
 class device;
 }
 
@@ -36,7 +36,7 @@ template <typename TYPE>
 class device_vector {
 
     // Make @c vecmem::edm::device a friend of this class.
-    template <typename T>
+    template <typename T, template <typename> class I>
     friend class edm::device;
 
 public:

--- a/core/include/vecmem/edm/container.hpp
+++ b/core/include/vecmem/edm/container.hpp
@@ -52,9 +52,11 @@ struct container {
 #endif  // __cplusplus >= 201700L
 
     /// (Non-const) Device container type
-    using device = interface_type<vecmem::edm::device<schema_type>>;
+    using device =
+        interface_type<vecmem::edm::device<schema_type, interface_type>>;
     /// (Const) Device container type
-    using const_device = interface_type<vecmem::edm::device<const_schema_type>>;
+    using const_device =
+        interface_type<vecmem::edm::device<const_schema_type, interface_type>>;
 
     /// (Non-const) View type
     using view = vecmem::edm::view<schema_type>;

--- a/core/include/vecmem/edm/container.hpp
+++ b/core/include/vecmem/edm/container.hpp
@@ -40,7 +40,7 @@ struct container {
 
 #if __cplusplus >= 201700L
     /// Host container type
-    using host = interface_type<vecmem::edm::host<schema_type> >;
+    using host = interface_type<vecmem::edm::host<schema_type, interface_type>>;
 
     /// (Non-const) Data type
     using data = vecmem::edm::data<schema_type>;
@@ -52,10 +52,9 @@ struct container {
 #endif  // __cplusplus >= 201700L
 
     /// (Non-const) Device container type
-    using device = interface_type<vecmem::edm::device<schema_type> >;
+    using device = interface_type<vecmem::edm::device<schema_type>>;
     /// (Const) Device container type
-    using const_device =
-        interface_type<vecmem::edm::device<const_schema_type> >;
+    using const_device = interface_type<vecmem::edm::device<const_schema_type>>;
 
     /// (Non-const) View type
     using view = vecmem::edm::view<schema_type>;

--- a/core/include/vecmem/edm/container.hpp
+++ b/core/include/vecmem/edm/container.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/edm/details/proxy_traits.hpp
+++ b/core/include/vecmem/edm/details/proxy_traits.hpp
@@ -1,0 +1,551 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/containers/device_vector.hpp"
+#include "vecmem/containers/vector.hpp"
+#include "vecmem/edm/details/device_traits.hpp"
+#include "vecmem/edm/details/host_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/utils/tuple.hpp"
+
+// System include(s).
+#include <tuple>
+#include <type_traits>
+
+namespace vecmem {
+namespace edm {
+namespace details {
+
+/// @brief The type of the proxy to use for a given container variable
+enum class proxy_type {
+    /// Proxy for a host container element
+    host,
+    /// Proxy for a device container element
+    device
+};
+
+/// @brief The "access type" of the proxy to use for a given container variable
+enum class proxy_access {
+    /// Proxy for a non-const container element
+    non_constant,
+    /// Proxy for a const container element
+    constant
+};
+
+/// @name Traits for the proxied variable types
+/// @{
+
+/// Technical base class for the @c proxy_var_type traits
+template <typename VTYPE, proxy_type PTYPE, proxy_access CTYPE>
+struct proxy_var_type;
+
+/// Constant access to a scalar variable (both host and device)
+template <typename VTYPE, proxy_type PTYPE>
+struct proxy_var_type<type::scalar<VTYPE>, PTYPE, proxy_access::constant> {
+
+    /// The scalar is kept by value in the proxy
+    using type = VTYPE;
+    /// It is returned as a const reference even on non-const access
+    using return_type = std::add_lvalue_reference_t<std::add_const_t<type>>;
+    /// It is returned as a const reference on const access
+    using const_return_type = return_type;
+
+    /// Helper function constructing a scalar proxy variable
+    template <typename ITYPE>
+    static return_type make(ITYPE, return_type variable) {
+        return variable;
+    }
+};
+
+/// Non-const access to a scalar variable (both host and device)
+template <typename VTYPE, proxy_type PTYPE>
+struct proxy_var_type<type::scalar<VTYPE>, PTYPE, proxy_access::non_constant> {
+
+    /// The scalar is kept by lvalue reference in the proxy
+    using type = std::add_lvalue_reference_t<VTYPE>;
+    /// It is returned as a non-const lvalue reference on non-const access
+    using return_type = type;
+    /// It is returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<VTYPE>>;
+
+    /// Helper function constructing a scalar proxy variable
+    template <typename ITYPE>
+    static return_type make(ITYPE, return_type variable) {
+        return variable;
+    }
+};
+
+/// Constant access to a vector variable from a host container
+template <typename VTYPE>
+struct proxy_var_type<type::vector<VTYPE>, proxy_type::host,
+                      proxy_access::constant> {
+
+    /// Vector elements are kept by value in the proxy
+    using type = VTYPE;
+    /// They are returned as a const reference even on non-const access
+    using return_type = std::add_lvalue_reference_t<std::add_const_t<type>>;
+    /// They are returned as a const reference on const access
+    using const_return_type = return_type;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(typename vector<VTYPE>::size_type i,
+                            const vector<VTYPE>& vec) {
+        return vec.at(i);
+    }
+};
+
+/// Non-const access to a vector variable from a host container
+template <typename VTYPE>
+struct proxy_var_type<type::vector<VTYPE>, proxy_type::host,
+                      proxy_access::non_constant> {
+
+    /// Vector elements are kept by lvalue reference in the proxy
+    using type = std::add_lvalue_reference_t<VTYPE>;
+    /// They are returned as a non-const lvalue reference on non-const access
+    using return_type = type;
+    /// They are returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<VTYPE>>;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(typename vector<VTYPE>::size_type i,
+                            vector<VTYPE>& vec) {
+        return vec.at(i);
+    }
+};
+
+/// Constant access to a vector variable from a device container
+template <typename VTYPE>
+struct proxy_var_type<type::vector<VTYPE>, proxy_type::device,
+                      proxy_access::constant> {
+
+    /// Vector elements are kept by value in the proxy
+    using type = typename proxy_var_type<VTYPE, proxy_type::host,
+                                         proxy_access::constant>::type;
+    /// They are returned as a const reference even on non-const access
+    using return_type =
+        typename proxy_var_type<VTYPE, proxy_type::host,
+                                proxy_access::constant>::return_type;
+    /// They are returned as a const reference on const access
+    using const_return_type =
+        typename proxy_var_type<VTYPE, proxy_type::host,
+                                proxy_access::constant>::const_return_type;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(
+        typename device_vector<std::add_const_t<VTYPE>>::size_type i,
+        const device_vector<std::add_const_t<VTYPE>>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Non-const access to a vector variable from a device container
+template <typename VTYPE>
+struct proxy_var_type<type::vector<VTYPE>, proxy_type::device,
+                      proxy_access::non_constant> {
+
+    /// Vector elements are kept by lvalue reference in the proxy
+    using type = typename proxy_var_type<VTYPE, proxy_type::host,
+                                         proxy_access::non_constant>::type;
+    /// They are returned as a non-const lvalue reference on non-const access
+    using return_type =
+        typename proxy_var_type<VTYPE, proxy_type::host,
+                                proxy_access::non_constant>::return_type;
+    /// They are returned as a const reference on const access
+    using const_return_type =
+        typename proxy_var_type<VTYPE, proxy_type::host,
+                                proxy_access::non_constant>::const_return_type;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(typename device_vector<VTYPE>::size_type i,
+                            device_vector<VTYPE>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Constant access to a jagged vector variable from a host container
+template <typename VTYPE>
+struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_type::host,
+                      proxy_access::constant> {
+
+    /// Jagged vector elements are kept by constant reference in the proxy
+    using type = std::add_lvalue_reference_t<std::add_const_t<vector<VTYPE>>>;
+    /// They are returned as a const reference even on non-const access
+    using return_type = type;
+    /// They are returned as a const reference on const access
+    using const_return_type = type;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(typename jagged_vector<VTYPE>::size_type i,
+                            const jagged_vector<VTYPE>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Non-const access to a jagged vector variable from a host container
+template <typename VTYPE>
+struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_type::host,
+                      proxy_access::non_constant> {
+
+    /// Jagged vector elements are kept by non-const lvalue reference in the
+    /// proxy
+    using type = std::add_lvalue_reference_t<vector<VTYPE>>;
+    /// They are returned as a non-const lvalue reference on non-const access
+    using return_type = type;
+    /// They are returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<vector<VTYPE>>>;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(typename jagged_vector<VTYPE>::size_type i,
+                            jagged_vector<VTYPE>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Constant access to a jagged vector variable from a device container
+template <typename VTYPE>
+struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_type::device,
+                      proxy_access::constant> {
+
+    /// Jagged vector elements are kept by constant device vectors in the proxy
+    using type = device_vector<std::add_const_t<VTYPE>>;
+    /// They are returned as a const reference to the device vector even in
+    /// non-const access
+    using return_type = std::add_lvalue_reference_t<std::add_const_t<type>>;
+    /// They are returned as a const reference to the device vector on const
+    /// access
+    using const_return_type = return_type;
+
+    /// Helper function constructing a vector proxy variable
+    static return_type make(
+        typename jagged_device_vector<std::add_const_t<VTYPE>>::size_type i,
+        const jagged_device_vector<std::add_const_t<VTYPE>>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Non-const access to a jagged vector variable from a device container
+template <typename VTYPE>
+struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_type::device,
+                      proxy_access::non_constant> {
+
+    /// Jagged vector elements are kept by non-const device vectors in the proxy
+    using type = device_vector<VTYPE>;
+    /// They are returned as non-const lvalue references to the non-const device
+    /// vector in non-const access
+    using return_type = std::add_lvalue_reference_t<type>;
+    /// They are returned as const references to the non-const device vector in
+    /// const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+
+    /// Helper function constructing a vector proxy variable
+    static type make(typename jagged_device_vector<VTYPE>::size_type i,
+                     jagged_device_vector<VTYPE>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Proxy types for one element of a type pack
+template <std::size_t INDEX, proxy_type PTYPE, proxy_access CTYPE,
+          typename... VARTYPES>
+struct proxy_var_type_at {
+    /// Type of the variable held by the proxy
+    using type =
+        typename proxy_var_type<tuple_element_t<INDEX, tuple<VARTYPES...>>,
+                                PTYPE, CTYPE>::type;
+    /// Return type on non-const access to the proxy
+    using return_type =
+        typename proxy_var_type<tuple_element_t<INDEX, tuple<VARTYPES...>>,
+                                PTYPE, CTYPE>::return_type;
+    /// Return type on const access to the proxy
+    using const_return_type =
+        typename proxy_var_type<tuple_element_t<INDEX, tuple<VARTYPES...>>,
+                                PTYPE, CTYPE>::const_return_type;
+};
+
+/// @}
+
+/// @name Traits for creating the proxy variables
+/// @{
+
+/// Technical base class for the @c proxy_data_creator traits
+template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+struct proxy_data_creator;
+
+template <typename VARTYPE>
+struct proxy_data_creator<schema<VARTYPE>, proxy_type::host,
+                          proxy_access::constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::host,
+                                      proxy_access::constant>::type>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(std::size_t i, const CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(std::size_t i, const CONTAINER& c) {
+
+        return {
+            proxy_var_type<VARTYPE, proxy_type::host, proxy_access::constant>::
+                make(i, c.template get<INDEX>())};
+    }
+};
+
+template <typename VARTYPE>
+struct proxy_data_creator<schema<VARTYPE>, proxy_type::host,
+                          proxy_access::non_constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::host,
+                                      proxy_access::non_constant>::type>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(std::size_t i, CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(std::size_t i, CONTAINER& c) {
+
+        return {proxy_var_type<
+            VARTYPE, proxy_type::host,
+            proxy_access::non_constant>::make(i, c.template get<INDEX>())};
+    }
+};
+
+template <typename VARTYPE>
+struct proxy_data_creator<schema<VARTYPE>, proxy_type::device,
+                          proxy_access::constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::device,
+                                      proxy_access::constant>::type>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(unsigned int i, const CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(unsigned int i, const CONTAINER& c) {
+
+        return {proxy_var_type<
+            VARTYPE, proxy_type::device,
+            proxy_access::constant>::make(i, c.template get<INDEX>())};
+    }
+};
+
+template <typename VARTYPE>
+struct proxy_data_creator<schema<VARTYPE>, proxy_type::device,
+                          proxy_access::non_constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::device,
+                                      proxy_access::non_constant>::type>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(unsigned int i, CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(unsigned int i, CONTAINER& c) {
+
+        return {proxy_var_type<
+            VARTYPE, proxy_type::device,
+            proxy_access::non_constant>::make(i, c.template get<INDEX>())};
+    }
+};
+
+template <typename VARTYPE, typename... VARTYPES>
+struct proxy_data_creator<schema<VARTYPE, VARTYPES...>, proxy_type::host,
+                          proxy_access::constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::host,
+                                      proxy_access::constant>::type,
+              typename proxy_var_type<VARTYPES, proxy_type::host,
+                                      proxy_access::constant>::type...>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(std::size_t i, const CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(std::size_t i, const CONTAINER& c) {
+
+        return proxy_tuple_type(
+            proxy_var_type<VARTYPE, proxy_type::host, proxy_access::constant>::
+                make(i, c.template get<INDEX>()),
+            proxy_data_creator<
+                schema<VARTYPES...>, proxy_type::host,
+                proxy_access::constant>::template make_impl<INDEX + 1>(i, c));
+    }
+};
+
+template <typename VARTYPE, typename... VARTYPES>
+struct proxy_data_creator<schema<VARTYPE, VARTYPES...>, proxy_type::host,
+                          proxy_access::non_constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::host,
+                                      proxy_access::non_constant>::type,
+              typename proxy_var_type<VARTYPES, proxy_type::host,
+                                      proxy_access::non_constant>::type...>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(std::size_t i, CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(std::size_t i, CONTAINER& c) {
+
+        return proxy_tuple_type(
+            proxy_var_type<
+                VARTYPE, proxy_type::host,
+                proxy_access::non_constant>::make(i, c.template get<INDEX>()),
+            proxy_data_creator<
+                schema<VARTYPES...>, proxy_type::host,
+                proxy_access::non_constant>::template make_impl<INDEX + 1>(i,
+                                                                           c));
+    }
+};
+
+template <typename VARTYPE, typename... VARTYPES>
+struct proxy_data_creator<schema<VARTYPE, VARTYPES...>, proxy_type::device,
+                          proxy_access::constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::device,
+                                      proxy_access::constant>::type,
+              typename proxy_var_type<VARTYPES, proxy_type::device,
+                                      proxy_access::constant>::type...>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(unsigned int i, const CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(unsigned int i, const CONTAINER& c) {
+
+        return proxy_tuple_type(
+            proxy_var_type<
+                VARTYPE, proxy_type::device,
+                proxy_access::constant>::make(i, c.template get<INDEX>()),
+            proxy_data_creator<
+                schema<VARTYPES...>, proxy_type::device,
+                proxy_access::constant>::template make_impl<INDEX + 1>(i, c));
+    }
+};
+
+template <typename VARTYPE, typename... VARTYPES>
+struct proxy_data_creator<schema<VARTYPE, VARTYPES...>, proxy_type::device,
+                          proxy_access::non_constant> {
+
+    /// Make all other instantiations of the struct friends
+    template <typename SCHEMA, proxy_type PTYPE, proxy_access CTYPE>
+    friend struct proxy_data_creator;
+
+    /// Proxy tuple type created by the helper
+    using proxy_tuple_type =
+        tuple<typename proxy_var_type<VARTYPE, proxy_type::device,
+                                      proxy_access::non_constant>::type,
+              typename proxy_var_type<VARTYPES, proxy_type::device,
+                                      proxy_access::non_constant>::type...>;
+
+    /// Construct the tuple used by the proxy
+    template <typename CONTAINER>
+    static proxy_tuple_type make(unsigned int i, CONTAINER& c) {
+        return make_impl<0>(i, c);
+    }
+
+private:
+    template <std::size_t INDEX, typename CONTAINER>
+    static proxy_tuple_type make_impl(unsigned int i, CONTAINER& c) {
+
+        return proxy_tuple_type(
+            proxy_var_type<
+                VARTYPE, proxy_type::device,
+                proxy_access::non_constant>::make(i, c.template get<INDEX>()),
+            proxy_data_creator<
+                schema<VARTYPES...>, proxy_type::device,
+                proxy_access::non_constant>::template make_impl<INDEX + 1>(i,
+                                                                           c));
+    }
+};
+
+/// @}
+
+}  // namespace details
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/details/proxy_traits.hpp
+++ b/core/include/vecmem/edm/details/proxy_traits.hpp
@@ -52,9 +52,9 @@ template <typename VTYPE, proxy_type PTYPE>
 struct proxy_var_type<type::scalar<VTYPE>, PTYPE, proxy_access::constant> {
 
     /// The scalar is kept by value in the proxy
-    using type = VTYPE;
+    using type = std::add_lvalue_reference_t<std::add_const_t<VTYPE>>;
     /// It is returned as a const reference even on non-const access
-    using return_type = std::add_lvalue_reference_t<std::add_const_t<type>>;
+    using return_type = type;
     /// It is returned as a const reference on const access
     using const_return_type = return_type;
 
@@ -92,9 +92,9 @@ struct proxy_var_type<type::vector<VTYPE>, proxy_type::device,
                       proxy_access::constant> {
 
     /// Vector elements are kept by value in the proxy
-    using type = VTYPE;
+    using type = std::add_lvalue_reference_t<std::add_const_t<VTYPE>>;
     /// They are returned as a const reference even on non-const access
-    using return_type = std::add_lvalue_reference_t<std::add_const_t<type>>;
+    using return_type = type;
     /// They are returned as a const reference on const access
     using const_return_type = return_type;
 

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,6 +10,7 @@
 #include "vecmem/edm/data.hpp"
 #include "vecmem/edm/details/host_traits.hpp"
 #include "vecmem/edm/details/schema_traits.hpp"
+#include "vecmem/edm/proxy.hpp"
 #include "vecmem/edm/schema.hpp"
 #include "vecmem/memory/memory_resource.hpp"
 #include "vecmem/utils/types.hpp"
@@ -22,8 +23,8 @@
 namespace vecmem {
 namespace edm {
 
-/// Technical base type for @c host<schema<VARTYPES...>>
-template <typename T>
+/// Technical base type for @c host<schema<VARTYPES...>,INTERFACE>
+template <typename T, template <typename> class I>
 class host;
 
 /// Structure-of-Arrays host container
@@ -34,8 +35,8 @@ class host;
 ///
 /// @tparam ...VARTYPES The variable types to store in the host container
 ///
-template <typename... VARTYPES>
-class host<schema<VARTYPES...>> {
+template <typename... VARTYPES, template <typename> class INTERFACE>
+class host<schema<VARTYPES...>, INTERFACE> {
 
 public:
     /// The schema describing the host's payload
@@ -45,6 +46,17 @@ public:
     /// The tuple type holding all of the the individual variable vectors
     using tuple_type =
         std::tuple<typename details::host_type<VARTYPES>::type...>;
+    /// The type of the interface used for the proxy objects
+    template <typename T>
+    using interface_type = INTERFACE<T>;
+    /// The type of the (non-const) proxy objects for the container elements
+    using proxy_type =
+        interface_type<proxy<schema_type, details::proxy_type::host,
+                             details::proxy_access::non_constant>>;
+    /// The type of the (const) proxy objects for the container elements
+    using const_proxy_type =
+        interface_type<proxy<schema_type, details::proxy_type::host,
+                             details::proxy_access::constant>>;
 
     /// @name Constructors and assignment operators
     /// @{
@@ -77,6 +89,40 @@ public:
     VECMEM_HOST
         typename details::host_type_at<INDEX, VARTYPES...>::const_return_type
         get() const;
+
+    /// Get a proxy object for a specific variable (non-const)
+    ///
+    /// While also checking that the index is within bounds.
+    ///
+    /// @param index The index of the element to proxy
+    /// @return A proxy object for the element at the given index
+    ///
+    VECMEM_HOST
+    proxy_type at(size_type index);
+    /// Get a proxy object for a specific variable (const)
+    ///
+    /// While also checking that the index is within bounds.
+    ///
+    /// @param index The index of the element to proxy
+    /// @return A proxy object for the element at the given index
+    ///
+    VECMEM_HOST
+    const_proxy_type at(size_type index) const;
+
+    /// Get a proxy object for a specific variable (non-const)
+    ///
+    /// @param index The index of the element to proxy
+    /// @return A proxy object for the element at the given index
+    ///
+    VECMEM_HOST
+    proxy_type operator[](size_type index);
+    /// Get a proxy object for a specific variable (const)
+    ///
+    /// @param index The index of the element to proxy
+    /// @return A proxy object for the element at the given index
+    ///
+    VECMEM_HOST
+    const_proxy_type operator[](size_type index) const;
 
     /// @}
 
@@ -113,9 +159,9 @@ private:
 /// @param resource The memory resource to use for any allocation(s)
 /// @return A (non-const) data object describing the host container
 ///
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 VECMEM_HOST edm::data<edm::schema<VARTYPES...>> get_data(
-    edm::host<edm::schema<VARTYPES...>>& host,
+    edm::host<edm::schema<VARTYPES...>, INTERFACE>& host,
     memory_resource* resource = nullptr);
 
 /// Helper function for getting a (const) data object for a host container
@@ -125,9 +171,9 @@ VECMEM_HOST edm::data<edm::schema<VARTYPES...>> get_data(
 /// @param resource The memory resource to use for any allocation(s)
 /// @return A (const) data object describing the host container
 ///
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 VECMEM_HOST edm::data<edm::details::add_const_t<edm::schema<VARTYPES...>>>
-get_data(const edm::host<edm::schema<VARTYPES...>>& host,
+get_data(const edm::host<edm::schema<VARTYPES...>, INTERFACE>& host,
          memory_resource* resource = nullptr);
 
 }  // namespace vecmem

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -34,6 +34,7 @@ class host;
 /// variables in the client code.
 ///
 /// @tparam ...VARTYPES The variable types to store in the host container
+/// @tparam INTERFACE    The interface type to use for the container('s proxies)
 ///
 template <typename... VARTYPES, template <typename> class INTERFACE>
 class host<schema<VARTYPES...>, INTERFACE> {

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -17,8 +17,8 @@
 namespace vecmem {
 namespace edm {
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE device<schema<VARTYPES...>>::device(
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE device<schema<VARTYPES...>, INTERFACE>::device(
     const view<schema_type>& view)
     : m_capacity{view.capacity()},
       m_size{details::device_size_pointer<vecmem::details::disjunction_v<
@@ -30,8 +30,8 @@ VECMEM_HOST_AND_DEVICE device<schema<VARTYPES...>>::device(
         m_capacity, m_data, std::index_sequence_for<VARTYPES...>{}));
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::size() const
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>, INTERFACE>::size() const
     -> size_type {
 
     // Check that all variables have the correct capacities.
@@ -41,9 +41,9 @@ VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::size() const
     return (m_size == nullptr ? m_capacity : *m_size);
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::capacity() const
-    -> size_type {
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>, INTERFACE>::capacity()
+    const -> size_type {
 
     // Check that all variables have the correct capacities.
     assert(details::device_capacities_match<VARTYPES...>(
@@ -52,9 +52,9 @@ VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::capacity() const
     return m_capacity;
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::push_back_default()
-    -> size_type {
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto
+device<schema<VARTYPES...>, INTERFACE>::push_back_default() -> size_type {
 
     // There must be no jagged vector variables for this to work.
     static_assert(!vecmem::details::disjunction<
@@ -83,43 +83,86 @@ VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::push_back_default()
     return index;
 }
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
     typename details::device_type_at<INDEX, VARTYPES...>::return_type
-    device<schema<VARTYPES...>>::get() {
+    device<schema<VARTYPES...>, INTERFACE>::get() {
 
     return details::device_get<tuple_element_t<INDEX, tuple<VARTYPES...>>>::get(
         vecmem::get<INDEX>(m_data));
 }
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
     typename details::device_type_at<INDEX, VARTYPES...>::const_return_type
-    device<schema<VARTYPES...>>::get() const {
+    device<schema<VARTYPES...>, INTERFACE>::get() const {
 
     return details::device_get<tuple_element_t<INDEX, tuple<VARTYPES...>>>::get(
         vecmem::get<INDEX>(m_data));
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::variables()
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE
+    typename device<schema<VARTYPES...>, INTERFACE>::proxy_type
+    device<schema<VARTYPES...>, INTERFACE>::at(size_type index) {
+
+    // Make sure that the index is within bounds.
+    assert(index < size());
+
+    // Use the unprotected function.
+    return this->operator[](index);
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE
+    typename device<schema<VARTYPES...>, INTERFACE>::const_proxy_type
+    device<schema<VARTYPES...>, INTERFACE>::at(size_type index) const {
+
+    // Make sure that the index is within bounds.
+    assert(index < size());
+
+    // Use the unprotected function.
+    return this->operator[](index);
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE
+    typename device<schema<VARTYPES...>, INTERFACE>::proxy_type
+    device<schema<VARTYPES...>, INTERFACE>::operator[](size_type index) {
+
+    // Create the proxy.
+    return proxy_type{*this, index};
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE
+    typename device<schema<VARTYPES...>, INTERFACE>::const_proxy_type
+    device<schema<VARTYPES...>, INTERFACE>::operator[](size_type index) const {
+
+    // Create the proxy.
+    return const_proxy_type{*this, index};
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>, INTERFACE>::variables()
     -> tuple_type& {
 
     return m_data;
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>>::variables() const
-    -> const tuple_type& {
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>, INTERFACE>::variables()
+    const -> const tuple_type& {
 
     return m_data;
 }
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <std::size_t INDEX, std::size_t... Is>
-VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_default(
+VECMEM_HOST_AND_DEVICE void
+device<schema<VARTYPES...>, INTERFACE>::construct_default(
     size_type index, std::index_sequence<INDEX, Is...>) {
 
     // Construct the new element in this variable, if it's a vector.
@@ -128,18 +171,20 @@ VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_default(
     construct_default(index, std::index_sequence<Is...>{});
 }
 
-template <typename... VARTYPES>
-VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_default(
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE void
+device<schema<VARTYPES...>, INTERFACE>::construct_default(
     size_type, std::index_sequence<>) {}
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <typename T>
-VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_vector(
-    size_type, T&) {}
+VECMEM_HOST_AND_DEVICE void
+device<schema<VARTYPES...>, INTERFACE>::construct_vector(size_type, T&) {}
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <typename T>
-VECMEM_HOST_AND_DEVICE void device<schema<VARTYPES...>>::construct_vector(
+VECMEM_HOST_AND_DEVICE void
+device<schema<VARTYPES...>, INTERFACE>::construct_vector(
     size_type index, device_vector<T>& vec) {
 
     vec.construct(index, {});

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -105,8 +105,8 @@ host<schema<VARTYPES...>, INTERFACE>::at(size_type index) {
                                 ") >= size (" + std::to_string(size()) + ")");
     }
 
-    // Create the proxy.
-    return proxy_type{*this, index};
+    // Use the unprotected function.
+    return this->operator[](index);
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
@@ -119,8 +119,8 @@ host<schema<VARTYPES...>, INTERFACE>::at(size_type index) const {
                                 ") >= size (" + std::to_string(size()) + ")");
     }
 
-    // Create the proxy.
-    return const_proxy_type{*this, index};
+    // Use the unprotected function.
+    return this->operator[](index);
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -16,7 +16,11 @@ VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
     PARENT& parent, typename PARENT::size_type index)
     : m_data{
           details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
-              index, parent)} {}
+              index, parent)} {
+
+    static_assert(CTYPE == details::proxy_access::non_constant,
+                  "This constructor is meant for non-const proxies.");
+}
 
 template <typename... VARTYPES, details::proxy_type PTYPE,
           details::proxy_access CTYPE>
@@ -25,7 +29,11 @@ VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
     const PARENT& parent, typename PARENT::size_type index)
     : m_data{
           details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
-              index, parent)} {}
+              index, parent)} {
+
+    static_assert(CTYPE == details::proxy_access::constant,
+                  "This constructor is meant for constant proxies.");
+}
 
 template <typename... VARTYPES, details::proxy_type PTYPE,
           details::proxy_access CTYPE>

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -1,0 +1,53 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem {
+namespace edm {
+
+template <typename... VARTYPES, details::proxy_type PTYPE,
+          details::proxy_access CTYPE>
+template <typename PARENT>
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
+    PARENT& parent, typename PARENT::size_type index)
+    : m_data{
+          details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
+              index, parent)} {}
+
+template <typename... VARTYPES, details::proxy_type PTYPE,
+          details::proxy_access CTYPE>
+template <typename PARENT>
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
+    const PARENT& parent, typename PARENT::size_type index)
+    : m_data{
+          details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
+              index, parent)} {}
+
+template <typename... VARTYPES, details::proxy_type PTYPE,
+          details::proxy_access CTYPE>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE
+    typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+                                        VARTYPES...>::return_type
+    proxy<schema<VARTYPES...>, PTYPE, CTYPE>::get() {
+
+    return vecmem::get<INDEX>(m_data);
+}
+
+template <typename... VARTYPES, details::proxy_type PTYPE,
+          details::proxy_access CTYPE>
+template <std::size_t INDEX>
+VECMEM_HOST_AND_DEVICE
+    typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+                                        VARTYPES...>::const_return_type
+    proxy<schema<VARTYPES...>, PTYPE, CTYPE>::get() const {
+
+    return vecmem::get<INDEX>(m_data);
+}
+
+}  // namespace edm
+}  // namespace vecmem

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -24,6 +24,8 @@ class proxy;
 /// This class implements a "view" of a single element in an SoA container.
 ///
 /// @tparam ...VARTYPES The variable types to store in the proxy object
+/// @tparam PTYPE       The type of the proxy (host or device)
+/// @tparam CTYPE       The access mode of the proxy (const or non-const)
 ///
 template <typename... VARTYPES, details::proxy_type PTYPE,
           details::proxy_access CTYPE>

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -1,0 +1,97 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2024 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/edm/details/proxy_traits.hpp"
+#include "vecmem/edm/schema.hpp"
+#include "vecmem/utils/tuple.hpp"
+#include "vecmem/utils/types.hpp"
+
+namespace vecmem {
+namespace edm {
+
+/// Technical base type for @c proxy<schema<VARTYPES...>,PTYPE,CTYPE>
+template <typename T, details::proxy_type PTYPE, details::proxy_access CTYPE>
+class proxy;
+
+/// Structure-of-Arrays element proxy
+///
+/// This class implements a "view" of a single element in an SoA container.
+///
+/// @tparam ...VARTYPES The variable types to store in the proxy object
+///
+template <typename... VARTYPES, details::proxy_type PTYPE,
+          details::proxy_access CTYPE>
+class proxy<schema<VARTYPES...>, PTYPE, CTYPE> {
+
+public:
+    /// The schema describing the host's payload
+    using schema_type = schema<VARTYPES...>;
+    /// The type of the proxy (host or device)
+    static constexpr details::proxy_type proxy_type = PTYPE;
+    /// The access mode of the proxy (const or non-const)
+    static constexpr details::proxy_access access_type = CTYPE;
+    /// The tuple type holding all of the the proxied variables
+    using tuple_type =
+        tuple<typename details::proxy_var_type<VARTYPES, proxy_type,
+                                               access_type>::type...>;
+
+    /// @name Constructors and assignment operators
+    /// @{
+
+    /// Constructor of a non-const proxy on top of a parent container
+    ///
+    /// @tparam PARENT The type of the parent container
+    /// @param  parent The parent container to create a proxy for
+    /// @param  index  The index of the element to proxy
+    ///
+    template <typename PARENT>
+    VECMEM_HOST_AND_DEVICE proxy(PARENT& parent,
+                                 typename PARENT::size_type index);
+
+    /// Constructor of a const proxy on top of a parent container
+    ///
+    /// @tparam PARENT The type of the parent container
+    /// @param  parent The parent container to create a proxy for
+    /// @param  index  The index of the element to proxy
+    ///
+    template <typename PARENT>
+    VECMEM_HOST_AND_DEVICE proxy(const PARENT& parent,
+                                 typename PARENT::size_type index);
+
+    /// @}
+
+    /// @name Variable accessor functions
+    /// @{
+
+    /// Get a specific variable (non-const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE
+        typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+                                            VARTYPES...>::return_type
+        get();
+    /// Get a specific variable (const)
+    template <std::size_t INDEX>
+    VECMEM_HOST_AND_DEVICE
+        typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+                                            VARTYPES...>::const_return_type
+        get() const;
+
+    /// @}
+
+private:
+    /// The tuple holding all of the individual proxy objects
+    tuple_type m_data;
+
+};  // class proxy
+
+}  // namespace edm
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/edm/impl/proxy.ipp"

--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -172,11 +172,11 @@ public:
         type::copy_type cptype = type::unknown) const;
 
     /// Copy from a view, into a host container
-    template <typename... VARTYPES>
+    template <typename... VARTYPES, template <typename> class INTERFACE>
     event_type operator()(
         const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
             from,
-        edm::host<edm::schema<VARTYPES...>>& to,
+        edm::host<edm::schema<VARTYPES...>, INTERFACE>& to,
         type::copy_type cptype = type::unknown) const;
 
     /// Get the (outer) size of a resizable SoA container
@@ -230,11 +230,13 @@ private:
     template <std::size_t INDEX, typename... VARTYPES>
     void memset_impl(edm::view<edm::schema<VARTYPES...>> data, int value) const;
     /// Implementation for setting the sizes of an SoA container
-    template <std::size_t INDEX, typename... VARTYPES>
+    template <std::size_t INDEX, typename... VARTYPES,
+              template <typename> class INTERFACE>
     void resize_impl(
         const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
             from,
-        edm::host<edm::schema<VARTYPES...>>& to, type::copy_type cptype) const;
+        edm::host<edm::schema<VARTYPES...>, INTERFACE>& to,
+        type::copy_type cptype) const;
     /// Implementation for the variadic @c copy function (for the sizes)
     template <std::size_t INDEX, typename... VARTYPES>
     void copy_sizes_impl(

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -431,11 +431,12 @@ copy::event_type copy::operator()(
     return create_event();
 }
 
-template <typename... VARTYPES>
+template <typename... VARTYPES, template <typename> class INTERFACE>
 copy::event_type copy::operator()(
     const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
         from_view,
-    edm::host<edm::schema<VARTYPES...>>& to_vec, type::copy_type cptype) const {
+    edm::host<edm::schema<VARTYPES...>, INTERFACE>& to_vec,
+    type::copy_type cptype) const {
 
     // Resize the output object to the correct size(s).
     resize_impl<0>(from_view, to_vec, cptype);
@@ -761,11 +762,12 @@ void copy::memset_impl(edm::view<edm::schema<VARTYPES...>> data,
     }
 }
 
-template <std::size_t INDEX, typename... VARTYPES>
+template <std::size_t INDEX, typename... VARTYPES,
+          template <typename> class INTERFACE>
 void copy::resize_impl(
     const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
         from_view,
-    edm::host<edm::schema<VARTYPES...>>& to_vec,
+    edm::host<edm::schema<VARTYPES...>, INTERFACE>& to_vec,
     [[maybe_unused]] type::copy_type cptype) const {
 
     // The target is a host container, so the copy type can't be anything

--- a/core/include/vecmem/utils/tuple.hpp
+++ b/core/include/vecmem/utils/tuple.hpp
@@ -74,6 +74,22 @@ struct tuple<T, Ts...> {
     VECMEM_HOST_AND_DEVICE constexpr tuple(U &&head, Us &&... tail)
         : m_head(std::forward<U>(head)), m_tail(std::forward<Us>(tail)...) {}
 
+    /// "Concatenation" constructor
+    ///
+    /// It is used in the @c vecmem::edm code while constructing some of the
+    /// internal tuples of the objects.
+    ///
+    /// @param head The first element to be stored in the tuple
+    /// @param tail The rest of the elements to be stored in the tuple
+    ///
+    template <typename U, typename... Us,
+              std::enable_if_t<vecmem::details::conjunction<
+                                   std::is_constructible<T, U &&>,
+                                   std::is_constructible<Ts, Us &&>...>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE constexpr tuple(U &&head, tuple<Us...> &&tail)
+        : m_head(std::forward<U>(head)), m_tail(std::move(tail)) {}
+
     /// The first/head element of the tuple
     T m_head;
     /// The rest of the tuple elements

--- a/tests/common/simple_soa_container_helpers.hpp
+++ b/tests/common/simple_soa_container_helpers.hpp
@@ -28,7 +28,7 @@ inline void fill(unsigned int i, simple_soa_container::device& obj) {
     if (i < obj.capacity()) {
         unsigned int ii = obj.push_back_default();
         obj.measurement()[ii] = 1.0f * static_cast<float>(ii);
-        obj.index()[ii] = static_cast<int>(ii);
+        obj.at(ii).index() = static_cast<int>(ii);
     }
 }
 
@@ -43,7 +43,7 @@ inline void modify(unsigned int i, simple_soa_container::device& obj) {
     }
     // In the rest of the threads modify the vector variables.
     if (i < obj.size()) {
-        obj.measurement()[i] *= 2.0f;
+        obj.at(i).measurement() *= 2.0f;
         obj.index()[i] += 10;
     }
 }

--- a/tests/core/test_core_edm_buffer.cpp
+++ b/tests/core/test_core_edm_buffer.cpp
@@ -42,6 +42,10 @@ protected:
     using jagged_const_schema =
         vecmem::edm::details::add_const_t<jagged_schema>;
 
+    /// Dummy container interface for the test
+    template <typename BASE>
+    struct interface {};
+
     /// Memory resource for the test(s)
     vecmem::host_memory_resource m_resource;
     /// Copy object for the test(s)
@@ -246,7 +250,7 @@ TEST_F(core_edm_buffer_test, device) {
         CAPACITY, m_resource, vecmem::data::buffer_type::fixed_size};
 
     // Make a device container on top of it.
-    vecmem::edm::device<simple_schema> device1{buffer1};
+    vecmem::edm::device<simple_schema, interface> device1{buffer1};
     ASSERT_EQ(device1.size(), CAPACITY);
     ASSERT_EQ(device1.capacity(), CAPACITY);
     auto check_fixed_vector = [&](const auto& v) {
@@ -282,7 +286,7 @@ TEST_F(core_edm_buffer_test, device) {
     m_copy.memset(buffer2.size(), 0);
 
     // Make a device container on top of it.
-    vecmem::edm::device<simple_schema> device2{buffer2};
+    vecmem::edm::device<simple_schema, interface> device2{buffer2};
     ASSERT_EQ(device2.size(), 0u);
     ASSERT_EQ(device2.capacity(), CAPACITY);
     auto check_resizable_vector = [&](const auto& v) {
@@ -324,7 +328,7 @@ TEST_F(core_edm_buffer_test, device) {
         CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::fixed_size};
 
     // Make a device container on top of it.
-    vecmem::edm::device<jagged_schema> device3{buffer3};
+    vecmem::edm::device<jagged_schema, interface> device3{buffer3};
     ASSERT_EQ(device3.size(), CAPACITY);
     ASSERT_EQ(device3.capacity(), CAPACITY);
     auto check_fixed_jagged = [&](const auto& v) {
@@ -365,7 +369,7 @@ TEST_F(core_edm_buffer_test, device) {
     m_copy.memset(buffer4.size(), 0);
 
     // Make a device container on top of it.
-    vecmem::edm::device<jagged_schema> device4{buffer4};
+    vecmem::edm::device<jagged_schema, interface> device4{buffer4};
     ASSERT_EQ(device4.size(), CAPACITY);
     ASSERT_EQ(device4.capacity(), CAPACITY);
     auto check_resizable_jagged = [&](const auto& v) {

--- a/tests/core/test_core_edm_device.cpp
+++ b/tests/core/test_core_edm_device.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,6 +14,14 @@
 // System include(s).
 #include <vector>
 
+namespace {
+
+/// Dummy container interface for the test
+template <typename BASE>
+struct interface {};
+
+}  // namespace
+
 TEST(core_edm_device_test, construct) {
 
     using schema =
@@ -25,9 +33,9 @@ TEST(core_edm_device_test, construct) {
     vecmem::edm::view<schema> view1{};
     vecmem::edm::view<const_schema> view2{};
 
-    vecmem::edm::device<schema> device1{view1};
-    vecmem::edm::device<const_schema> device2{view1};
-    vecmem::edm::device<const_schema> device3{view2};
+    vecmem::edm::device<schema, interface> device1{view1};
+    vecmem::edm::device<const_schema, interface> device2{view1};
+    vecmem::edm::device<const_schema, interface> device3{view2};
 }
 
 TEST(core_edm_device_test, members) {
@@ -44,8 +52,8 @@ TEST(core_edm_device_test, members) {
     view.get<0>() = &value1;
     view.get<1>() = {static_cast<unsigned int>(value2.size()), value2.data()};
 
-    vecmem::edm::device<schema> device1{view};
-    vecmem::edm::device<const_schema> device2{view};
+    vecmem::edm::device<schema, interface> device1{view};
+    vecmem::edm::device<const_schema, interface> device2{view};
 
     EXPECT_EQ(device2.get<0>(), value1);
     ASSERT_EQ(device2.get<1>().size(), value2.size());

--- a/tests/core/test_core_edm_host.cpp
+++ b/tests/core/test_core_edm_host.cpp
@@ -150,16 +150,16 @@ TEST_F(core_edm_host_test, device) {
 
     // Create a non-const device object for it, and check its contents.
     auto data1 = vecmem::get_data(host1);
-    vecmem::edm::device<schema> device1{data1};
+    vecmem::edm::device<schema, interface> device1{data1};
     compare(device1, host1);
 
     // Create constant device objects for it, and check their contents.
     auto data2 = [](const vecmem::edm::host<schema, interface>& host) {
         return vecmem::get_data(host);
     }(host1);
-    vecmem::edm::device<const_schema> device2{data2};
+    vecmem::edm::device<const_schema, interface> device2{data2};
     compare(device2, host1);
-    vecmem::edm::device<const_schema> device3{data1};
+    vecmem::edm::device<const_schema, interface> device3{data1};
     compare(device3, host1);
 }
 


### PR DESCRIPTION
With the final straw being https://github.com/acts-project/traccc/pull/712, this is an attempt at providing "proxies" for the SoA containers that would allow an "AoS-like" access to the containers in the client code.

The code requires the user to create the same type of interface struct/class for their container, as they did so far. But now that interface is no longer only used providing a user-friendly API for the containers, but also to provide the same API for the proxy objects. Allowing user code to interchangeably use
  - `container.variable().at(i)` or;
  - `container.at(i).variable()`

semantics to access the same variable.

We discussed about this already with @stephenswat, and I'm absolutely not convinced that I did the correct thing here, but I made the proxies behave in the following way:
  - "constant proxies" keep their variables by value for the scalar and vector variable types;
  - "non-const proxies" keep their variables by reference.

My idea being that this way we could force the loading of all variables of a given container in a single place in device code, when we are only reading from those variables. But as @stephenswat pointed out, I might very well be doing something silly with this. And should maybe just use references in the proxies everywhere. :thinking:

The device code, and a lot of additional testing code is still to come, but I wanted to showcase already how I want to implement this feature.