### PR TITLE
Zero Allocations Fix, main branch (2025.02.24.)

### DIFF
--- a/core/include/vecmem/memory/details/unique_alloc_deleter.hpp
+++ b/core/include/vecmem/memory/details/unique_alloc_deleter.hpp
@@ -99,12 +99,12 @@ public:
      * @param p The pointer to deallocate.
      */
     void operator()(void* p) const {
-        assert(m_mr != nullptr);
+        assert(m_mr != nullptr || m_size == 0u);
 
         /*
-         * As before, if this happens... Something has gone VERY wrong.
+         * Non-null pointers with a zero size can happen.
          */
-        if (m_mr == nullptr) {
+        if (m_size == 0u) {
             return;
         }
 

--- a/core/include/vecmem/memory/details/unique_obj_deleter.hpp
+++ b/core/include/vecmem/memory/details/unique_obj_deleter.hpp
@@ -122,12 +122,12 @@ public:
      * makes it easier to cross-check the logic.
      */
     void operator()(pointer_t p) const {
-        assert(m_mr != nullptr);
+        assert(m_mr != nullptr || m_size == 0u);
 
         /*
-         * If this ever happens, something has gone VERY wrong...
+         * Non-null pointers with a zero size can happen.
          */
-        if (m_mr == nullptr) {
+        if (m_size == 0u) {
             return;
         }
 

--- a/core/include/vecmem/memory/unique_ptr.hpp
+++ b/core/include/vecmem/memory/unique_ptr.hpp
@@ -17,6 +17,20 @@
 #include "vecmem/vecmem_core_export.hpp"
 
 namespace vecmem {
+namespace details {
+
+/// Helper function for generating a nonexistent, but still "aligned" pointer.
+///
+/// @tparam T The type of the pointer
+/// @return The pointer
+///
+template <typename T>
+T get_nonexistent_pointer() {
+    return reinterpret_cast<T>(0xf000U);
+}
+
+}  // namespace details
+
 /**
  * @brief A unique pointer type for non-trivial objects.
  *
@@ -118,7 +132,7 @@ make_unique_obj(memory_resource& m, std::size_t n) {
 
     // Handle the case with zero elements.
     if (n == 0) {
-        return unique_obj_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+        return unique_obj_ptr<T>(details::get_nonexistent_pointer<pointer_t>());
     }
 
     /*
@@ -249,7 +263,8 @@ unique_alloc_ptr<T> make_unique_alloc(memory_resource& m, std::size_t n) {
 
     // Handle the case with zero elements.
     if (n == 0) {
-        return unique_alloc_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+        return unique_alloc_ptr<T>(
+            details::get_nonexistent_pointer<pointer_t>());
     }
 
     /*
@@ -403,7 +418,8 @@ unique_alloc_ptr<T> make_unique_alloc(memory_resource& m, std::size_t n,
 
     // Handle the case with zero elements.
     if (n == 0) {
-        return unique_alloc_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+        return unique_alloc_ptr<T>(
+            details::get_nonexistent_pointer<pointer_t>());
     }
 
     /*

--- a/core/include/vecmem/memory/unique_ptr.hpp
+++ b/core/include/vecmem/memory/unique_ptr.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -115,6 +115,11 @@ typename std::enable_if_t<std::is_array_v<T> && std::extent_v<T> == 0,
                           unique_obj_ptr<T>>
 make_unique_obj(memory_resource& m, std::size_t n) {
     using pointer_t = typename unique_obj_ptr<T>::deleter_type::pointer_t;
+
+    // Handle the case with zero elements.
+    if (n == 0) {
+        return unique_obj_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+    }
 
     /*
      * Calculate the size of the allocation and use the memory resource to
@@ -241,6 +246,11 @@ unique_alloc_ptr<T> make_unique_alloc(memory_resource& m, std::size_t n) {
 
     using pointer_t =
         std::conditional_t<std::is_array_v<T>, std::decay_t<T>, T*>;
+
+    // Handle the case with zero elements.
+    if (n == 0) {
+        return unique_alloc_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+    }
 
     /*
      * Calculate the size of the allocation and use the memory resource to
@@ -390,6 +400,11 @@ unique_alloc_ptr<T> make_unique_alloc(memory_resource& m, std::size_t n,
 
     using pointer_t =
         std::conditional_t<std::is_array_v<T>, std::decay_t<T>, T*>;
+
+    // Handle the case with zero elements.
+    if (n == 0) {
+        return unique_alloc_ptr<T>(reinterpret_cast<pointer_t>(0xf0000000));
+    }
 
     /*
      * Calculate the size of the allocation and use the memory resource to

--- a/core/src/memory/details/memory_resource_impl.hpp
+++ b/core/src/memory/details/memory_resource_impl.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,6 +9,10 @@
 
 // Local include(s).
 #include "vecmem/utils/debug.hpp"
+
+// System include(s).
+#include <cassert>
+#include <stdexcept>
 
 /// Helper macro for implementing all standard constructors, copy/move
 /// operators and functions for a memory resource that uses PIMPL.
@@ -22,7 +26,7 @@
     CLASSNAME& CLASSNAME::operator=(CLASSNAME&&) = default;                 \
     void* CLASSNAME::do_allocate(std::size_t size, std::size_t alignment) { \
         if (size == 0) {                                                    \
-            return nullptr;                                                 \
+            throw std::bad_alloc();                                         \
         }                                                                   \
         void* ptr = m_impl->allocate(size, alignment);                      \
         VECMEM_DEBUG_MSG(2, "Allocated %lu bytes at %p", size, ptr);        \
@@ -30,7 +34,8 @@
     }                                                                       \
     void CLASSNAME::do_deallocate(void* ptr, std::size_t size,              \
                                   std::size_t alignment) {                  \
-        if (ptr == nullptr) {                                               \
+        assert(ptr != nullptr);                                             \
+        if (size == 0u) {                                                   \
             return;                                                         \
         }                                                                   \
         VECMEM_DEBUG_MSG(2, "De-allocating memory at %p", ptr);             \

--- a/core/src/memory/host_memory_resource.cpp
+++ b/core/src/memory/host_memory_resource.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
+#include <stdexcept>
 
 namespace vecmem {
 
@@ -27,7 +28,7 @@ void *host_memory_resource::do_allocate(std::size_t bytes,
                                         std::size_t alignment) {
 
     if (bytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
 #ifdef VECMEM_HAVE_STD_ALIGNED_ALLOC
@@ -77,9 +78,11 @@ void *host_memory_resource::do_allocate(std::size_t bytes,
     return ptr;
 }
 
-void host_memory_resource::do_deallocate(void *ptr, std::size_t, std::size_t) {
+void host_memory_resource::do_deallocate(void *ptr, std::size_t bytes,
+                                         std::size_t) {
 
-    if (ptr == nullptr) {
+    assert(ptr != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/core/src/memory/identity_memory_resource.cpp
+++ b/core/src/memory/identity_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,10 +19,6 @@ identity_memory_resource::~identity_memory_resource() = default;
 void *identity_memory_resource::do_allocate(std::size_t size,
                                             std::size_t align) {
 
-    if (size == 0) {
-        return nullptr;
-    }
-
     /*
      * By definition, this just forwards the allocation upstream.
      */
@@ -31,10 +27,6 @@ void *identity_memory_resource::do_allocate(std::size_t size,
 
 void identity_memory_resource::do_deallocate(void *ptr, std::size_t size,
                                              std::size_t align) {
-
-    if (ptr == nullptr) {
-        return;
-    }
 
     /*
      * The deallocation, like allocation, is a forwarding method.

--- a/cuda/src/memory/device_memory_resource.cpp
+++ b/cuda/src/memory/device_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,6 +18,10 @@
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::cuda {
 
 device_memory_resource::device_memory_resource(int device)
@@ -32,7 +36,7 @@ device_memory_resource::~device_memory_resource() = default;
 void *device_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
 
     if (bytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Make sure that we would use the appropriate device.
@@ -46,9 +50,11 @@ void *device_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
     return res;
 }
 
-void device_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+void device_memory_resource::do_deallocate(void *p, std::size_t bytes,
+                                           std::size_t) {
 
-    if (p == nullptr) {
+    assert(p != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/cuda/src/memory/host_memory_resource.cpp
+++ b/cuda/src/memory/host_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,10 @@
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::cuda {
 
 host_memory_resource::host_memory_resource() = default;
@@ -24,7 +28,7 @@ host_memory_resource::~host_memory_resource() = default;
 void *host_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
 
     if (bytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.
@@ -34,9 +38,11 @@ void *host_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
     return res;
 }
 
-void host_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+void host_memory_resource::do_deallocate(void *p, std::size_t bytes,
+                                         std::size_t) {
 
-    if (p == nullptr) {
+    assert(p != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/cuda/src/memory/managed_memory_resource.cpp
+++ b/cuda/src/memory/managed_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,10 @@
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::cuda {
 
 managed_memory_resource::managed_memory_resource() = default;
@@ -24,7 +28,7 @@ managed_memory_resource::~managed_memory_resource() = default;
 void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
 
     if (bytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.
@@ -34,9 +38,11 @@ void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
     return res;
 }
 
-void managed_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+void managed_memory_resource::do_deallocate(void *p, std::size_t bytes,
+                                            std::size_t) {
 
-    if (p == nullptr) {
+    assert(p != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/hip/src/memory/device_memory_resource.cpp
+++ b/hip/src/memory/device_memory_resource.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,10 @@
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::hip {
 
 device_memory_resource::device_memory_resource(int device)
@@ -26,7 +30,7 @@ device_memory_resource::~device_memory_resource() = default;
 void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 
     if (nbytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.
@@ -39,10 +43,11 @@ void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
     return result;
 }
 
-void device_memory_resource::do_deallocate(void* ptr, std::size_t,
+void device_memory_resource::do_deallocate(void* ptr, std::size_t bytes,
                                            std::size_t) {
 
-    if (ptr == nullptr) {
+    assert(ptr != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/hip/src/memory/host_memory_resource.cpp
+++ b/hip/src/memory/host_memory_resource.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -14,6 +14,10 @@
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::hip {
 
 host_memory_resource::host_memory_resource() = default;
@@ -23,7 +27,7 @@ host_memory_resource::~host_memory_resource() = default;
 void* host_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 
     if (nbytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.
@@ -33,9 +37,11 @@ void* host_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
     return result;
 }
 
-void host_memory_resource::do_deallocate(void* ptr, std::size_t, std::size_t) {
+void host_memory_resource::do_deallocate(void* ptr, std::size_t bytes,
+                                         std::size_t) {
 
-    if (ptr == nullptr) {
+    assert(ptr != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/hip/src/memory/managed_memory_resource.cpp
+++ b/hip/src/memory/managed_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -15,6 +15,10 @@
 // HIP include(s).
 #include <hip/hip_runtime_api.h>
 
+// System include(s).
+#include <cassert>
+#include <stdexcept>
+
 namespace vecmem::hip {
 
 managed_memory_resource::managed_memory_resource() = default;
@@ -24,7 +28,7 @@ managed_memory_resource::~managed_memory_resource() = default;
 void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
 
     if (bytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.
@@ -34,9 +38,11 @@ void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
     return res;
 }
 
-void managed_memory_resource::do_deallocate(void *p, std::size_t, std::size_t) {
+void managed_memory_resource::do_deallocate(void *p, std::size_t bytes,
+                                            std::size_t) {
 
-    if (p == nullptr) {
+    assert(p != nullptr);
+    if (bytes == 0u) {
         return;
     }
 

--- a/sycl/src/memory/device_memory_resource.sycl
+++ b/sycl/src/memory/device_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,9 @@
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
+// System include(s).
+#include <stdexcept>
+
 namespace vecmem::sycl {
 
 device_memory_resource::device_memory_resource(const queue_wrapper& queue)
@@ -24,7 +27,7 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
                                           std::size_t alignment) {
 
     if (nbytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.

--- a/sycl/src/memory/host_memory_resource.sycl
+++ b/sycl/src/memory/host_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,9 @@
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
+// System include(s).
+#include <stdexcept>
+
 namespace vecmem::sycl {
 
 host_memory_resource::host_memory_resource(const queue_wrapper& queue)
@@ -24,7 +27,7 @@ void* host_memory_resource::do_allocate(std::size_t nbytes,
                                         std::size_t alignment) {
 
     if (nbytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.

--- a/sycl/src/memory/memory_resource_base.sycl
+++ b/sycl/src/memory/memory_resource_base.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,9 @@
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
+// System include(s).
+#include <cassert>
+
 namespace vecmem::sycl::details {
 
 memory_resource_base::memory_resource_base(const queue_wrapper& queue)
@@ -20,9 +23,11 @@ memory_resource_base::memory_resource_base(const queue_wrapper& queue)
 
 memory_resource_base::~memory_resource_base() = default;
 
-void memory_resource_base::do_deallocate(void* ptr, std::size_t, std::size_t) {
+void memory_resource_base::do_deallocate(void* ptr, std::size_t size,
+                                         std::size_t) {
 
-    if (ptr == nullptr) {
+    assert(ptr != nullptr);
+    if (size == 0u) {
         return;
     }
 

--- a/sycl/src/memory/shared_memory_resource.sycl
+++ b/sycl/src/memory/shared_memory_resource.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,6 +13,9 @@
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
+// System include(s).
+#include <stdexcept>
+
 namespace vecmem::sycl {
 
 shared_memory_resource::shared_memory_resource(const queue_wrapper& queue)
@@ -24,7 +27,7 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
                                           std::size_t alignment) {
 
     if (nbytes == 0) {
-        return nullptr;
+        throw std::bad_alloc();
     }
 
     // Allocate the memory.

--- a/tests/common/memory_resource_test_basic.ipp
+++ b/tests/common/memory_resource_test_basic.ipp
@@ -1,19 +1,24 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 
 #pragma once
 
+// System include(s).
+#include <stdexcept>
+
 /// Perform some very basic tests that do not need host accessibility
 TEST_P(memory_resource_test_basic, allocations) {
 
     vecmem::memory_resource* resource = GetParam();
-    for (std::size_t size = 0; size < 100000; size += 1000) {
+    EXPECT_THROW(static_cast<void>(resource->allocate(0)), std::bad_alloc);
+    for (std::size_t size = 1; size < 100000; size += 1000) {
         void* ptr = resource->allocate(size);
+        EXPECT_NE(ptr, nullptr);
         resource->deallocate(ptr, size);
     }
 }

--- a/tests/core/test_core_conditional_memory_resource.cpp
+++ b/tests/core/test_core_conditional_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,8 +25,8 @@ TEST(core_conditional_memory_resource_test, allocate1) {
 
     void* p = nullptr;
 
+    EXPECT_THROW(p = res.allocate(0), std::bad_alloc);
     EXPECT_THROW(p = res.allocate(10), std::bad_alloc);
-    EXPECT_NO_THROW(p = res.allocate(0));
     EXPECT_EQ(allocs, 0);
     EXPECT_NO_THROW(p = res.allocate(5321));
     EXPECT_EQ(allocs, 1);
@@ -58,8 +58,8 @@ TEST(core_conditional_memory_resource_test, allocate2) {
 
     void* p = nullptr;
 
+    EXPECT_THROW(p = res.allocate(0), std::bad_alloc);
     EXPECT_THROW(p = res.allocate(10), std::bad_alloc);
-    EXPECT_NO_THROW(p = res.allocate(0));
     EXPECT_THROW(p = res.allocate(5321), std::bad_alloc);
     EXPECT_THROW(p = res.allocate(55), std::bad_alloc);
     EXPECT_THROW(p = res.allocate(19), std::bad_alloc);

--- a/tests/core/test_core_terminal_memory_resource.cpp
+++ b/tests/core/test_core_terminal_memory_resource.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,12 +34,9 @@ TEST(core_terminal_memory_resource_test, deallocate) {
 
     void* p = ups.allocate(1024);
 
-    void* i = nullptr;
-
     /*
      * How do you even meaningfully test that a bit of code does nothing?
      */
-    EXPECT_NO_THROW(res.deallocate(i, 8));
     EXPECT_NO_THROW(res.deallocate(p, 1024));
 
     ups.deallocate(p, 1024);


### PR DESCRIPTION
Ever since GCC 13 arrived, we've been getting the following runtime errors in our tests:

```
/usr/include/c++/13/bits/memory_resource.h:76:71: runtime error: null pointer returned from function declared to never return null
```

Along with a couple of:

```
/data/ssd-1tb/projects/vecmem/vecmem/tests/core/test_core_terminal_memory_resource.cpp:42:5: runtime error: null pointer passed as argument 2, which is declared to never be null
```

It was just never the most urgent thing to fix, since the downstream projects don't ask for 0 allocations. :thinking: But as a bit of a palette cleanser, it seemed to be time to do this finally. :thinking: