### PR TITLE
SYCL Memset Fix, main branch (2024.11.06.)

### DIFF
--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -15,6 +15,7 @@
 #include "vecmem/utils/sycl/async_copy.hpp"
 
 // System include(s).
+#include <algorithm>
 #include <exception>
 #include <vector>
 
@@ -111,7 +112,9 @@ void async_copy::do_memset(std::size_t size, void* ptr, int value) const {
     // We can not perform this operation asynchronously, since the data used
     // in the copy only exists as long as this function is executing. So we
     // don't record this event, but rather wait it out right here.
-    const std::vector<int> dummy(size / sizeof(int) + 1, value);
+    std::vector<int> dummy(size / sizeof(int) + 1);
+    std::fill_n(reinterpret_cast<unsigned char*>(dummy.data()), size,
+                static_cast<unsigned char>(value));
     details::get_queue(m_data->m_queue)
         .memcpy(ptr, dummy.data(), size)
         .wait_and_throw();

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -15,6 +15,7 @@
 #include "vecmem/utils/sycl/copy.hpp"
 
 // System include(s).
+#include <algorithm>
 #include <vector>
 
 namespace vecmem::sycl {
@@ -71,7 +72,9 @@ void copy::do_memset(std::size_t size, void* ptr, int value) const {
         .memset(ptr, value, size)
         .wait_and_throw();
 #else
-    const std::vector<int> dummy(size / sizeof(int) + 1, value);
+    std::vector<int> dummy(size / sizeof(int) + 1);
+    std::fill_n(reinterpret_cast<unsigned char*>(dummy.data()), size,
+                static_cast<unsigned char>(value));
     details::get_queue(m_data->m_queue)
         .memcpy(ptr, dummy.data(), size)
         .wait_and_throw();


### PR DESCRIPTION
Fixing `vecmem::sycl::copy::memset` and `vecmem::sycl::async_copy::memset` in the absence of `::sycl::queue::memset`.

I came across this issue while making a mistake in #301. Apparently with old SYCL compilers the `memset(...)` functions would've never worked. :thinking:

In the end, checking for whether `::sycl::queue::memset` exists is quite futile by now. With #301 we'll only be able to use compilers that implement the [SYCL2020](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html) standard. Which includes `::sycl::queue::memset`. Nevertheless, this seemed like a simple fix to make.