### PR TITLE
SonarCloud Fixes, main branch (2024.11.07.)

### DIFF
--- a/core/include/vecmem/containers/array.hpp
+++ b/core/include/vecmem/containers/array.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -89,7 +89,7 @@ public:
     /// Can only be used if the user chose a non-default value for the size
     /// template parameter.
     ///
-    array(memory_resource& resource);
+    explicit array(memory_resource& resource);
 
     /// Constructor with a size and a memory resource to use
     ///

--- a/core/include/vecmem/containers/details/aligned_multiple_placement.hpp
+++ b/core/include/vecmem/containers/details/aligned_multiple_placement.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -88,7 +88,7 @@ namespace details {
  */
 template <typename... Ts, typename... Ps>
 std::tuple<vecmem::unique_alloc_ptr<char[]>, std::add_pointer_t<Ts>...>
-aligned_multiple_placement(vecmem::memory_resource &r, Ps... ps);
+aligned_multiple_placement(vecmem::memory_resource &r, Ps &&... ps);
 }  // namespace details
 }  // namespace vecmem
 

--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -40,7 +40,7 @@ public:
     /// Type of the data object that we have an array of
     typedef data::vector_view<TYPE> data_type;
     /// Pointer to the data object
-    typedef const data_type* data_pointer;
+    typedef std::add_pointer_t<std::add_const_t<data_type>> data_pointer;
 
     /// @}
 
@@ -70,7 +70,7 @@ public:
         /// the existence of this type as possible.
         ///
         VECMEM_HOST_AND_DEVICE
-        pointer(const data_pointer data);
+        explicit pointer(const data_pointer data);
 
         /// Return a pointer to a device vector (non-const)
         VECMEM_HOST_AND_DEVICE
@@ -92,7 +92,7 @@ public:
     jagged_device_vector_iterator();
     /// Constructor from an underlying data object
     VECMEM_HOST_AND_DEVICE
-    jagged_device_vector_iterator(data_pointer data);
+    explicit jagged_device_vector_iterator(data_pointer data);
     /// Constructor from a slightly different underlying data object
     template <typename OTHERTYPE,
               std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
@@ -189,7 +189,7 @@ namespace std {
 /// of @c vecmem::details::jagged_device_vector_iterator.
 ///
 template <typename T>
-struct iterator_traits<vecmem::details::jagged_device_vector_iterator<T> > {
+struct iterator_traits<vecmem::details::jagged_device_vector_iterator<T>> {
     typedef
         typename vecmem::details::jagged_device_vector_iterator<T>::value_type
             value_type;

--- a/core/include/vecmem/containers/device_array.hpp
+++ b/core/include/vecmem/containers/device_array.hpp
@@ -61,12 +61,12 @@ public:
 
     /// Constructor, on top of a previously allocated/filled block of memory
     VECMEM_HOST_AND_DEVICE
-    device_array(const data::vector_view<value_type>& data);
+    explicit device_array(const data::vector_view<value_type>& data);
     /// Construct a const device array from a non-const data object
     template <
         typename OTHERTYPE,
         std::enable_if_t<details::is_same_nc<T, OTHERTYPE>::value, bool> = true>
-    VECMEM_HOST_AND_DEVICE device_array(
+    VECMEM_HOST_AND_DEVICE explicit device_array(
         const data::vector_view<OTHERTYPE>& data);
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -78,13 +78,7 @@ public:
 
     /// Constructor, on top of a previously allocated/filled block of memory
     VECMEM_HOST_AND_DEVICE
-    device_vector(const data::vector_view<value_type>& data);
-    /// Construct a const device vector from a non-const data object
-    template <typename OTHERTYPE,
-              std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
-                               bool> = true>
-    VECMEM_HOST_AND_DEVICE device_vector(
-        const data::vector_view<OTHERTYPE>& data);
+    explicit device_vector(const data::vector_view<value_type>& data);
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE
     device_vector(const device_vector& parent);

--- a/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
+++ b/core/include/vecmem/containers/impl/aligned_multiple_placement.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022-2023 CERN for the benefit of the ACTS project
+ * (c) 2022-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,7 +44,7 @@ namespace details {
  */
 template <typename T, typename... Ts, typename P, typename... Ps>
 std::tuple<std::add_pointer_t<T>, std::add_pointer_t<Ts>...>
-aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps... ps) {
+aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps &&... ps) {
     /*
      * We start out by calculating the size of the current region.
      */
@@ -134,7 +134,7 @@ aligned_multiple_placement_helper(void *p, std::size_t q, P n, Ps... ps) {
 
 template <typename... Ts, typename... Ps>
 std::tuple<vecmem::unique_alloc_ptr<char[]>, std::add_pointer_t<Ts>...>
-aligned_multiple_placement(vecmem::memory_resource &r, Ps... ps) {
+aligned_multiple_placement(vecmem::memory_resource &r, Ps &&... ps) {
     /*
      * First, we will assert that we have exactly as many template arguments as
      * we have positional arguments, barring the memory resource. This is very

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -29,20 +29,6 @@ VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
 }
 
 template <typename TYPE>
-template <typename OTHERTYPE,
-          std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value, bool> >
-VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
-    const data::vector_view<OTHERTYPE>& data)
-    : m_capacity(data.capacity()), m_size(data.size_ptr()), m_ptr(data.ptr()) {
-
-    VECMEM_DEBUG_MSG(5,
-                     "Created vecmem::device_vector with capacity %u and "
-                     "size pointer %p from pointer %p",
-                     m_capacity, static_cast<const void*>(m_size),
-                     static_cast<const void*>(m_ptr));
-}
-
-template <typename TYPE>
 VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
     const device_vector& parent)
     : m_capacity(parent.m_capacity),

--- a/core/include/vecmem/containers/impl/jagged_device_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -49,7 +49,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::at(size_type pos)
     assert(pos < m_size);
 
     // Return a reference to the vector element.
-    return m_ptr[pos];
+    return reference{m_ptr[pos]};
 }
 
 template <typename T>
@@ -60,7 +60,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::at(size_type pos) const
     assert(pos < m_size);
 
     // Return a reference to the vector element.
-    return m_ptr[pos];
+    return const_reference{m_ptr[pos]};
 }
 
 template <typename T>
@@ -68,7 +68,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::operator[](size_type pos)
     -> reference {
 
     // Return a reference to the vector element.
-    return m_ptr[pos];
+    return reference{m_ptr[pos]};
 }
 
 template <typename T>
@@ -76,7 +76,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::operator[](
     size_type pos) const -> const_reference {
 
     // Return a reference to the vector element.
-    return m_ptr[pos];
+    return const_reference{m_ptr[pos]};
 }
 
 template <typename T>
@@ -86,7 +86,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::front() -> reference {
     assert(m_size > 0);
 
     // Return a reference to the first element of the vector.
-    return m_ptr[0];
+    return reference{m_ptr[0]};
 }
 
 template <typename T>
@@ -97,7 +97,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::front() const
     assert(m_size > 0);
 
     // Return a reference to the first element of the vector.
-    return m_ptr[0];
+    return const_reference{m_ptr[0]};
 }
 
 template <typename T>
@@ -107,7 +107,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::back() -> reference {
     assert(m_size > 0);
 
     // Return a reference to the last element of the vector.
-    return m_ptr[m_size - 1];
+    return reference{m_ptr[m_size - 1]};
 }
 
 template <typename T>
@@ -118,7 +118,7 @@ VECMEM_HOST_AND_DEVICE auto jagged_device_vector<T>::back() const
     assert(m_size > 0);
 
     // Return a reference to the last element of the vector.
-    return m_ptr[m_size - 1];
+    return const_reference{m_ptr[m_size - 1]};
 }
 
 template <typename T>

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -85,21 +85,21 @@ template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto jagged_device_vector_iterator<TYPE>::operator*()
     const -> reference {
 
-    return *m_ptr;
+    return reference{*m_ptr};
 }
 
 template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto
 jagged_device_vector_iterator<TYPE>::operator->() const -> pointer {
 
-    return m_ptr;
+    return pointer{m_ptr};
 }
 
 template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto jagged_device_vector_iterator<TYPE>::operator[](
     difference_type n) const -> reference {
 
-    return *(*this + n);
+    return reference{*(*this + n)};
 }
 
 template <typename TYPE>

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -78,7 +78,7 @@ public:
      * object.
      */
     VECMEM_HOST_AND_DEVICE
-    jagged_device_vector(data::jagged_vector_view<T> data);
+    explicit jagged_device_vector(data::jagged_vector_view<T> data);
 
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE

--- a/core/include/vecmem/containers/static_vector.hpp
+++ b/core/include/vecmem/containers/static_vector.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -77,7 +77,8 @@ public:
     static_vector();
     /// Construct a vector with a specific size
     VECMEM_HOST_AND_DEVICE
-    static_vector(size_type size, const_reference value = value_type());
+    explicit static_vector(size_type size,
+                           const_reference value = value_type());
     /// Construct a vector with values coming from a pair of iterators
     template <
         typename InputIt,

--- a/core/include/vecmem/utils/tuple.hpp
+++ b/core/include/vecmem/utils/tuple.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -66,11 +66,14 @@ struct tuple<T, Ts...> {
     /// @param head The first element to be stored in the tuple
     /// @param tail The rest of the elements to be stored in the tuple
     ///
-    template <typename U, typename... Us,
-              std::enable_if_t<vecmem::details::conjunction<
-                                   std::is_constructible<T, U &&>,
-                                   std::is_constructible<Ts, Us &&>...>::value,
-                               bool> = true>
+    template <
+        typename U, typename... Us,
+        std::enable_if_t<
+            vecmem::details::conjunction<
+                vecmem::details::negation<std::is_same<tuple<T, Ts...>, U>>,
+                std::is_constructible<T, U &&>,
+                std::is_constructible<Ts, Us &&>...>::value,
+            bool> = true>
     VECMEM_HOST_AND_DEVICE constexpr tuple(U &&head, Us &&... tail)
         : m_head(std::forward<U>(head)), m_tail(std::forward<Us>(tail)...) {}
 

--- a/tests/cuda/test_cuda_containers_kernels.cu
+++ b/tests/cuda/test_cuda_containers_kernels.cu
@@ -270,8 +270,11 @@ __global__ void arrayTransformKernel(
     }
 
     // Create the "device type".
-    vecmem::static_array<vecmem::device_vector<int>, 4> vec{data[0], data[1],
-                                                            data[2], data[3]};
+    vecmem::static_array<vecmem::device_vector<int>, 4> vec{
+        vecmem::device_vector<int>{data[0]},
+        vecmem::device_vector<int>{data[1]},
+        vecmem::device_vector<int>{data[2]},
+        vecmem::device_vector<int>{data[3]}};
 
     // Perform the transformation.
     vec[i][j] *= 2;

--- a/tests/hip/test_hip_containers_kernels.hip
+++ b/tests/hip/test_hip_containers_kernels.hip
@@ -317,8 +317,11 @@ __global__ void arrayTransformKernel(
     }
 
     // Create the "device type".
-    vecmem::static_array<vecmem::device_vector<int>, 4> vec{data[0], data[1],
-                                                            data[2], data[3]};
+    vecmem::static_array<vecmem::device_vector<int>, 4> vec{
+        vecmem::device_vector<int>{data[0]},
+        vecmem::device_vector<int>{data[1]},
+        vecmem::device_vector<int>{data[2]},
+        vecmem::device_vector<int>{data[3]}};
 
     // Perform the transformation.
     vec[i][j] *= 2;

--- a/tests/sycl/test_sycl_containers.sycl
+++ b/tests/sycl/test_sycl_containers.sycl
@@ -483,7 +483,10 @@ TEST_F(sycl_containers_test, array_memory) {
 
                     // Create the "device type".
                     vecmem::static_array<vecmem::device_vector<int>, 4> vec{
-                        data[0], data[1], data[2], data[3]};
+                        vecmem::device_vector<int>{data[0]},
+                        vecmem::device_vector<int>{data[1]},
+                        vecmem::device_vector<int>{data[2]},
+                        vecmem::device_vector<int>{data[3]}};
 
                     // Perform the transformation.
                     vec[static_cast<vecmem::static_array<


### PR DESCRIPTION
This is a first set of fixes triggered by SonarCloud's results on our code. It's more or less exploratory at this point, as I want to see how easy it is to track issues in that system.

It was not directly pointed out by SonarCloud, but these changes also allowed me to remove one constructor of `vecmem::device_vector` since the non-const -> const conversion can actually happen at the level of the views. We don't need to have this type of templated code inside of `device_vector` itself. 🤔

@stephenswat, I also received some notes about "your" code. Have a look if you like what I did to resolve those reports.