### PR TITLE
SoA Proxy Updates, main branch (2025.02.20.)

### DIFF
--- a/core/include/vecmem/edm/details/proxy_traits.hpp
+++ b/core/include/vecmem/edm/details/proxy_traits.hpp
@@ -61,7 +61,7 @@ template <typename VTYPE, proxy_domain PDOMAIN>
 struct proxy_var_type<type::scalar<VTYPE>, PDOMAIN, proxy_access::constant,
                       proxy_type::reference> {
 
-    /// The scalar is kept by value in the proxy
+    /// The scalar is kept by constant lvalue reference in the proxy
     using type = std::add_lvalue_reference_t<std::add_const_t<VTYPE>>;
     /// It is returned as a const reference even on non-const access
     using return_type = type;
@@ -91,6 +91,26 @@ struct proxy_var_type<type::scalar<VTYPE>, PDOMAIN, proxy_access::non_constant,
     /// Helper function constructing a scalar proxy variable
     template <typename ITYPE>
     VECMEM_HOST_AND_DEVICE static type make(ITYPE, return_type variable) {
+        return variable;
+    }
+};
+
+/// Standalone scalar variable (both host and device, const and non-const)
+template <typename VTYPE, proxy_domain PDOMAIN, proxy_access PACCESS>
+struct proxy_var_type<type::scalar<VTYPE>, PDOMAIN, PACCESS,
+                      proxy_type::standalone> {
+
+    /// The scalar is kept by value in the proxy
+    using type = std::remove_cv_t<VTYPE>;
+    /// It is returned as a const reference even on non-const access
+    using return_type = std::add_lvalue_reference_t<type>;
+    /// It is returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+
+    /// Helper function constructing a scalar proxy variable
+    template <typename ITYPE>
+    VECMEM_HOST_AND_DEVICE static type make(ITYPE, const_return_type variable) {
         return variable;
     }
 };
@@ -131,6 +151,27 @@ struct proxy_var_type<type::vector<VTYPE>, PDOMAIN, proxy_access::non_constant,
     /// Helper function constructing a vector proxy variable
     template <typename ITYPE, typename VECTYPE>
     VECMEM_HOST_AND_DEVICE static type make(ITYPE i, VECTYPE& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Standalone vector variable (both host and device, const and non-const)
+template <typename VTYPE, proxy_domain PDOMAIN, proxy_access PACCESS>
+struct proxy_var_type<type::vector<VTYPE>, PDOMAIN, PACCESS,
+                      proxy_type::standalone> {
+
+    /// The scalar is kept by value in the proxy
+    using type = std::remove_cv_t<VTYPE>;
+    /// It is returned as a const reference even on non-const access
+    using return_type = std::add_lvalue_reference_t<type>;
+    /// It is returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+
+    /// Helper function constructing a vector proxy variable
+    template <typename ITYPE, typename VECTYPE>
+    VECMEM_HOST_AND_DEVICE static type make(ITYPE i, const VECTYPE& vec) {
 
         return vec.at(i);
     }
@@ -225,6 +266,28 @@ struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_domain::host,
     VECMEM_HOST
     static type make(typename jagged_vector<VTYPE>::size_type i,
                      jagged_vector<VTYPE>& vec) {
+
+        return vec.at(i);
+    }
+};
+
+/// Standalone host jagged vector variable (const and non-const)
+template <typename VTYPE, proxy_access PACCESS>
+struct proxy_var_type<type::jagged_vector<VTYPE>, proxy_domain::host, PACCESS,
+                      proxy_type::standalone> {
+
+    /// Jagged vector elements are kept by constant reference in the proxy
+    using type = vector<VTYPE>;
+    /// They are returned as a const reference even on non-const access
+    using return_type = std::add_lvalue_reference_t<type>;
+    /// They are returned as a const reference on const access
+    using const_return_type =
+        std::add_lvalue_reference_t<std::add_const_t<type>>;
+
+    /// Helper function constructing a vector proxy variable
+    VECMEM_HOST
+    static type make(typename jagged_vector<VTYPE>::size_type i,
+                     const jagged_vector<VTYPE>& vec) {
 
         return vec.at(i);
     }

--- a/core/include/vecmem/edm/device.hpp
+++ b/core/include/vecmem/edm/device.hpp
@@ -60,6 +60,11 @@ public:
     using const_proxy_type = interface_type<
         proxy<schema_type, details::proxy_domain::device,
               details::proxy_access::constant, details::proxy_type::reference>>;
+    /// Type type of standalone proxy objects for the container
+    using object_type =
+        interface_type<proxy<schema_type, details::proxy_domain::device,
+                             details::proxy_access::non_constant,
+                             details::proxy_type::standalone>>;
 
     /// @name Constructors and assignment operators
     /// @{
@@ -83,6 +88,8 @@ public:
     /// Add one default element to all (vector) variables (thread safe)
     VECMEM_HOST_AND_DEVICE
     size_type push_back_default();
+    /// Add one element to all (vector) variables (thread safe)
+    VECMEM_HOST_AND_DEVICE size_type push_back(const object_type& element);
 
     /// Get a specific variable (non-const)
     template <std::size_t INDEX>

--- a/core/include/vecmem/edm/device.hpp
+++ b/core/include/vecmem/edm/device.hpp
@@ -54,11 +54,12 @@ public:
     /// The type of the (non-const) proxy objects for the container elements
     using proxy_type =
         interface_type<proxy<schema_type, details::proxy_domain::device,
-                             details::proxy_access::non_constant>>;
+                             details::proxy_access::non_constant,
+                             details::proxy_type::reference>>;
     /// The type of the (const) proxy objects for the container elements
-    using const_proxy_type =
-        interface_type<proxy<schema_type, details::proxy_domain::device,
-                             details::proxy_access::constant>>;
+    using const_proxy_type = interface_type<
+        proxy<schema_type, details::proxy_domain::device,
+              details::proxy_access::constant, details::proxy_type::reference>>;
 
     /// @name Constructors and assignment operators
     /// @{

--- a/core/include/vecmem/edm/device.hpp
+++ b/core/include/vecmem/edm/device.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -53,11 +53,11 @@ public:
     using interface_type = INTERFACE<T>;
     /// The type of the (non-const) proxy objects for the container elements
     using proxy_type =
-        interface_type<proxy<schema_type, details::proxy_type::device,
+        interface_type<proxy<schema_type, details::proxy_domain::device,
                              details::proxy_access::non_constant>>;
     /// The type of the (const) proxy objects for the container elements
     using const_proxy_type =
-        interface_type<proxy<schema_type, details::proxy_type::device,
+        interface_type<proxy<schema_type, details::proxy_domain::device,
                              details::proxy_access::constant>>;
 
     /// @name Constructors and assignment operators

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -59,6 +59,11 @@ public:
     using const_proxy_type = interface_type<
         proxy<schema_type, details::proxy_domain::host,
               details::proxy_access::constant, details::proxy_type::reference>>;
+    /// Type type of standalone proxy objects for the container
+    using object_type =
+        interface_type<proxy<schema_type, details::proxy_domain::host,
+                             details::proxy_access::non_constant,
+                             details::proxy_type::standalone>>;
 
     /// @name Constructors and assignment operators
     /// @{
@@ -81,6 +86,8 @@ public:
     /// Reserve memory for the container
     VECMEM_HOST
     void reserve(size_type size);
+    /// Add a new element to the container
+    VECMEM_HOST void push_back(const object_type& element);
 
     /// Get the vector of a specific variable (non-const)
     template <std::size_t INDEX>

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -52,11 +52,11 @@ public:
     using interface_type = INTERFACE<T>;
     /// The type of the (non-const) proxy objects for the container elements
     using proxy_type =
-        interface_type<proxy<schema_type, details::proxy_type::host,
+        interface_type<proxy<schema_type, details::proxy_domain::host,
                              details::proxy_access::non_constant>>;
     /// The type of the (const) proxy objects for the container elements
     using const_proxy_type =
-        interface_type<proxy<schema_type, details::proxy_type::host,
+        interface_type<proxy<schema_type, details::proxy_domain::host,
                              details::proxy_access::constant>>;
 
     /// @name Constructors and assignment operators

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -53,11 +53,12 @@ public:
     /// The type of the (non-const) proxy objects for the container elements
     using proxy_type =
         interface_type<proxy<schema_type, details::proxy_domain::host,
-                             details::proxy_access::non_constant>>;
+                             details::proxy_access::non_constant,
+                             details::proxy_type::reference>>;
     /// The type of the (const) proxy objects for the container elements
-    using const_proxy_type =
-        interface_type<proxy<schema_type, details::proxy_domain::host,
-                             details::proxy_access::constant>>;
+    using const_proxy_type = interface_type<
+        proxy<schema_type, details::proxy_domain::host,
+              details::proxy_access::constant, details::proxy_type::reference>>;
 
     /// @name Constructors and assignment operators
     /// @{

--- a/core/include/vecmem/edm/impl/device.ipp
+++ b/core/include/vecmem/edm/impl/device.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -78,6 +78,20 @@ device<schema<VARTYPES...>, INTERFACE>::push_back_default() -> size_type {
 
     // Construct the new elements in all of the vector variables.
     construct_default(index, std::index_sequence_for<VARTYPES...>{});
+
+    // Return the position of the new variable(s).
+    return index;
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST_AND_DEVICE auto device<schema<VARTYPES...>, INTERFACE>::push_back(
+    const object_type& element) -> size_type {
+
+    // Add a new default element to the container.
+    const size_type index = push_back_default();
+
+    // Set it to the given value.
+    at(index) = element;
 
     // Return the position of the new variable(s).
     return index;

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -66,6 +66,22 @@ VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::reserve(
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::push_back(
+    const object_type& element) {
+
+    // Make sure that there are some (jagged) vector types in the container.
+    static_assert(
+        std::disjunction_v<type::details::is_vector<VARTYPES>...>,
+        "This function requires at least one (jagged) vector variable.");
+
+    // Add a new element to the container.
+    const size_type index = size();
+    resize(index + 1);
+    // Set the new element.
+    at(index) = element;
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
 template <std::size_t INDEX>
 VECMEM_HOST typename details::host_type_at<INDEX, VARTYPES...>::return_type
 host<schema<VARTYPES...>, INTERFACE>::get() {

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,50 +9,48 @@
 namespace vecmem {
 namespace edm {
 
-template <typename... VARTYPES, details::proxy_type PTYPE,
-          details::proxy_access CTYPE>
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
 template <typename PARENT>
-VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::proxy(
     PARENT& parent, typename PARENT::size_type index)
-    : m_data{
-          details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
-              index, parent)} {
+    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN,
+                                         PACCESS>::make(index, parent)} {
 
-    static_assert(CTYPE == details::proxy_access::non_constant,
+    static_assert(PACCESS == details::proxy_access::non_constant,
                   "This constructor is meant for non-const proxies.");
 }
 
-template <typename... VARTYPES, details::proxy_type PTYPE,
-          details::proxy_access CTYPE>
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
 template <typename PARENT>
-VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PTYPE, CTYPE>::proxy(
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::proxy(
     const PARENT& parent, typename PARENT::size_type index)
-    : m_data{
-          details::proxy_data_creator<schema<VARTYPES...>, PTYPE, CTYPE>::make(
-              index, parent)} {
+    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN,
+                                         PACCESS>::make(index, parent)} {
 
-    static_assert(CTYPE == details::proxy_access::constant,
+    static_assert(PACCESS == details::proxy_access::constant,
                   "This constructor is meant for constant proxies.");
 }
 
-template <typename... VARTYPES, details::proxy_type PTYPE,
-          details::proxy_access CTYPE>
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
-    typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
                                         VARTYPES...>::return_type
-    proxy<schema<VARTYPES...>, PTYPE, CTYPE>::get() {
+    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::get() {
 
     return vecmem::get<INDEX>(m_data);
 }
 
-template <typename... VARTYPES, details::proxy_type PTYPE,
-          details::proxy_access CTYPE>
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
-    typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
                                         VARTYPES...>::const_return_type
-    proxy<schema<VARTYPES...>, PTYPE, CTYPE>::get() const {
+    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::get() const {
 
     return vecmem::get<INDEX>(m_data);
 }

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -10,47 +10,49 @@ namespace vecmem {
 namespace edm {
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <typename PARENT>
-VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::proxy(
-    PARENT& parent, typename PARENT::size_type index)
-    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN,
-                                         PACCESS>::make(index, parent)} {
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS,
+                             PTYPE>::proxy(PARENT& parent,
+                                           typename PARENT::size_type index)
+    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN, PACCESS,
+                                         PTYPE>::make(index, parent)} {
 
     static_assert(PACCESS == details::proxy_access::non_constant,
                   "This constructor is meant for non-const proxies.");
 }
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <typename PARENT>
-VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::proxy(
-    const PARENT& parent, typename PARENT::size_type index)
-    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN,
-                                         PACCESS>::make(index, parent)} {
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS,
+                             PTYPE>::proxy(const PARENT& parent,
+                                           typename PARENT::size_type index)
+    : m_data{details::proxy_data_creator<schema<VARTYPES...>, PDOMAIN, PACCESS,
+                                         PTYPE>::make(index, parent)} {
 
     static_assert(PACCESS == details::proxy_access::constant,
                   "This constructor is meant for constant proxies.");
 }
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
-    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
+    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
                                         VARTYPES...>::return_type
-    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::get() {
+    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::get() {
 
     return vecmem::get<INDEX>(m_data);
 }
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
-    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
+    typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
                                         VARTYPES...>::const_return_type
-    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS>::get() const {
+    proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::get() const {
 
     return vecmem::get<INDEX>(m_data);
 }

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -37,6 +37,37 @@ VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS,
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
           details::proxy_access PACCESS, details::proxy_type PTYPE>
+template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
+          details::proxy_type OPTYPE>
+VECMEM_HOST_AND_DEVICE
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::proxy(
+    const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other)
+    : m_data(other.variables()) {}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+VECMEM_HOST_AND_DEVICE
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::proxy(
+    typename details::proxy_var_type<VARTYPES, proxy_domain, access_type,
+                                     proxy_type>::type... data)
+    : m_data(data...) {}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
+          details::proxy_type OPTYPE>
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>&
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::operator=(
+    const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other) {
+
+    if (static_cast<const void*>(this) != static_cast<const void*>(&other)) {
+        m_data = other.variables();
+    }
+    return *this;
+}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <std::size_t INDEX>
 VECMEM_HOST_AND_DEVICE
     typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
@@ -55,6 +86,24 @@ VECMEM_HOST_AND_DEVICE
     proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::get() const {
 
     return vecmem::get<INDEX>(m_data);
+}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+VECMEM_HOST_AND_DEVICE auto
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::variables() const
+    -> const tuple_type& {
+
+    return m_data;
+}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+VECMEM_HOST_AND_DEVICE auto
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::variables()
+    -> tuple_type& {
+
+    return m_data;
 }
 
 }  // namespace edm

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -69,6 +69,46 @@ public:
     VECMEM_HOST_AND_DEVICE proxy(const PARENT& parent,
                                  typename PARENT::size_type index);
 
+    /// Copy constructor
+    ///
+    /// @tparam OPDOMAIN The domain of the other proxy
+    /// @tparam OPACCESS The access mode of the other proxy
+    /// @tparam OPTYPE   The type of the other proxy
+    ///
+    /// @param other The proxy to copy
+    ///
+    template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
+              details::proxy_type OPTYPE>
+    VECMEM_HOST_AND_DEVICE proxy(
+        const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
+
+    /// Construct a proxy from a list of variables
+    ///
+    /// This is mainly meant for "standalone proxies", but technically would
+    /// work for any type of a proxy.
+    ///
+    /// @param data The list of variables to proxy
+    ///
+    VECMEM_HOST_AND_DEVICE proxy(
+        typename details::proxy_var_type<VARTYPES, proxy_domain, access_type,
+                                         proxy_type>::type... data);
+
+    /// Assignment operator
+    ///
+    /// @tparam OPDOMAIN The domain of the other proxy
+    /// @tparam OPACCESS The access mode of the other proxy
+    /// @tparam OPTYPE   The type of the other proxy
+    ///
+    /// @param other The proxy to copy
+    ///
+    /// @return A reference to the proxy object
+    ///
+    template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
+              details::proxy_type OPTYPE>
+    VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>&
+    operator=(
+        const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
+
     /// @}
 
     /// @name Variable accessor functions
@@ -86,6 +126,18 @@ public:
         typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
                                             VARTYPES...>::const_return_type
         get() const;
+
+    /// @}
+
+    /// @name Function(s) meant for internal use by other VecMem types
+    /// @{
+
+    /// Direct (non-const) access to the underlying tuple of variables
+    VECMEM_HOST_AND_DEVICE
+    tuple_type& variables();
+    /// Direct (const) access to the underlying tuple of variables
+    VECMEM_HOST_AND_DEVICE
+    const tuple_type& variables() const;
 
     /// @}
 

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,7 +16,8 @@ namespace vecmem {
 namespace edm {
 
 /// Technical base type for @c proxy<schema<VARTYPES...>,PTYPE,CTYPE>
-template <typename T, details::proxy_type PTYPE, details::proxy_access CTYPE>
+template <typename T, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
 class proxy;
 
 /// Structure-of-Arrays element proxy
@@ -27,20 +28,20 @@ class proxy;
 /// @tparam PTYPE       The type of the proxy (host or device)
 /// @tparam CTYPE       The access mode of the proxy (const or non-const)
 ///
-template <typename... VARTYPES, details::proxy_type PTYPE,
-          details::proxy_access CTYPE>
-class proxy<schema<VARTYPES...>, PTYPE, CTYPE> {
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS>
+class proxy<schema<VARTYPES...>, PDOMAIN, PACCESS> {
 
 public:
     /// The schema describing the host's payload
     using schema_type = schema<VARTYPES...>;
     /// The type of the proxy (host or device)
-    static constexpr details::proxy_type proxy_type = PTYPE;
+    static constexpr details::proxy_domain proxy_domain = PDOMAIN;
     /// The access mode of the proxy (const or non-const)
-    static constexpr details::proxy_access access_type = CTYPE;
+    static constexpr details::proxy_access access_type = PACCESS;
     /// The tuple type holding all of the the proxied variables
     using tuple_type =
-        tuple<typename details::proxy_var_type<VARTYPES, proxy_type,
+        tuple<typename details::proxy_var_type<VARTYPES, proxy_domain,
                                                access_type>::type...>;
 
     /// @name Constructors and assignment operators
@@ -74,13 +75,13 @@ public:
     /// Get a specific variable (non-const)
     template <std::size_t INDEX>
     VECMEM_HOST_AND_DEVICE
-        typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
                                             VARTYPES...>::return_type
         get();
     /// Get a specific variable (const)
     template <std::size_t INDEX>
     VECMEM_HOST_AND_DEVICE
-        typename details::proxy_var_type_at<INDEX, PTYPE, CTYPE,
+        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
                                             VARTYPES...>::const_return_type
         get() const;
 

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -15,9 +15,9 @@
 namespace vecmem {
 namespace edm {
 
-/// Technical base type for @c proxy<schema<VARTYPES...>,PTYPE,CTYPE>
+/// Technical base type for @c proxy<schema<VARTYPES...>,PDOMAIN,PACCESS,PTYPE>
 template <typename T, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 class proxy;
 
 /// Structure-of-Arrays element proxy
@@ -25,12 +25,13 @@ class proxy;
 /// This class implements a "view" of a single element in an SoA container.
 ///
 /// @tparam ...VARTYPES The variable types to store in the proxy object
-/// @tparam PTYPE       The type of the proxy (host or device)
-/// @tparam CTYPE       The access mode of the proxy (const or non-const)
+/// @tparam PDOMAIN     The "domain" of the proxy (host or device)
+/// @tparam PACCESS     The access mode of the proxy (const or non-const)
+/// @tparam PTYPE       The type of the proxy (reference or standalone)
 ///
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
-          details::proxy_access PACCESS>
-class proxy<schema<VARTYPES...>, PDOMAIN, PACCESS> {
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+class proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE> {
 
 public:
     /// The schema describing the host's payload
@@ -39,10 +40,11 @@ public:
     static constexpr details::proxy_domain proxy_domain = PDOMAIN;
     /// The access mode of the proxy (const or non-const)
     static constexpr details::proxy_access access_type = PACCESS;
+    /// The type of the proxy (reference or standalone)
+    static constexpr details::proxy_type proxy_type = PTYPE;
     /// The tuple type holding all of the the proxied variables
-    using tuple_type =
-        tuple<typename details::proxy_var_type<VARTYPES, proxy_domain,
-                                               access_type>::type...>;
+    using tuple_type = tuple<typename details::proxy_var_type<
+        VARTYPES, proxy_domain, access_type, proxy_type>::type...>;
 
     /// @name Constructors and assignment operators
     /// @{
@@ -75,13 +77,13 @@ public:
     /// Get a specific variable (non-const)
     template <std::size_t INDEX>
     VECMEM_HOST_AND_DEVICE
-        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
+        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
                                             VARTYPES...>::return_type
         get();
     /// Get a specific variable (const)
     template <std::size_t INDEX>
     VECMEM_HOST_AND_DEVICE
-        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS,
+        typename details::proxy_var_type_at<INDEX, PDOMAIN, PACCESS, PTYPE,
                                             VARTYPES...>::const_return_type
         get() const;
 

--- a/core/include/vecmem/utils/tuple.hpp
+++ b/core/include/vecmem/utils/tuple.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -92,6 +92,22 @@ struct tuple<T, Ts...> {
                                bool> = true>
     VECMEM_HOST_AND_DEVICE constexpr tuple(U &&head, tuple<Us...> &&tail)
         : m_head(std::forward<U>(head)), m_tail(std::move(tail)) {}
+
+    /// Assignment operator from a (slightly) different tuple type
+    ///
+    /// @param parent The parent to copy
+    ///
+    template <typename U, typename... Us,
+              std::enable_if_t<
+                  (!std::is_same<tuple<T, Ts...>, tuple<U, Us...>>::value) &&
+                      sizeof...(Ts) == sizeof...(Us),
+                  bool> = true>
+    VECMEM_HOST_AND_DEVICE constexpr tuple &operator=(
+        const tuple<U, Us...> &parent) {
+        m_head = parent.m_head;
+        m_tail = parent.m_tail;
+        return *this;
+    }
 
     /// The first/head element of the tuple
     T m_head;

--- a/tests/common/simple_soa_container.hpp
+++ b/tests/common/simple_soa_container.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,8 +18,11 @@ template <typename BASE>
 class simple_soa_interface : public BASE {
 
 public:
-    /// Inherit the base class's constructor(s)
+    /// @name Inherit the base class's constructor(s) and operator(s)
+    /// @{
     using BASE::BASE;
+    using BASE::operator=;
+    /// @}
 
     /// Global "count" of something (non-const)
     VECMEM_HOST_AND_DEVICE

--- a/tests/common/simple_soa_container_helpers.hpp
+++ b/tests/common/simple_soa_container_helpers.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,9 +26,8 @@ inline void fill(unsigned int i, simple_soa_container::device& obj) {
     }
     // In the rest of the threads modify the vector variables.
     if (i < obj.capacity()) {
-        unsigned int ii = obj.push_back_default();
-        obj.measurement()[ii] = 1.0f * static_cast<float>(ii);
-        obj.at(ii).index() = static_cast<int>(ii);
+        obj.push_back(
+            {55, 1.0f * static_cast<float>(i), 3.141592f, static_cast<int>(i)});
     }
 }
 


### PR DESCRIPTION
Triggered by @beomki-yeo's insistence in https://github.com/acts-project/traccc/pull/878, I spent a bit of time trying to come up with a way of filling SoA containers conveniently "by hand".

I considered a number of options, but in the end went with making `vecmem::edm::proxy` even a bit more complicated. 🤔 Instead of only being able to refer to (i.e. "proxy"...) an element of a container, now they can also behave as standalone objects, which hold some payload of their own.

I went with this, because if I introduced a new type for this (let's say `vecmem::edm::object`), I would've had to create conversion operators back and forth between the new type and `vecmem::edm::proxy`. So it was easier to just use the same type for the standalone objects as well.

So far I only added `vecmem::edm::host::push_back(...)` with the new machinery, just as a proof of concept. Along with some testing code for it. Please have a look, especially at the unit test code. Since some early feedback could be useful here.

Note that it will never be possible to use such a formalism on containers that have jagged vectors, in device code. (Since a dynamic sized vector cannot be used in device code for this.) But since SoA containers with jagged vectors are not resizable to begin with, that is not a new limitation actually... 🤔