### PR TITLE
SYCL Compiler Support, main branch (2024.11.05.)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY
 # Flags controlling the meta-build system.
 option( VECMEM_USE_SYSTEM_LIBS "Use system libraries by default" FALSE )
 option( VECMEM_BUILD_TESTING "Build the unit tests of VecMem" TRUE )
+option( VECMEM_TEST_UBSAN "Use the undefined behavior sanitizer for the tests"
+   TRUE )
 
 # Include the VecMem CMake code.
 list( APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" )

--- a/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
+++ b/cmake/sycl/CMakeDetermineSYCLCompiler.cmake
@@ -24,16 +24,15 @@ if( NOT "$ENV{SYCLCXX}" STREQUAL "" )
    endif()
 
    # Determine the type and version of the SYCL compiler.
-   execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}" "--version"
-      OUTPUT_VARIABLE _syclVersionOutput
-      ERROR_VARIABLE _syclVersionError
-      RESULT_VARIABLE _syclVersionResult )
-   if( NOT ${_syclVersionResult} EQUAL 0 )
-      execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}"
-                               "--hipsycl-version"
+   foreach( _version_cmdl "--acpp-version" "--version" "--hipsycl-version" )
+      execute_process( COMMAND "${CMAKE_SYCL_COMPILER_INIT}" "${_version_cmdl}"
          OUTPUT_VARIABLE _syclVersionOutput
+         ERROR_VARIABLE _syclVersionError
          RESULT_VARIABLE _syclVersionResult )
-   endif()
+      if( ${_syclVersionResult} EQUAL 0 )
+         break()
+      endif()
+   endforeach()
    if( ${_syclVersionResult} EQUAL 0 )
       if( "${_syclVersionOutput}" MATCHES "ComputeCpp" )
          set( CMAKE_SYCL_COMPILER_ID "ComputeCpp" CACHE STRING
@@ -47,6 +46,10 @@ if( NOT "$ENV{SYCLCXX}" STREQUAL "" )
          set( CMAKE_SYCL_COMPILER_ID "IntelLLVM" CACHE STRING
             "Identifier for the SYCL compiler in use" )
          set( _syclVersionRegex "clang version ([0-9\.]+)" )
+      elseif( "${_syclVersionOutput}" MATCHES "AdaptiveCpp" )
+         set( CMAKE_SYCL_COMPILER_ID "AdaptiveCpp" CACHE STRING
+            "Identifier for the SYCL compiler in use" )
+         set( _syclVersionRegex "AdaptiveCpp version: ([0-9\.]+)" )
       elseif( "${_syclVersionOutput}" MATCHES "hipSYCL" )
          set( CMAKE_SYCL_COMPILER_ID "hipSYCL" CACHE STRING
             "Identifier for the SYCL compiler in use" )

--- a/cmake/sycl/CMakeTestSYCLCompiler.cmake
+++ b/cmake/sycl/CMakeTestSYCLCompiler.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021 CERN for the benefit of the ACTS project
+# (c) 2021-2024 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -17,7 +17,7 @@ endif()
 # Try to use the HIP compiler.
 file( WRITE
    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/main.sycl"
-   "#include <CL/sycl.hpp>\n"
+   "#include <sycl/sycl.hpp>\n"
    "int main() {\n"
    "#if (!defined(CL_SYCL_LANGUAGE_VERSION)) &&"
    "    (!defined(SYCL_LANGUAGE_VERSION))\n"

--- a/cmake/sycl/Platform/Linux-AdaptiveCpp-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-AdaptiveCpp-SYCL.cmake
@@ -1,0 +1,31 @@
+# VecMem project, part of the ACTS project (R&D line)
+#
+# (c) 2022-2024 CERN for the benefit of the ACTS project
+#
+# Mozilla Public License Version 2.0
+
+# Use the standard GNU compiler options for hipSYCL.
+include( Platform/Linux-GNU )
+__linux_compiler_gnu( SYCL )
+include( Compiler/GNU )
+__compiler_gnu( SYCL )
+
+# Set up the dependency file generation for this platform. Note that SYCL
+# compilation only works with Makefile and Ninja generators, so no check is made
+# here for the current generator.
+set( CMAKE_SYCL_DEPENDS_USE_COMPILER TRUE )
+set( CMAKE_SYCL_DEPFILE_FORMAT gcc )
+
+# Set an archive (static library) creation command explicitly for this platform.
+set( CMAKE_SYCL_CREATE_STATIC_LIBRARY
+   "<CMAKE_AR> qc <TARGET> <LINK_FLAGS> <OBJECTS>" )
+
+# Set the flags controlling the C++ standard used by the SYCL compiler.
+set( CMAKE_SYCL17_STANDARD_COMPILE_OPTION "-std=c++17" )
+set( CMAKE_SYCL17_EXTENSION_COMPILE_OPTION "-std=c++17" )
+
+set( CMAKE_SYCL20_STANDARD_COMPILE_OPTION "-std=c++20" )
+set( CMAKE_SYCL20_EXTENSION_COMPILE_OPTION "-std=c++20" )
+
+set( CMAKE_SYCL23_STANDARD_COMPILE_OPTION "-std=c++23" )
+set( CMAKE_SYCL23_EXTENSION_COMPILE_OPTION "-std=c++23" )

--- a/core/cmake/vecmem-setup-core.cmake
+++ b/core/cmake/vecmem-setup-core.cmake
@@ -44,7 +44,7 @@ function( vecmem_setup_core libName )
 
       # Test which SYCL printf function(s) is/are available.
       vecmem_check_sycl_source_compiles( "
-         #include <CL/sycl.hpp>
+         #include <sycl/sycl.hpp>
          #ifdef __SYCL_DEVICE_ONLY__
          #  define VECMEM_MSG_ATTRIBUTES __attribute__((opencl_constant))
          #else
@@ -52,12 +52,12 @@ function( vecmem_setup_core libName )
          #endif
          int main() {
              const VECMEM_MSG_ATTRIBUTES char __msg[] = \"Test message %i\";
-             cl::sycl::ext::oneapi::experimental::printf(__msg, 20);
+             ::sycl::ext::oneapi::experimental::printf(__msg, 20);
              return 0;
          }
          " VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF )
       vecmem_check_sycl_source_compiles( "
-         #include <CL/sycl.hpp>
+         #include <sycl/sycl.hpp>
          #ifdef __SYCL_DEVICE_ONLY__
          #  define VECMEM_MSG_ATTRIBUTES __attribute__((opencl_constant))
          #else
@@ -65,7 +65,7 @@ function( vecmem_setup_core libName )
          #endif
          int main() {
              const VECMEM_MSG_ATTRIBUTES char __msg[] = \"Test message %i\";
-             cl::sycl::ONEAPI::experimental::printf(__msg, 20);
+             ::sycl::ONEAPI::experimental::printf(__msg, 20);
              return 0;
          }
          " VECMEM_HAVE_SYCL_ONEAPI_PRINTF )
@@ -73,10 +73,10 @@ function( vecmem_setup_core libName )
       # Set up the appropriate flag based on these checks.
       if( VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF )
          target_compile_definitions( ${libName} INTERFACE
-            $<BUILD_INTERFACE:VECMEM_SYCL_PRINTF_FUNCTION=cl::sycl::ext::oneapi::experimental::printf> )
+            $<BUILD_INTERFACE:VECMEM_SYCL_PRINTF_FUNCTION=::sycl::ext::oneapi::experimental::printf> )
       elseif( VECMEM_HAVE_SYCL_ONEAPI_PRINTF )
          target_compile_definitions( ${libName} INTERFACE
-            $<BUILD_INTERFACE:VECMEM_SYCL_PRINTF_FUNCTION=cl::sycl::ONEAPI::experimental::printf> )
+            $<BUILD_INTERFACE:VECMEM_SYCL_PRINTF_FUNCTION=::sycl::ONEAPI::experimental::printf> )
       else()
          message( WARNING "No valid printf function found for SYCL."
             " Enabling debug messages will likely not work in device code." )
@@ -87,12 +87,12 @@ function( vecmem_setup_core libName )
 
       # Test whether sycl::atomic_ref is available.
       vecmem_check_sycl_source_compiles( "
-         #include <CL/sycl.hpp>
+         #include <sycl/sycl.hpp>
          int main() {
              int dummy = 0;
-             cl::sycl::atomic_ref<int, sycl::memory_order::relaxed,
-                                 cl::sycl::memory_scope::device,
-                                 cl::sycl::access::address_space::global_space>
+             ::sycl::atomic_ref<int, sycl::memory_order::relaxed,
+                               ::sycl::memory_scope::device,
+                               ::sycl::access::address_space::global_space>
                  atomic_dummy(dummy);
              atomic_dummy.store(3);
              atomic_dummy.fetch_add(1);

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -197,7 +197,7 @@ VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::emplace_back(Args&&... args)
     // Increment the size of the vector at first. So that we would "claim" the
     // index from other threads.
     device_atomic_ref<size_type> asize(*m_size);
-    const size_type index = asize.fetch_add(1);
+    const size_type index = asize.fetch_add(1u);
     assert(index < m_capacity);
 
     // Instantiate the new value.
@@ -217,7 +217,7 @@ VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::push_back(
     // Increment the size of the vector at first. So that we would "claim" the
     // index from other threads.
     device_atomic_ref<size_type> asize(*m_size);
-    const size_type index = asize.fetch_add(1);
+    const size_type index = asize.fetch_add(1u);
     assert(index < m_capacity);
 
     // Instantiate the new value.
@@ -315,7 +315,7 @@ VECMEM_HOST_AND_DEVICE auto device_vector<TYPE>::pop_back() -> size_type {
 
     // Decrement the size of the vector, and remember this new size.
     device_atomic_ref<size_type> asize(*m_size);
-    const size_type new_size = asize.fetch_sub(1) - 1;
+    const size_type new_size = asize.fetch_sub(1u) - 1;
 
     // Remove the last element.
     destruct(new_size);

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -73,7 +73,7 @@ device<schema<VARTYPES...>, INTERFACE>::push_back_default() -> size_type {
     // Increment the size of the container at first. So that we would "claim"
     // the index from other threads.
     device_atomic_ref<size_type> asize(*m_size);
-    const size_type index = asize.fetch_add(1);
+    const size_type index = asize.fetch_add(1u);
     assert(index < m_capacity);
 
     // Construct the new elements in all of the vector variables.

--- a/core/include/vecmem/memory/details/sycl_builtin_device_atomic_ref.hpp
+++ b/core/include/vecmem/memory/details/sycl_builtin_device_atomic_ref.hpp
@@ -11,7 +11,7 @@
 #include "vecmem/memory/device_address_space.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem {
 namespace sycl {
@@ -27,23 +27,20 @@ struct builtin_address_space {};
 /// Specialization for global device memory
 template <>
 struct builtin_address_space<device_address_space::global> {
-    static constexpr cl::sycl::memory_order ord =
-        cl::sycl::memory_order::relaxed;
-    static constexpr cl::sycl::memory_scope scp =
-        cl::sycl::memory_scope::device;
-    static constexpr cl::sycl::access::address_space add =
-        cl::sycl::access::address_space::global_space;
+    static constexpr ::sycl::memory_order ord = ::sycl::memory_order::relaxed;
+    static constexpr ::sycl::memory_scope scp = ::sycl::memory_scope::device;
+    static constexpr ::sycl::access::address_space add =
+        ::sycl::access::address_space::global_space;
 };
 
 /// Specialization for local device memory
 template <>
 struct builtin_address_space<device_address_space::local> {
-    static constexpr cl::sycl::memory_order ord =
-        cl::sycl::memory_order::relaxed;
-    static constexpr cl::sycl::memory_scope scp =
-        cl::sycl::memory_scope::work_group;
-    static constexpr cl::sycl::access::address_space add =
-        cl::sycl::access::address_space::local_space;
+    static constexpr ::sycl::memory_order ord = ::sycl::memory_order::relaxed;
+    static constexpr ::sycl::memory_scope scp =
+        ::sycl::memory_scope::work_group;
+    static constexpr ::sycl::access::address_space add =
+        ::sycl::access::address_space::local_space;
 };
 
 }  // namespace details
@@ -52,9 +49,9 @@ struct builtin_address_space<device_address_space::local> {
 template <typename T,
           device_address_space address = device_address_space::global>
 using builtin_device_atomic_ref =
-    cl::sycl::atomic_ref<T, details::builtin_address_space<address>::ord,
-                         details::builtin_address_space<address>::scp,
-                         details::builtin_address_space<address>::add>;
+    ::sycl::atomic_ref<T, details::builtin_address_space<address>::ord,
+                       details::builtin_address_space<address>::scp,
+                       details::builtin_address_space<address>::add>;
 
 }  // namespace sycl
 }  // namespace vecmem

--- a/core/include/vecmem/memory/impl/atomic.ipp
+++ b/core/include/vecmem/memory/impl/atomic.ipp
@@ -14,22 +14,21 @@
 
 // SYCL include(s).
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 /// Helpers for explicit calls to the SYCL atomic functions
 #if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
 #define __VECMEM_SYCL_ATOMIC_CALL0(FNAME, PTR) \
-    cl::sycl::atomic_##FNAME<value_type>(      \
-        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)))
-#define __VECMEM_SYCL_ATOMIC_CALL1(FNAME, PTR, ARG1)                         \
-    cl::sycl::atomic_##FNAME<value_type>(                                    \
-        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
-        ARG1)
-#define __VECMEM_SYCL_ATOMIC_CALL2(FNAME, PTR, ARG1, ARG2)                   \
-    cl::sycl::atomic_##FNAME<value_type>(                                    \
-        cl::sycl::atomic<value_type>(cl::sycl::global_ptr<value_type>(PTR)), \
-        ARG1, ARG2)
+    ::sycl::atomic_##FNAME<value_type>(        \
+        ::sycl::atomic<value_type>(::sycl::global_ptr<value_type>(PTR)))
+#define __VECMEM_SYCL_ATOMIC_CALL1(FNAME, PTR, ARG1) \
+    ::sycl::atomic_##FNAME<value_type>(              \
+        ::sycl::atomic<value_type>(::sycl::global_ptr<value_type>(PTR)), ARG1)
+#define __VECMEM_SYCL_ATOMIC_CALL2(FNAME, PTR, ARG1, ARG2)                     \
+    ::sycl::atomic_##FNAME<value_type>(                                        \
+        ::sycl::atomic<value_type>(::sycl::global_ptr<value_type>(PTR)), ARG1, \
+        ARG2)
 #endif
 
 namespace vecmem {

--- a/core/include/vecmem/memory/impl/sycl_custom_device_atomic_ref.ipp
+++ b/core/include/vecmem/memory/impl/sycl_custom_device_atomic_ref.ipp
@@ -8,7 +8,7 @@
 #pragma once
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem {
 namespace sycl {
@@ -19,43 +19,43 @@ struct custom_address_space {};
 
 template <>
 struct custom_address_space<device_address_space::global> {
-    static constexpr cl::sycl::access::address_space add =
-        cl::sycl::access::address_space::global_space;
+    static constexpr ::sycl::access::address_space add =
+        ::sycl::access::address_space::global_space;
 
     template <typename T>
-    using ptr_t = cl::sycl::global_ptr<T>;
+    using ptr_t = ::sycl::global_ptr<T>;
 };
 
 template <>
 struct custom_address_space<device_address_space::local> {
-    static constexpr cl::sycl::access::address_space add =
-        cl::sycl::access::address_space::local_space;
+    static constexpr ::sycl::access::address_space add =
+        ::sycl::access::address_space::local_space;
     template <typename T>
-    using ptr_t = cl::sycl::local_ptr<T>;
+    using ptr_t = ::sycl::local_ptr<T>;
 };
 
 }  // namespace details
 
 #define __VECMEM_SYCL_ATOMIC_CALL0(FNAME, PTR)                               \
-    cl::sycl::atomic_##FNAME<value_type,                                     \
-                             details::custom_address_space<address>::add>(   \
-        cl::sycl::atomic<value_type,                                         \
-                         details::custom_address_space<address>::add>(       \
+    ::sycl::atomic_##FNAME<value_type,                                       \
+                           details::custom_address_space<address>::add>(     \
+        ::sycl::atomic<value_type,                                           \
+                       details::custom_address_space<address>::add>(         \
             typename details::custom_address_space<address>::template ptr_t< \
                 value_type>(PTR)))
 #define __VECMEM_SYCL_ATOMIC_CALL1(FNAME, PTR, ARG1)                         \
-    cl::sycl::atomic_##FNAME<value_type,                                     \
-                             details::custom_address_space<address>::add>(   \
-        cl::sycl::atomic<value_type,                                         \
-                         details::custom_address_space<address>::add>(       \
+    ::sycl::atomic_##FNAME<value_type,                                       \
+                           details::custom_address_space<address>::add>(     \
+        ::sycl::atomic<value_type,                                           \
+                       details::custom_address_space<address>::add>(         \
             typename details::custom_address_space<address>::template ptr_t< \
                 value_type>(PTR)),                                           \
         ARG1)
 #define __VECMEM_SYCL_ATOMIC_CALL2(FNAME, PTR, ARG1, ARG2)                   \
-    cl::sycl::atomic_##FNAME<value_type,                                     \
-                             details::custom_address_space<address>::add>(   \
-        cl::sycl::atomic<value_type,                                         \
-                         details::custom_address_space<address>::add>(       \
+    ::sycl::atomic_##FNAME<value_type,                                       \
+                           details::custom_address_space<address>::add>(     \
+        ::sycl::atomic<value_type,                                           \
+                       details::custom_address_space<address>::add>(         \
             typename details::custom_address_space<address>::template ptr_t< \
                 value_type>(PTR)),                                           \
         ARG1, ARG2)

--- a/core/include/vecmem/memory/memory_order.hpp
+++ b/core/include/vecmem/memory/memory_order.hpp
@@ -14,7 +14,7 @@
 #if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && \
     defined(VECMEM_HAVE_SYCL_ATOMIC_REF)
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 namespace vecmem {

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -41,7 +41,7 @@ set_target_properties( vecmem_sycl PROPERTIES
    CXX_VISIBILITY_PRESET  "hidden"
    SYCL_VISIBILITY_PRESET "hidden" )
 vecmem_check_sycl_source_compiles( "
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    int main() { return 0; }
    "
    VECMEM_HAVE_SYCL_VISIBILITY_MS_COMPAT
@@ -94,9 +94,9 @@ endif()
 # Check if sycl::queue::memset is available, and set a compiler option
 # accordingly.
 vecmem_check_sycl_source_compiles( "
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    int main() {
-       cl::sycl::queue queue;
+       ::sycl::queue queue;
        queue.memset(nullptr, 0, 100);
        return 0;
    }

--- a/sycl/cmake/assert_test.sycl
+++ b/sycl/cmake/assert_test.sycl
@@ -1,12 +1,12 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // System include(s).
 #include <cassert>
@@ -14,12 +14,12 @@
 int main() {
 
     // Run a useless little kernel that requires assert(...) to be available.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
     int i = 20;
     (void)i;
-    queue.submit([&](cl::sycl::handler& h) {
+    queue.submit([&](::sycl::handler& h) {
         h.parallel_for<class test_kernel>(
-            cl::sycl::range<1>(100), [=](cl::sycl::id<1>) { assert(i == 20); });
+            ::sycl::range<1>(100), [=](::sycl::id<1>) { assert(i == 20); });
     });
 
     // Return gracefully.

--- a/sycl/cmake/vecmem-setup-sycl.cmake
+++ b/sycl/cmake/vecmem-setup-sycl.cmake
@@ -25,11 +25,11 @@ function( vecmem_setup_sycl libName )
 
       # Check if sycl::local_accessor is available.
       vecmem_check_sycl_source_compiles( "
-         #include <CL/sycl.hpp>
+         #include <sycl/sycl.hpp>
          int main() {
-             cl::sycl::queue queue;
-             queue.submit([](cl::sycl::handler& h) {
-                 cl::sycl::local_accessor<int> dummy(10, h);
+             ::sycl::queue queue;
+             queue.submit([](::sycl::handler& h) {
+                 ::sycl::local_accessor<int> dummy(10, h);
                  (void)dummy;
              }).wait_and_throw();
              return 0;

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,7 +25,7 @@ struct async_copy_data;
 ///
 /// Unlike @c vecmem::cuda::copy and @c vecmem::hip::copy, this object does
 /// have a state. As USM memory operations in SYCL happen through a
-/// @c cl::sycl::queue object. So this object needs to point to a valid
+/// @c ::sycl::queue object. So this object needs to point to a valid
 /// queue object itself.
 ///
 /// Different to @c vecmem::sycl::copy, this type performs operations

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,7 +25,7 @@ struct copy_data;
 ///
 /// Unlike @c vecmem::cuda::copy and @c vecmem::hip::copy, this object does
 /// have a state. As USM memory operations in SYCL happen through a
-/// @c cl::sycl::queue object. So this object needs to point to a valid
+/// @c ::sycl::queue object. So this object needs to point to a valid
 /// queue object itself.
 ///
 class copy : public vecmem::copy {

--- a/sycl/include/vecmem/utils/sycl/local_accessor.hpp
+++ b/sycl/include/vecmem/utils/sycl/local_accessor.hpp
@@ -1,12 +1,12 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
 
-// Cowardly don't include <CL/sycl.hpp> here, leave it up to the user to
+// Cowardly don't include <sycl/sycl.hpp> here, leave it up to the user to
 // do that. This way the vecmem::sycl library doesn't have to set up an
 // explicit public dependency on the SYCL headers.
 
@@ -21,7 +21,7 @@ namespace vecmem::sycl {
 /// @tparam DIM Dimensions for the local memory array.
 ///
 template <typename T, int DIM = 1>
-using local_accessor = cl::sycl::local_accessor<T, DIM>;
+using local_accessor = ::sycl::local_accessor<T, DIM>;
 
 #elif (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
 
@@ -32,8 +32,8 @@ using local_accessor = cl::sycl::local_accessor<T, DIM>;
 ///
 template <typename T, int DIM = 1>
 using local_accessor =
-    cl::sycl::accessor<T, DIM, cl::sycl::access::mode::read_write,
-                       cl::sycl::access::target::local>;
+    ::sycl::accessor<T, DIM, ::sycl::access::mode::read_write,
+                     ::sycl::access::target::local>;
 
 #endif  // VECMEM_HAVE_SYCL_LOCAL_ACCESSOR
 

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,7 +19,7 @@ namespace details {
 class opaque_queue;
 }
 
-/// Wrapper class for @c cl::sycl::queue
+/// Wrapper class for @c ::sycl::queue
 ///
 /// It is necessary for passing around SYCL queue objects in code that should
 /// not be directly exposed to the SYCL headers.
@@ -30,7 +30,7 @@ public:
     /// Construct a queue for the default device
     VECMEM_SYCL_EXPORT
     queue_wrapper();
-    /// Wrap an existing @c cl::sycl::queue object
+    /// Wrap an existing @c ::sycl::queue object
     ///
     /// Without taking ownership of it!
     ///
@@ -62,18 +62,18 @@ public:
     VECMEM_SYCL_EXPORT
     queue_wrapper& operator=(queue_wrapper&& rhs);
 
-    /// Access a typeless pointer to the managed @c cl::sycl::queue object
+    /// Access a typeless pointer to the managed @c ::sycl::queue object
     VECMEM_SYCL_EXPORT
     void* queue();
-    /// Access a typeless pointer to the managed @c cl::sycl::queue object
+    /// Access a typeless pointer to the managed @c ::sycl::queue object
     VECMEM_SYCL_EXPORT
     const void* queue() const;
 
 private:
-    /// Bare pointer to the wrapped @c cl::sycl::queue object
+    /// Bare pointer to the wrapped @c ::sycl::queue object
     void* m_queue;
 
-    /// Smart pointer to the managed @c cl::sycl::queue object
+    /// Smart pointer to the managed @c ::sycl::queue object
     std::unique_ptr<details::opaque_queue> m_managedQueue;
 
 };  // class queue_wrapper

--- a/sycl/src/memory/device_memory_resource.sycl
+++ b/sycl/src/memory/device_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,7 +11,7 @@
 #include "vecmem/utils/debug.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl {
 
@@ -28,8 +28,8 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
     }
 
     // Allocate the memory.
-    void* result = cl::sycl::aligned_alloc_device(alignment, nbytes,
-                                                  details::get_queue(m_queue));
+    void* result = ::sycl::aligned_alloc_device(alignment, nbytes,
+                                                details::get_queue(m_queue));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {
@@ -42,7 +42,7 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
         nbytes, alignment,
         details::get_queue(m_queue)
             .get_device()
-            .get_info<cl::sycl::info::device::name>()
+            .get_info<::sycl::info::device::name>()
             .c_str(),
         result);
 

--- a/sycl/src/memory/host_memory_resource.sycl
+++ b/sycl/src/memory/host_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,7 +11,7 @@
 #include "vecmem/utils/debug.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl {
 
@@ -28,8 +28,8 @@ void* host_memory_resource::do_allocate(std::size_t nbytes,
     }
 
     // Allocate the memory.
-    void* result = cl::sycl::aligned_alloc_host(alignment, nbytes,
-                                                details::get_queue(m_queue));
+    void* result = ::sycl::aligned_alloc_host(alignment, nbytes,
+                                              details::get_queue(m_queue));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {

--- a/sycl/src/memory/memory_resource_base.sycl
+++ b/sycl/src/memory/memory_resource_base.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,7 +11,7 @@
 #include "vecmem/utils/debug.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl::details {
 
@@ -28,7 +28,7 @@ void memory_resource_base::do_deallocate(void* ptr, std::size_t, std::size_t) {
 
     // Free the memory.
     VECMEM_DEBUG_MSG(2, "De-allocating memory at %p", ptr);
-    cl::sycl::free(ptr, get_queue(m_queue));
+    ::sycl::free(ptr, get_queue(m_queue));
 }
 
 bool memory_resource_base::do_is_equal(

--- a/sycl/src/memory/shared_memory_resource.sycl
+++ b/sycl/src/memory/shared_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -11,7 +11,7 @@
 #include "vecmem/utils/debug.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl {
 
@@ -28,8 +28,8 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
     }
 
     // Allocate the memory.
-    void* result = cl::sycl::aligned_alloc_shared(alignment, nbytes,
-                                                  details::get_queue(m_queue));
+    void* result = ::sycl::aligned_alloc_shared(alignment, nbytes,
+                                                details::get_queue(m_queue));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {
@@ -42,7 +42,7 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
         nbytes, alignment,
         details::get_queue(m_queue)
             .get_device()
-            .get_info<cl::sycl::info::device::name>()
+            .get_info<::sycl::info::device::name>()
             .c_str(),
         result);
 

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -7,7 +7,7 @@
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // VecMem include(s).
 #include "get_queue.hpp"
@@ -24,7 +24,7 @@ namespace {
 struct sycl_event : public vecmem::abstract_event {
 
     /// Constructor with a SYCL event
-    sycl_event(const std::vector<cl::sycl::event>& events) : m_events(events) {}
+    sycl_event(const std::vector<::sycl::event>& events) : m_events(events) {}
     /// Destructor
     ~sycl_event() {
         // Check if the user forgot to wait on this asynchronous event.
@@ -41,7 +41,7 @@ struct sycl_event : public vecmem::abstract_event {
 
     /// Synchronize on the underlying SYCL event
     virtual void wait() override {
-        cl::sycl::event::wait_and_throw(m_events);
+        ::sycl::event::wait_and_throw(m_events);
         ignore();
     }
 
@@ -49,7 +49,7 @@ struct sycl_event : public vecmem::abstract_event {
     virtual void ignore() override { m_events.clear(); }
 
     /// The managed SYCL event
-    std::vector<cl::sycl::event> m_events;
+    std::vector<::sycl::event> m_events;
 
 };  // struct sycl_event
 
@@ -60,7 +60,7 @@ namespace details {
 
 struct async_copy_data {
     queue_wrapper m_queue;
-    std::vector<cl::sycl::event> m_events;
+    std::vector<::sycl::event> m_events;
 };
 
 }  // namespace details

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -1,13 +1,13 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // VecMem include(s).
 #include "get_queue.hpp"

--- a/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
+++ b/sycl/src/utils/sycl/cuda_assert_polyfill.sycl
@@ -1,12 +1,12 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // I can't figure out how to make the __assert_fail(...) function noreturn. :-(
 // So for now let's just silence this warning from the compiler.

--- a/sycl/src/utils/sycl/get_queue.hpp
+++ b/sycl/src/utils/sycl/get_queue.hpp
@@ -14,11 +14,11 @@
 
 namespace vecmem::sycl::details {
 
-/// Helper function for getting a @c cl::sycl::queue out of
+/// Helper function for getting a @c ::sycl::queue out of
 /// @c vecmem::sycl::queue_wrapper (non-const)
 ::sycl::queue& get_queue(vecmem::sycl::queue_wrapper& queue);
 
-/// Helper function for getting a @c cl::sycl::queue out of
+/// Helper function for getting a @c ::sycl::queue out of
 /// @c vecmem::sycl::queue_wrapper (const)
 const ::sycl::queue& get_queue(const vecmem::sycl::queue_wrapper& queue);
 

--- a/sycl/src/utils/sycl/get_queue.hpp
+++ b/sycl/src/utils/sycl/get_queue.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,16 +10,16 @@
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl::details {
 
 /// Helper function for getting a @c cl::sycl::queue out of
 /// @c vecmem::sycl::queue_wrapper (non-const)
-cl::sycl::queue& get_queue(vecmem::sycl::queue_wrapper& queue);
+::sycl::queue& get_queue(vecmem::sycl::queue_wrapper& queue);
 
 /// Helper function for getting a @c cl::sycl::queue out of
 /// @c vecmem::sycl::queue_wrapper (const)
-const cl::sycl::queue& get_queue(const vecmem::sycl::queue_wrapper& queue);
+const ::sycl::queue& get_queue(const vecmem::sycl::queue_wrapper& queue);
 
 }  // namespace vecmem::sycl::details

--- a/sycl/src/utils/sycl/get_queue.sycl
+++ b/sycl/src/utils/sycl/get_queue.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,16 +13,16 @@
 
 namespace vecmem::sycl::details {
 
-cl::sycl::queue& get_queue(vecmem::sycl::queue_wrapper& queue) {
+::sycl::queue& get_queue(vecmem::sycl::queue_wrapper& queue) {
 
     assert(queue.queue() != nullptr);
-    return *(reinterpret_cast<cl::sycl::queue*>(queue.queue()));
+    return *(reinterpret_cast<::sycl::queue*>(queue.queue()));
 }
 
-const cl::sycl::queue& get_queue(const vecmem::sycl::queue_wrapper& queue) {
+const ::sycl::queue& get_queue(const vecmem::sycl::queue_wrapper& queue) {
 
     assert(queue.queue() != nullptr);
-    return *(reinterpret_cast<const cl::sycl::queue*>(queue.queue()));
+    return *(reinterpret_cast<const ::sycl::queue*>(queue.queue()));
 }
 
 }  // namespace vecmem::sycl::details

--- a/sycl/src/utils/sycl/opaque_queue.hpp
+++ b/sycl/src/utils/sycl/opaque_queue.hpp
@@ -1,20 +1,20 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl::details {
 
 /// Helper class for managing queue objects in memory
-class opaque_queue : public cl::sycl::queue {
+class opaque_queue : public ::sycl::queue {
 public:
-    using cl::sycl::queue::queue;
+    using ::sycl::queue::queue;
 };
 
 }  // namespace vecmem::sycl::details

--- a/sycl/src/utils/sycl/queue_wrapper.sycl
+++ b/sycl/src/utils/sycl/queue_wrapper.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,7 +12,7 @@
 #include "vecmem/utils/sycl/queue_wrapper.hpp"
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace vecmem::sycl {
 
@@ -26,7 +26,7 @@ queue_wrapper::queue_wrapper()
                      "device: %s",
                      details::get_queue(*this)
                          .get_device()
-                         .get_info<cl::sycl::info::device::name>()
+                         .get_info<::sycl::info::device::name>()
                          .c_str());
 }
 
@@ -37,7 +37,7 @@ queue_wrapper::queue_wrapper(void* queue) : m_queue(queue), m_managedQueue() {
                      "device: %s",
                      details::get_queue(*this)
                          .get_device()
-                         .get_info<cl::sycl::info::device::name>()
+                         .get_info<::sycl::info::device::name>()
                          .c_str());
 }
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -35,7 +35,7 @@ vecmem_add_test( core
 # Add UBSAN for the tests, if it's available.
 include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
-if( VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN AND VECMEM_TEST_UBSAN )
    target_compile_options( vecmem_test_core PRIVATE "-fsanitize=undefined" )
    target_link_options( vecmem_test_core PRIVATE "-fsanitize=undefined" )
 endif()

--- a/tests/cuda/CMakeLists.txt
+++ b/tests/cuda/CMakeLists.txt
@@ -59,7 +59,7 @@ vecmem_add_test( cuda
 # Add UBSAN for the tests, if it's available.
 include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
-if( VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN AND VECMEM_TEST_UBSAN )
    target_compile_options( vecmem_test_cuda PRIVATE
       $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=undefined> )
    target_link_options( vecmem_test_cuda PRIVATE "-fsanitize=undefined" )

--- a/tests/hip/CMakeLists.txt
+++ b/tests/hip/CMakeLists.txt
@@ -30,7 +30,7 @@ vecmem_add_test( hip
 # Add UBSAN for the tests, if it's available.
 include( CheckCXXCompilerFlag )
 check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
-if( VECMEM_HAVE_UBSAN )
+if( VECMEM_HAVE_UBSAN AND VECMEM_TEST_UBSAN )
    target_compile_options( vecmem_test_hip PRIVATE
       $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=undefined> )
    target_link_options( vecmem_test_hip PRIVATE "-fsanitize=undefined" )

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -31,7 +31,7 @@ vecmem_check_sycl_source_compiles( "
    int main() { return 0; }
    " VECMEM_HAVE_SYCL_UBSAN
    CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fsanitize=undefined )
-if( VECMEM_HAVE_UBSAN AND VECMEM_HAVE_SYCL_UBSAN )
+if( VECMEM_HAVE_UBSAN AND VECMEM_HAVE_SYCL_UBSAN AND VECMEM_TEST_UBSAN )
    target_compile_options( vecmem_test_sycl PRIVATE "-fsanitize=undefined" )
    target_link_options( vecmem_test_sycl PRIVATE "-fsanitize=undefined" )
 endif()

--- a/tests/sycl/CMakeLists.txt
+++ b/tests/sycl/CMakeLists.txt
@@ -27,7 +27,7 @@ vecmem_add_test( sycl
 # Add UBSAN for the tests, if it's available.
 check_cxx_compiler_flag( "-fsanitize=undefined" VECMEM_HAVE_UBSAN )
 vecmem_check_sycl_source_compiles( "
-   #include <CL/sycl.hpp>
+   #include <sycl/sycl.hpp>
    int main() { return 0; }
    " VECMEM_HAVE_SYCL_UBSAN
    CMAKE_FLAGS -DCOMPILE_DEFINITIONS=-fsanitize=undefined )

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -6,7 +6,7 @@
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // Local include(s).
 #include "vecmem/containers/array.hpp"
@@ -37,7 +37,7 @@ class sycl_containers_test : public testing::Test {};
 TEST_F(sycl_containers_test, shared_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The shared memory resource.
     vecmem::sycl::shared_memory_resource resource(&queue);
@@ -54,13 +54,13 @@ TEST_F(sycl_containers_test, shared_memory) {
 
     // Perform a linear transformation using the vecmem vector helper types.
     queue
-        .submit([&constants, &inputvec, &outputvec](cl::sycl::handler& h) {
+        .submit([&constants, &inputvec, &outputvec](::sycl::handler& h) {
             // Run the kernel.
             h.parallel_for<class LinearTransform1>(
-                cl::sycl::range<1>(inputvec.size()),
+                ::sycl::range<1>(inputvec.size()),
                 [constants = vecmem::get_data(constants),
                  input = vecmem::get_data(inputvec),
-                 output = vecmem::get_data(outputvec)](cl::sycl::id<1> id) {
+                 output = vecmem::get_data(outputvec)](::sycl::id<1> id) {
                     // Skip invalid indices.
                     const vecmem::device_vector<int>::size_type i =
                         static_cast<vecmem::device_vector<int>::size_type>(
@@ -102,7 +102,7 @@ TEST_F(sycl_containers_test, shared_memory) {
 TEST_F(sycl_containers_test, device_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resources.
     vecmem::sycl::host_memory_resource host_resource(&queue);
@@ -139,14 +139,13 @@ TEST_F(sycl_containers_test, device_memory) {
     // Perform a linear transformation using the vecmem vector helper types.
     queue
         .submit([&const_data, &input_data,
-                 &outputvecdevice](cl::sycl::handler& h) {
+                 &outputvecdevice](::sycl::handler& h) {
             // Run the kernel.
             h.parallel_for<class LinearTransform2>(
-                cl::sycl::range<1>(input_data.size()),
+                ::sycl::range<1>(input_data.size()),
                 [constants = vecmem::get_data(const_data),
                  input = vecmem::get_data(input_data),
-                 output =
-                     vecmem::get_data(outputvecdevice)](cl::sycl::id<1> id) {
+                 output = vecmem::get_data(outputvecdevice)](::sycl::id<1> id) {
                     // Skip invalid indices.
                     const vecmem::device_vector<int>::size_type i =
                         static_cast<vecmem::device_vector<int>::size_type>(
@@ -185,7 +184,7 @@ TEST_F(sycl_containers_test, device_memory) {
 TEST_F(sycl_containers_test, atomic_shared_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resources.
     vecmem::sycl::shared_memory_resource resource(&queue);
@@ -198,10 +197,10 @@ TEST_F(sycl_containers_test, atomic_shared_memory) {
 
     // Do very basic atomic modifications on the buffer.
     queue
-        .submit([&buffer](cl::sycl::handler& h) {
+        .submit([&buffer](::sycl::handler& h) {
             h.parallel_for<class AtomicSharedTests>(
-                cl::sycl::range<1>(buffer.size() * ITERATIONS),
-                [buffer = vecmem::get_data(buffer)](cl::sycl::item<1> id) {
+                ::sycl::range<1>(buffer.size() * ITERATIONS),
+                [buffer = vecmem::get_data(buffer)](::sycl::item<1> id) {
                     // Check if anything needs to be done.
                     const std::size_t i = id[0];
                     if (i >= buffer.size() * ITERATIONS) {
@@ -216,7 +215,7 @@ TEST_F(sycl_containers_test, atomic_shared_memory) {
                     vecmem::atomic<int> a(ptr);
                     a.fetch_add(4);
                     a.fetch_sub(2);
-                    a.fetch_and(0xffffffff);
+                    a.fetch_and(0x7fffffff);
                     a.fetch_or(0x00000000);
 
                     // Do the same simple stuff with it using
@@ -224,7 +223,7 @@ TEST_F(sycl_containers_test, atomic_shared_memory) {
                     vecmem::device_atomic_ref<int> a2(*ptr);
                     a2.fetch_add(4);
                     a2.fetch_sub(2);
-                    a2.fetch_and(0xffffffff);
+                    a2.fetch_and(0x7fffffff);
                     a2.fetch_or(0x00000000);
                 });
         })
@@ -240,7 +239,7 @@ TEST_F(sycl_containers_test, atomic_shared_memory) {
 TEST_F(sycl_containers_test, atomic_device_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resources.
     vecmem::sycl::host_memory_resource host_resource(&queue);
@@ -261,11 +260,10 @@ TEST_F(sycl_containers_test, atomic_device_memory) {
 
     // Do very basic atomic modifications on the buffer.
     queue
-        .submit([&device_buffer](cl::sycl::handler& h) {
+        .submit([&device_buffer](::sycl::handler& h) {
             h.parallel_for<class AtomicDeviceTests>(
-                cl::sycl::range<1>(device_buffer.size() * ITERATIONS),
-                [buffer =
-                     vecmem::get_data(device_buffer)](cl::sycl::item<1> id) {
+                ::sycl::range<1>(device_buffer.size() * ITERATIONS),
+                [buffer = vecmem::get_data(device_buffer)](::sycl::item<1> id) {
                     // Check if anything needs to be done.
                     const std::size_t i = id[0];
                     if (i >= buffer.size() * ITERATIONS) {
@@ -280,7 +278,7 @@ TEST_F(sycl_containers_test, atomic_device_memory) {
                     vecmem::atomic<int> a(ptr);
                     a.fetch_add(4);
                     a.fetch_sub(2);
-                    a.fetch_and(0xffffffff);
+                    a.fetch_and(0x7fffffff);
                     a.fetch_or(0x00000000);
 
                     // Do the same simple stuff with it using
@@ -288,7 +286,7 @@ TEST_F(sycl_containers_test, atomic_device_memory) {
                     vecmem::device_atomic_ref<int> a2(*ptr);
                     a2.fetch_add(4);
                     a2.fetch_sub(2);
-                    a2.fetch_and(0xffffffff);
+                    a2.fetch_and(0x7fffffff);
                     a2.fetch_or(0x00000000);
                 });
         })
@@ -307,11 +305,11 @@ TEST_F(sycl_containers_test, atomic_device_memory) {
 TEST_F(sycl_containers_test, atomic_local_ref) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // Skip test if not running on a gpu.
-    if (queue.get_device().get_info<cl::sycl::info::device::device_type>() !=
-        cl::sycl::info::device_type::gpu) {
+    if (queue.get_device().get_info<::sycl::info::device::device_type>() !=
+        ::sycl::info::device_type::gpu) {
         GTEST_SKIP();
     }
 
@@ -337,13 +335,13 @@ TEST_F(sycl_containers_test, atomic_local_ref) {
 
     // Do basic atomic addition on local memory.
     queue
-        .submit([&device_buffer](cl::sycl::handler& h) {
+        .submit([&device_buffer](::sycl::handler& h) {
             vecmem::sycl::local_accessor<int> shared(1, h);
 
             h.parallel_for<class AtomicLocalRefTests>(
-                cl::sycl::nd_range<1>(BLOCKSIZE * NUMBLOCKS, BLOCKSIZE),
+                ::sycl::nd_range<1>(BLOCKSIZE * NUMBLOCKS, BLOCKSIZE),
                 [buffer = vecmem::get_data(device_buffer),
-                 shared](cl::sycl::nd_item<1> item) {
+                 shared](::sycl::nd_item<1> item) {
                     // Do simple stuff using local atomic ref
                     const int i = item.get_group_linear_id();
 
@@ -359,7 +357,7 @@ TEST_F(sycl_containers_test, atomic_local_ref) {
                         atom(shared[0]);
                     atom.fetch_add(2 * i);
                     atom.fetch_sub(i);
-                    atom.fetch_and(0xffffffff);
+                    atom.fetch_and(0x7fffffff);
                     atom.fetch_or(0x00000000);
 
                     // Wait for work to be done
@@ -387,7 +385,7 @@ TEST_F(sycl_containers_test, atomic_local_ref) {
 TEST_F(sycl_containers_test, extendable_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resources.
     vecmem::sycl::host_memory_resource host_resource(&queue);
@@ -411,12 +409,11 @@ TEST_F(sycl_containers_test, extendable_memory) {
 
     // Run a kernel that filters the elements of the input vector.
     queue
-        .submit([&input, &output_buffer](cl::sycl::handler& h) {
+        .submit([&input, &output_buffer](::sycl::handler& h) {
             h.parallel_for<class FilterTests>(
-                cl::sycl::range<1>(input.size()),
+                ::sycl::range<1>(input.size()),
                 [input = vecmem::get_data(input),
-                 output =
-                     vecmem::get_data(output_buffer)](cl::sycl::item<1> id) {
+                 output = vecmem::get_data(output_buffer)](::sycl::item<1> id) {
                     // Check if anything needs to be done.
                     const vecmem::device_vector<int>::size_type i =
                         static_cast<vecmem::device_vector<int>::size_type>(
@@ -453,7 +450,7 @@ TEST_F(sycl_containers_test, extendable_memory) {
 TEST_F(sycl_containers_test, array_memory) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resource(s).
     vecmem::sycl::shared_memory_resource shared_resource(&queue);
@@ -473,10 +470,9 @@ TEST_F(sycl_containers_test, array_memory) {
     // Run a kernel on it that multiplies each element in the array of vectors
     // by 2.
     queue
-        .submit([&vec_data](cl::sycl::handler& h) {
+        .submit([&vec_data](::sycl::handler& h) {
             h.parallel_for<class ArrayVecTest>(
-                cl::sycl::range<2>(4, 4),
-                [data = vec_data](cl::sycl::item<2> id) {
+                ::sycl::range<2>(4, 4), [data = vec_data](::sycl::item<2> id) {
                     // Check if anything needs to be done.
                     if (id[0] >= data.size()) {
                         return;
@@ -515,7 +511,7 @@ TEST_F(sycl_containers_test, array_memory) {
 TEST_F(sycl_containers_test, large_buffer) {
 
     // Create the SYCL queue that we'll be using in the test.
-    cl::sycl::queue queue;
+    ::sycl::queue queue;
 
     // The memory resource(s).
     vecmem::sycl::shared_memory_resource shared_resource{&queue};
@@ -530,10 +526,10 @@ TEST_F(sycl_containers_test, large_buffer) {
 
     // Run a kernel that enlarges the (1D) buffer.
     queue
-        .submit([&buffer1](cl::sycl::handler& h) {
+        .submit([&buffer1](::sycl::handler& h) {
             h.parallel_for<class BufferResize>(
-                cl::sycl::range<1>(1),
-                [data = vecmem::get_data(buffer1)](cl::sycl::item<1> id) {
+                ::sycl::range<1>(1),
+                [data = vecmem::get_data(buffer1)](::sycl::item<1> id) {
                     // Check if anything needs to be done.
                     if (id[0] != 0) {
                         return;
@@ -562,10 +558,10 @@ TEST_F(sycl_containers_test, large_buffer) {
 
     // Run a kernel that enlarges the (jagged) buffer.
     queue
-        .submit([&buffer2](cl::sycl::handler& h) {
+        .submit([&buffer2](::sycl::handler& h) {
             h.parallel_for<class JaggedBufferResize>(
-                cl::sycl::range<1>(1),
-                [data = vecmem::get_data(buffer2)](cl::sycl::item<1> id) {
+                ::sycl::range<1>(1),
+                [data = vecmem::get_data(buffer2)](::sycl::item<1> id) {
                     // Check if anything needs to be done.
                     if (id[0] != 0) {
                         return;

--- a/tests/sycl/test_sycl_edm.sycl
+++ b/tests/sycl/test_sycl_edm.sycl
@@ -5,6 +5,9 @@
  * Mozilla Public License Version 2.0
  */
 
+// SYCL include(s).
+#include <sycl/sycl.hpp>
+
 // Local include(s).
 #include "../common/jagged_soa_container.hpp"
 #include "../common/jagged_soa_container_helpers.hpp"
@@ -21,11 +24,8 @@
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
-// SYCL include(s).
-#include <CL/sycl.hpp>
-
 /// SYCL queue to use in the tests.
-static cl::sycl::queue queue;
+static ::sycl::queue queue;
 
 /// Host memory resource to use in the tests.
 static vecmem::sycl::host_memory_resource sycl_host_mr{&queue};
@@ -41,10 +41,9 @@ static vecmem::sycl::copy sycl_copy{&queue};
 bool syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
 
     queue
-        .submit([&view](cl::sycl::handler& h) {
+        .submit([&view](::sycl::handler& h) {
             h.parallel_for<class edm_simple_fill>(
-                cl::sycl::range<1>{view.capacity()},
-                [view](cl::sycl::id<1> id) {
+                ::sycl::range<1>{view.capacity()}, [view](::sycl::id<1> id) {
                     vecmem::testing::simple_soa_container::device device{view};
                     vecmem::testing::fill(id[0], device);
                 });
@@ -57,15 +56,14 @@ bool syclSimpleFill(vecmem::testing::simple_soa_container::view view) {
 bool syclJaggedFill(vecmem::testing::jagged_soa_container::view view) {
 
     // Skip test if FP64 instructions are not available on the device.
-    if (queue.get_device().has(cl::sycl::aspect::fp64) == false) {
+    if (queue.get_device().has(::sycl::aspect::fp64) == false) {
         return false;
     }
 
     queue
-        .submit([&view](cl::sycl::handler& h) {
+        .submit([&view](::sycl::handler& h) {
             h.parallel_for<class edm_jagged_fill>(
-                cl::sycl::range<1>{view.capacity()},
-                [view](cl::sycl::id<1> id) {
+                ::sycl::range<1>{view.capacity()}, [view](::sycl::id<1> id) {
                     vecmem::testing::jagged_soa_container::device device{view};
                     vecmem::testing::fill(id[0], device);
                 });
@@ -78,10 +76,9 @@ bool syclJaggedFill(vecmem::testing::jagged_soa_container::view view) {
 bool syclSimpleModify(vecmem::testing::simple_soa_container::view view) {
 
     queue
-        .submit([&view](cl::sycl::handler& h) {
+        .submit([&view](::sycl::handler& h) {
             h.parallel_for<class edm_simple_modify>(
-                cl::sycl::range<1>{view.capacity()},
-                [view](cl::sycl::id<1> id) {
+                ::sycl::range<1>{view.capacity()}, [view](::sycl::id<1> id) {
                     vecmem::testing::simple_soa_container::device device{view};
                     vecmem::testing::modify(id[0], device);
                 });
@@ -94,15 +91,14 @@ bool syclSimpleModify(vecmem::testing::simple_soa_container::view view) {
 bool syclJaggedModify(vecmem::testing::jagged_soa_container::view view) {
 
     // Skip test if FP64 instructions are not available on the device.
-    if (queue.get_device().has(cl::sycl::aspect::fp64) == false) {
+    if (queue.get_device().has(::sycl::aspect::fp64) == false) {
         return false;
     }
 
     queue
-        .submit([&view](cl::sycl::handler& h) {
+        .submit([&view](::sycl::handler& h) {
             h.parallel_for<class edm_jagged_modify>(
-                cl::sycl::range<1>{view.capacity()},
-                [view](cl::sycl::id<1> id) {
+                ::sycl::range<1>{view.capacity()}, [view](::sycl::id<1> id) {
                     vecmem::testing::jagged_soa_container::device device{view};
                     vecmem::testing::modify(id[0], device);
                 });

--- a/tests/sycl/test_sycl_jagged_containers.sycl
+++ b/tests/sycl/test_sycl_jagged_containers.sycl
@@ -1,12 +1,12 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 // SYCL include(s).
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 // VecMem include(s).
 #include "vecmem/containers/array.hpp"
@@ -51,7 +51,7 @@ public:
 
 protected:
     // SYCL queue used in the tests
-    cl::sycl::queue m_queue;
+    ::sycl::queue m_queue;
     /// Shared (managed) memory resource
     vecmem::sycl::shared_memory_resource m_mem;
     /// The base vector to perform tests with
@@ -75,7 +75,7 @@ public:
     }
 
     /// Operator executing the functor in a single thread
-    void operator()(cl::sycl::id<1> id) const {
+    void operator()(::sycl::id<1> id) const {
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
@@ -118,7 +118,7 @@ public:
         : m_data(data) {}
 
     /// Operator executing the functor in a single thread
-    void operator()(cl::sycl::id<1> id) const {
+    void operator()(::sycl::id<1> id) const {
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
@@ -158,7 +158,7 @@ public:
     FillKernel(vecmem::data::jagged_vector_view<int> view) : m_view(view) {}
 
     /// Operator implementing the functor
-    void operator()(cl::sycl::id<1> id) const {
+    void operator()(::sycl::id<1> id) const {
 
         // Check if anything needs to be done.
         const std::size_t i = id[0];
@@ -191,21 +191,21 @@ TEST_F(sycl_jagged_containers_test, mutate_in_kernel) {
 
     // Run the linear transformation.
     m_queue
-        .submit([&const_data, &vec_data](cl::sycl::handler& h) {
+        .submit([&const_data, &vec_data](::sycl::handler& h) {
             // Create the kernel functor.
             LinearTransformKernel kernel(const_data, vec_data, vec_data);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(vec_data.size()), kernel);
+                ::sycl::range<1>(vec_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
     m_queue
-        .submit([&vec_data](cl::sycl::handler& h) {
+        .submit([&vec_data](::sycl::handler& h) {
             // Create the kernel functor.
             SummationKernel kernel(vec_data);
             // Execute this kernel.
-            h.parallel_for<SummationKernel>(cl::sycl::range<1>(vec_data.size()),
+            h.parallel_for<SummationKernel>(::sycl::range<1>(vec_data.size()),
                                             kernel);
         })
         .wait_and_throw();
@@ -255,23 +255,23 @@ TEST_F(sycl_jagged_containers_test, set_in_kernel) {
     // Run the linear transformation.
     m_queue
         .submit([&const_data, &input_data,
-                 &output_data_device](cl::sycl::handler& h) {
+                 &output_data_device](::sycl::handler& h) {
             // Create the kernel functor.
             LinearTransformKernel kernel(const_data, input_data,
                                          output_data_device);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(input_data.size()), kernel);
+                ::sycl::range<1>(input_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
     m_queue
-        .submit([&output_data_device](cl::sycl::handler& h) {
+        .submit([&output_data_device](::sycl::handler& h) {
             // Create the kernel functor.
             SummationKernel kernel(output_data_device);
             // Execute this kernel.
             h.parallel_for<SummationKernel>(
-                cl::sycl::range<1>(output_data_device.size()), kernel);
+                ::sycl::range<1>(output_data_device.size()), kernel);
         })
         .wait_and_throw();
 
@@ -330,23 +330,23 @@ TEST_F(sycl_jagged_containers_test, set_in_contiguous_kernel) {
     // Run the linear transformation.
     m_queue
         .submit([&const_data, &input_data,
-                 &output_data_device](cl::sycl::handler& h) {
+                 &output_data_device](::sycl::handler& h) {
             // Create the kernel functor.
             LinearTransformKernel kernel(const_data, input_data,
                                          output_data_device);
             // Execute this kernel.
             h.parallel_for<LinearTransformKernel>(
-                cl::sycl::range<1>(input_data.size()), kernel);
+                ::sycl::range<1>(input_data.size()), kernel);
         })
         .wait_and_throw();
     // Run the summation.
     m_queue
-        .submit([&output_data_device](cl::sycl::handler& h) {
+        .submit([&output_data_device](::sycl::handler& h) {
             // Create the kernel functor.
             SummationKernel kernel(output_data_device);
             // Execute this kernel.
             h.parallel_for<SummationKernel>(
-                cl::sycl::range<1>(output_data_device.size()), kernel);
+                ::sycl::range<1>(output_data_device.size()), kernel);
         })
         .wait_and_throw();
 
@@ -393,12 +393,12 @@ TEST_F(sycl_jagged_containers_test, filter) {
 
     // Run the filtering.
     m_queue
-        .submit([&input_data, &output_data_device](cl::sycl::handler& h) {
+        .submit([&input_data, &output_data_device](::sycl::handler& h) {
             h.parallel_for<class FilterKernel>(
-                cl::sycl::range<2>(input_data.size(), 5),
+                ::sycl::range<2>(input_data.size(), 5),
                 [input = vecmem::get_data(input_data),
-                 output = vecmem::get_data(output_data_device)](
-                    cl::sycl::item<2> id) {
+                 output =
+                     vecmem::get_data(output_data_device)](::sycl::item<2> id) {
                     // Skip invalid indices.
                     if (id[0] >= input.size()) {
                         return;
@@ -465,11 +465,11 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
 
     // Run the vector filling.
     m_queue
-        .submit([&managed_data](cl::sycl::handler& h) {
+        .submit([&managed_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(managed_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(managed_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(managed_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -495,11 +495,11 @@ TEST_F(sycl_jagged_containers_test, zero_capacity) {
 
     // Run the vector filling.
     m_queue
-        .submit([&device_data](cl::sycl::handler& h) {
+        .submit([&device_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(device_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(device_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(device_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -572,11 +572,11 @@ TEST_F(sycl_jagged_containers_test, sizeless) {
 
     // Run the vector filling.
     m_queue
-        .submit([&output_data](cl::sycl::handler& h) {
+        .submit([&output_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(output_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(output_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(output_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -607,11 +607,11 @@ TEST_F(sycl_jagged_containers_test, sizeless_fixed) {
 
     // Run the vector filling.
     m_queue
-        .submit([&output_data](cl::sycl::handler& h) {
+        .submit([&output_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(output_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(output_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(output_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -642,11 +642,11 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless) {
 
     // Run the vector filling.
     m_queue
-        .submit([&output_data](cl::sycl::handler& h) {
+        .submit([&output_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(output_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(output_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(output_data.size()),
                                        kernel);
         })
         .wait_and_throw();
@@ -681,11 +681,11 @@ TEST_F(sycl_jagged_containers_test, partially_sizeless_fixed) {
 
     // Run the vector filling.
     m_queue
-        .submit([&output_data](cl::sycl::handler& h) {
+        .submit([&output_data](::sycl::handler& h) {
             // Create the kernel functor.
             FillKernel kernel(output_data);
             // Execute this kernel.
-            h.parallel_for<FillKernel>(cl::sycl::range<1>(output_data.size()),
+            h.parallel_for<FillKernel>(::sycl::range<1>(output_data.size()),
                                        kernel);
         })
         .wait_and_throw();


### PR DESCRIPTION
Triggered by the release of [oneAPI 2025.0.0](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-toolkit-release-notes.html), which deprecates the `<CL/sycl.hpp>` include, I set out to make sure that the project would work with both oneAPI 2025.0.0 and [AdaptiveCpp 24.06.0](https://github.com/AdaptiveCpp/AdaptiveCpp/releases/tag/v24.06.0).

I had to do the following:
  - Replace all `<CL/sycl.hpp>` includes with `<sycl/sycl.hpp>`;
  - Replace all uses of the `cl::sycl::` namespace with `::sycl::`;
  - Teach the CMake code how to detect AdaptiveCpp, which now has a new command line flag (`--acpp-version`) for collecting the necessary info;
  - Make sure that I would use consistent argument types in `vecmem::device_atomic_ref` function calls with the type that the atomic reference is created on top of;
    * The AdaptiveCpp code seem to be a little too templated in this respect. 🤔 As the following fails to compile (see https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1591):

```c++
vecmem::device_atomic_ref<unsigned int> foo(...);
foo.atomic_add(1);
```

  - Had to make it possible to turn off the use of UBSAN in the tests, as AdaptiveCpp seems to make the same mistake with exporting its symbols that we ourselves fixed in #282;
    * *Update:* According to https://github.com/AdaptiveCpp/AdaptiveCpp/issues/1283, it's a different issue after all. But the ability to turn off the usage of UBSAN on our end is still necessary.
  - Had to make sure that `<sycl/sycl.hpp>` would be included "early enough" in one of our tests, otherwise `device_atomic_ref.hpp` would select the wrong backend. Which I'm very surprised didn't hit us with oneAPI... 😕

With all of this in place, the code works relatively well like the following for instance:

```
> export SYCLCXX=/software/AdaptiveCpp/24.06.0/x86_64-el9-clang18-opt/bin/acpp
> export SYCLFLAGS="--acpp-targets='omp;cuda:sm_75;hip:gfx1031'"
> cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVECMEM_TEST_UBSAN=FALSE -DVECMEM_DEBUG_MSG_LVL=1 ../vecmem/
-- The CXX compiler identification is Clang 18.1.8
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /software/llvm/18.1.8/x86_64-el9-gcc11-opt/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
...
-- The SYCL compiler identification is AdaptiveCpp 24.06.0
-- Check for working SYCL compiler: /software/AdaptiveCpp/24.06.0/x86_64-el9-clang18-opt/bin/acpp
-- Check for working SYCL compiler: /software/AdaptiveCpp/24.06.0/x86_64-el9-clang18-opt/bin/acpp - works
-- Performing Test VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF
-- Performing Test VECMEM_HAVE_SYCL_EXT_ONEAPI_PRINTF - Failed
...
```

```
> ACPP_VISIBILITY_MASK=cuda ./bin/vecmem_test_sycl
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: NVIDIA RTX A5000
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: NVIDIA RTX A5000
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: NVIDIA RTX A5000
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: NVIDIA RTX A5000
Running main() from /mnt/hdd1/krasznaa/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 186 tests from 9 test suites.
[----------] Global test environment set-up.
[----------] 8 tests from sycl_containers_test
[ RUN      ] sycl_containers_test.shared_memory
[       OK ] sycl_containers_test.shared_memory (310 ms)
[ RUN      ] sycl_containers_test.device_memory
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 8 bytes from 0x7f5275600400 to 0x7f5275800200
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f5275600000 to 0x7f5275800400
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f5275800000 to 0x7f5275600200
[       OK ] sycl_containers_test.device_memory (2 ms)
[ RUN      ] sycl_containers_test.atomic_shared_memory
[       OK ] sycl_containers_test.atomic_shared_memory (0 ms)
...
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 56 bytes from 0x7f5275601374 to 0x7f525a006c00
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f52756013c4 to 0x7f525a006e00
[       OK ] sycl_soa_copy_tests_jagged/soa_copy_tests_jagged.host_to_fixed_device_to_resizable_device_to_host/7 (3 ms)
[----------] 32 tests from sycl_soa_copy_tests_jagged/soa_copy_tests_jagged (107 ms total)

[----------] Global test environment tear-down
[==========] 186 tests from 9 test suites ran. (1048 ms total)
[  PASSED  ] 186 tests.
```

```
> ACPP_VISIBILITY_MASK=hip ./bin/vecmem_test_sycl
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: AMD Radeon RX 6700 XT
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: AMD Radeon RX 6700 XT
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: AMD Radeon RX 6700 XT
[vecmem] sycl/src/utils/sycl/queue_wrapper.sycl:30 Created an "owning wrapper" around a queue on device: AMD Radeon RX 6700 XT
Running main() from /mnt/hdd1/krasznaa/projects/vecmem/build/_deps/googletest-src/googletest/src/gtest_main.cc
[==========] Running 186 tests from 9 test suites.
[----------] Global test environment set-up.
[----------] 8 tests from sycl_containers_test
[ RUN      ] sycl_containers_test.shared_memory
[       OK ] sycl_containers_test.shared_memory (183 ms)
[ RUN      ] sycl_containers_test.device_memory
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 8 bytes from 0x7f297f7d0000 to 0x7f2869a01000
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f297f7d4000 to 0x7f2869a02000
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f2869a00000 to 0x7f297f7d2000
[       OK ] sycl_containers_test.device_memory (1 ms)
[ RUN      ] sycl_containers_test.atomic_shared_memory
[       OK ] sycl_containers_test.atomic_shared_memory (4 ms)
...
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 56 bytes from 0x7f2869a01b74 to 0x7f297f7d7000
[vecmem] sycl/src/utils/sycl/async_copy.sycl:92 Performed memory copy of 40 bytes from 0x7f2869a01bc4 to 0x7f297f7d5000
[       OK ] sycl_soa_copy_tests_jagged/soa_copy_tests_jagged.host_to_fixed_device_to_resizable_device_to_host/7 (5 ms)
[----------] 32 tests from sycl_soa_copy_tests_jagged/soa_copy_tests_jagged (166 ms total)

[----------] Global test environment tear-down
[==========] 186 tests from 9 test suites ran. (561 ms total)
[  PASSED  ] 186 tests.
```

The OpenMP backed tests don't all succeed, but that's something to worry about later... 🤔