### PR TITLE
MSVC C++20 Fix, main branch (2024.11.21.)

### DIFF
--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -11,6 +11,7 @@
 #include "vecmem/edm/details/schema_traits.hpp"
 
 // System include(s).
+#include <string>
 #include <tuple>
 #include <type_traits>
 


### PR DESCRIPTION
Added a missing include. This was only found by MSVC, in C\+\+20 mode for some reason.

This popped up in https://github.com/acts-project/algebra-plugins/pull/136, since this project's CI is not testing C\+\+20 with MSVC (yet).