### PR TITLE
HIP Build Fix, main branch (2025.02.21.)

### DIFF
--- a/cmake/FindHIPToolkit.cmake
+++ b/cmake/FindHIPToolkit.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -85,7 +85,7 @@ if( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "hcc" ) OR
 elseif( ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvcc" ) OR
         ( "${CMAKE_HIP_PLATFORM}" STREQUAL "nvidia" ) )
    set( HIPToolkit_RUNTIME_LIBRARY "${CUDA_CUDART}" )
-   list( APPEND HIPToolkit_LIBRARIES CUDA::cudart )
+   list( APPEND HIPToolkit_LIBRARIES CUDA::cudart CUDA::cuda_driver )
 else()
    message( SEND_ERROR
       "Invalid CMAKE_HIP_PLATFORM setting (${CMAKE_HIP_PLATFORM}) received" )


### PR DESCRIPTION
Allow HIP to use the CUDA driver API. Because as it turns out, since #308 building `vecmem::hip` with an NVIDIA backend results in:

```
/usr/bin/c++ -fPIC  -Wall -Wextra -Wshadow -Wunused-local-typedefs -pedantic -Wconversion -O2 -g -DNDEBUG -Wl,--dependency-file=CMakeFiles/vecmem_hip.dir/link.d  -Wl,--no-undefined -shared -Wl,-soname,libvecmem_hip.so.1 -o ../lib/libvecmem_hip.so.1.13.0 CMakeFiles/vecmem_hip.dir/src/memory/device_memory_resource.cpp.o CMakeFiles/vecmem_hip.dir/src/memory/host_memory_resource.cpp.o CMakeFiles/vecmem_hip.dir/src/memory/managed_memory_resource.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/hip/copy.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/stream_wrapper.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/get_device_name.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/get_device.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/get_stream.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/hip_error_handling.cpp.o CMakeFiles/vecmem_hip.dir/src/utils/select_device.cpp.o  -Wl,-rpath,/home/krasznaa/ATLAS/projects/vecmem/build/lib:/home/krasznaa/software/nvidia/cuda-12.6.3/x86_64/lib64:/home/krasznaa/software/nvidia/cuda-12.6.3/x86_64/targets/x86_64-linux/lib: ../lib/libvecmem_core.so.1.13.0 /home/krasznaa/software/nvidia/cuda-12.6.3/x86_64/lib64/libcudart.so /home/krasznaa/software/nvidia/cuda-12.6.3/x86_64/targets/x86_64-linux/lib/libcudart.so -ldl /usr/lib/x86_64-linux-gnu/librt.a  
/usr/bin/ld: CMakeFiles/vecmem_hip.dir/src/utils/stream_wrapper.cpp.o: in function `vecmem::hip::stream_wrapper::device_name[abi:cxx11]() const':
/opt/rocm-6.2.2/include/hip/nvidia_detail/nvidia_hip_runtime_api.h:2864:(.text+0x2f4): undefined reference to `cuStreamGetCtx'
/usr/bin/ld: CMakeFiles/vecmem_hip.dir/src/utils/stream_wrapper.cpp.o: in function `hipStreamGetDevice':
/opt/rocm-6.2.2/include/hip/nvidia_detail/nvidia_hip_runtime_api.h:2867:(.text+0x34e): undefined reference to `cuCtxPushCurrent_v2'
/usr/bin/ld: /opt/rocm-6.2.2/include/hip/nvidia_detail/nvidia_hip_runtime_api.h:2870:(.text+0x363): undefined reference to `cuCtxGetDevice'
/usr/bin/ld: /opt/rocm-6.2.2/include/hip/nvidia_detail/nvidia_hip_runtime_api.h:2873:(.text+0x376): undefined reference to `cuCtxPopCurrent_v2'
collect2: error: ld returned 1 exit status
make[3]: *** [hip/CMakeFiles/vecmem_hip.dir/build.make:249: lib/libvecmem_hip.so.1.13.0] Error 1
make[3]: Leaving directory '/home/krasznaa/ATLAS/projects/vecmem/build'
make[2]: *** [CMakeFiles/Makefile2:3174: hip/CMakeFiles/vecmem_hip.dir/all] Error 2
make[2]: Leaving directory '/home/krasznaa/ATLAS/projects/vecmem/build'
make[1]: *** [CMakeFiles/Makefile2:3181: hip/CMakeFiles/vecmem_hip.dir/rule] Error 2
make[1]: Leaving directory '/home/krasznaa/ATLAS/projects/vecmem/build'
make: *** [Makefile:1278: vecmem_hip] Error 2
```

I'm not too happy about this low level dependency, but nothing that I can see that I could do about it.