### PR TITLE
Allow const and non-const reverse iterator comparisons

### DIFF
--- a/core/include/vecmem/containers/details/reverse_iterator.hpp
+++ b/core/include/vecmem/containers/details/reverse_iterator.hpp
@@ -126,13 +126,13 @@ private:
 };  // class reverse_iterator
 
 /// Comparison operator for reverse iterators
-template <typename T>
-VECMEM_HOST_AND_DEVICE bool operator==(const reverse_iterator<T>& itr1,
-                                       const reverse_iterator<T>& itr2);
+template <typename T1, typename T2>
+VECMEM_HOST_AND_DEVICE bool operator==(const reverse_iterator<T1>& itr1,
+                                       const reverse_iterator<T2>& itr2);
 /// Comparison operator for reverse iterators
-template <typename T>
-VECMEM_HOST_AND_DEVICE bool operator!=(const reverse_iterator<T>& itr1,
-                                       const reverse_iterator<T>& itr2);
+template <typename T1, typename T2>
+VECMEM_HOST_AND_DEVICE bool operator!=(const reverse_iterator<T1>& itr1,
+                                       const reverse_iterator<T2>& itr2);
 
 }  // namespace details
 }  // namespace vecmem

--- a/core/include/vecmem/containers/impl/reverse_iterator.ipp
+++ b/core/include/vecmem/containers/impl/reverse_iterator.ipp
@@ -157,16 +157,16 @@ reverse_iterator<Iterator>::to_pointer(T itr) {
     return itr.operator->();
 }
 
-template <typename T>
-VECMEM_HOST_AND_DEVICE bool operator==(const reverse_iterator<T>& itr1,
-                                       const reverse_iterator<T>& itr2) {
+template <typename T1, typename T2>
+VECMEM_HOST_AND_DEVICE bool operator==(const reverse_iterator<T1>& itr1,
+                                       const reverse_iterator<T2>& itr2) {
 
     return (itr1.base() == itr2.base());
 }
 
-template <typename T>
-VECMEM_HOST_AND_DEVICE bool operator!=(const reverse_iterator<T>& itr1,
-                                       const reverse_iterator<T>& itr2) {
+template <typename T1, typename T2>
+VECMEM_HOST_AND_DEVICE bool operator!=(const reverse_iterator<T1>& itr1,
+                                       const reverse_iterator<T2>& itr2) {
 
     return !(itr1 == itr2);
 }

--- a/tests/core/test_core_containers.cpp
+++ b/tests/core/test_core_containers.cpp
@@ -71,6 +71,35 @@ TEST_F(core_container_test, device_vector) {
     }
 }
 
+/// Test(s) for @c vecmem::device_vector
+TEST_F(core_container_test, device_vector_iterators) {
+
+    using V = vecmem::device_vector<int>;
+    V test_vector(vecmem::get_data(m_reference_vector));
+
+    V::const_iterator itfc1 = test_vector.cbegin();
+    V::const_iterator itfc2 = test_vector.cend();
+    V::iterator itfn1 = test_vector.begin();
+    V::iterator itfn2 = test_vector.end();
+    V::const_reverse_iterator itrc1 = test_vector.crbegin();
+    V::const_reverse_iterator itrc2 = test_vector.crend();
+    V::reverse_iterator itrn1 = test_vector.rbegin();
+    V::reverse_iterator itrn2 = test_vector.rend();
+
+    EXPECT_EQ(itfn1, itfc1);
+    EXPECT_EQ(itfc1, itfn1);
+    EXPECT_NE(itfn2, itfc1);
+    EXPECT_NE(itfc1, itfn2);
+    EXPECT_EQ(itrn1, itrc1);
+    EXPECT_EQ(itrc1, itrn1);
+    EXPECT_NE(itrn2, itrc1);
+    EXPECT_NE(itrc1, itrn2);
+    EXPECT_EQ(itfc2, itfn2);
+    EXPECT_NE(itfc2, itfn1);
+    EXPECT_EQ(itrc2, itrn2);
+    EXPECT_NE(itrc2, itrn1);
+}
+
 /// Test(s) for @c vecmem::static_vector
 TEST_F(core_container_test, static_vector) {
 


### PR DESCRIPTION
As @beomki-yeo discovered in https://github.com/acts-project/traccc/pull/788, constant reverse iterators cannot be currently compared to non-constant reverse iterators as is required by the C++ standard in section [container.requirements.general]. This commit adds the necessary comparison code, and adds some tests for the new behaviour.