### PR TITLE
SoA Fixes, main branch (2025.02.28.)

### DIFF
--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -81,12 +81,23 @@ public:
     VECMEM_HOST_AND_DEVICE
     explicit device_vector(const data::vector_view<value_type>& data);
     /// Copy constructor
-    VECMEM_HOST_AND_DEVICE
-    device_vector(const device_vector& parent);
+    device_vector(const device_vector& parent) = default;
+    /// Copy constructor
+    template <typename OTHERTYPE,
+              std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE device_vector(
+        const device_vector<OTHERTYPE>& parent);
 
-    /// Copy assignment operator
-    VECMEM_HOST_AND_DEVICE
-    device_vector& operator=(const device_vector& rhs);
+    /// Copy assignment operator from an identical type
+    VECMEM_HOST_AND_DEVICE device_vector& operator=(const device_vector& rhs);
+
+    /// Copy assignment operator from a different type
+    template <typename OTHERTYPE,
+              std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE device_vector& operator=(
+        const device_vector<OTHERTYPE>& rhs);
 
     /// @name Vector element access functions
     /// @{

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -29,8 +29,10 @@ VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
 }
 
 template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value, bool>>
 VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
-    const device_vector& parent)
+    const device_vector<OTHERTYPE>& parent)
     : m_capacity(parent.m_capacity),
       m_size(parent.m_size),
       m_ptr(parent.m_ptr) {
@@ -52,9 +54,26 @@ VECMEM_HOST_AND_DEVICE device_vector<TYPE>& device_vector<TYPE>::operator=(
     }
 
     // Copy the other object's payload.
-    m_capacity = rhs.m_capacity;
-    m_size = rhs.m_size;
-    m_ptr = rhs.m_ptr;
+    resize(rhs.size());
+    for (size_type i = 0; i < size(); ++i) {
+        this->at(i) = rhs.at(i);
+    }
+
+    // Return a reference to this object.
+    return *this;
+}
+
+template <typename TYPE>
+template <typename OTHERTYPE,
+          std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value, bool>>
+VECMEM_HOST_AND_DEVICE device_vector<TYPE>& device_vector<TYPE>::operator=(
+    const device_vector<OTHERTYPE>& rhs) {
+
+    // Copy the other object's payload.
+    resize(rhs.size());
+    for (size_type i = 0; i < size(); ++i) {
+        this->at(i) = rhs.at(i);
+    }
 
     // Return a reference to this object.
     return *this;

--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -70,7 +70,7 @@ public:
 
     /// Constructor with a mandatory memory resource
     VECMEM_HOST
-    host(memory_resource& resource);
+    explicit host(memory_resource& resource);
 
     /// @}
 

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -183,7 +183,9 @@ VECMEM_HOST memory_resource& host<schema<VARTYPES...>, INTERFACE>::resource()
 template <typename... VARTYPES, template <typename> class INTERFACE>
 VECMEM_HOST void get_data_impl(edm::host<edm::schema<VARTYPES...>, INTERFACE>&,
                                edm::data<edm::schema<VARTYPES...>>&,
-                               memory_resource&, std::index_sequence<>) {}
+                               memory_resource&, std::index_sequence<>) {
+    // For SonarCloud: The terminal node doesn't need to do anything.
+}
 
 /// Helper function recursive node
 template <typename... VARTYPES, template <typename> class INTERFACE,
@@ -199,10 +201,12 @@ VECMEM_HOST void get_data_impl(
         // Make the @c vecmem::edm::data object hold on to the
         // @c vecmem::data::jagged_vector_data object. Notice that this is a
         // move assignment here.
-        std::get<I>(data.variables()) = get_data(host.template get<I>(), &mr);
+        std::get<I>(data.variables()) =
+            ::vecmem::get_data(host.template get<I>(), &mr);
         // Set up the @c vecmem::edm::view object to point at the
         // @c vecmem::data::jagged_vector_data object.
-        data.template get<I>() = get_data(std::get<I>(data.variables()));
+        data.template get<I>() =
+            ::vecmem::get_data(std::get<I>(data.variables()));
     } else if constexpr (edm::type::details::is_scalar<
                              typename std::tuple_element<
                                  I, std::tuple<VARTYPES...>>::type>::value) {
@@ -212,7 +216,7 @@ VECMEM_HOST void get_data_impl(
     } else {
         // For 1D vectors it's enough to make @c vecmem::edm::view have a
         // correct @c vecmem::data::vector_view object.
-        data.template get<I>() = get_data(host.template get<I>());
+        data.template get<I>() = ::vecmem::get_data(host.template get<I>());
     }
     // Continue the recursion.
     get_data_impl(host, data, mr, std::index_sequence<Is...>{});
@@ -249,7 +253,9 @@ template <typename... VARTYPES, template <typename> class INTERFACE>
 VECMEM_HOST void get_data_impl(
     const edm::host<edm::schema<VARTYPES...>, INTERFACE>&,
     edm::data<edm::details::add_const_t<edm::schema<VARTYPES...>>>&,
-    memory_resource&, std::index_sequence<>) {}
+    memory_resource&, std::index_sequence<>) {
+    // For SonarCloud: The terminal node doesn't need to do anything.
+}
 
 /// Helper function recursive node
 template <typename... VARTYPES, template <typename> class INTERFACE,
@@ -265,10 +271,12 @@ VECMEM_HOST void get_data_impl(
         // Make the @c vecmem::edm::data object hold on to the
         // @c vecmem::data::jagged_vector_data object. Notice that this is a
         // move assignment here.
-        std::get<I>(data.variables()) = get_data(host.template get<I>(), &mr);
+        std::get<I>(data.variables()) =
+            ::vecmem::get_data(host.template get<I>(), &mr);
         // Set up the @c vecmem::edm::view object to point at the
         // @c vecmem::data::jagged_vector_data object.
-        data.template get<I>() = get_data(std::get<I>(data.variables()));
+        data.template get<I>() =
+            ::vecmem::get_data(std::get<I>(data.variables()));
     } else if constexpr (edm::type::details::is_scalar<
                              typename std::tuple_element<
                                  I, std::tuple<VARTYPES...>>::type>::value) {
@@ -278,7 +286,7 @@ VECMEM_HOST void get_data_impl(
     } else {
         // For 1D vectors it's enough to make @c vecmem::edm::view have a
         // correct @c vecmem::data::vector_view object.
-        data.template get<I>() = get_data(host.template get<I>());
+        data.template get<I>() = ::vecmem::get_data(host.template get<I>());
     }
     // Continue the recursion.
     get_data_impl(host, data, mr, std::index_sequence<Is...>{});

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -37,11 +37,11 @@ VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS,
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
           details::proxy_access PACCESS, details::proxy_type PTYPE>
-template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
-          details::proxy_type OPTYPE>
+template <typename... OVARTYPES, details::proxy_domain OPDOMAIN,
+          details::proxy_access OPACCESS, details::proxy_type OPTYPE>
 VECMEM_HOST_AND_DEVICE
 proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::proxy(
-    const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other)
+    const proxy<schema<OVARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other)
     : m_data(other.variables()) {}
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
@@ -54,15 +54,25 @@ proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::proxy(
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
           details::proxy_access PACCESS, details::proxy_type PTYPE>
-template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
-          details::proxy_type OPTYPE>
 VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>&
 proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::operator=(
-    const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other) {
+    const proxy& other) {
 
-    if (static_cast<const void*>(this) != static_cast<const void*>(&other)) {
+    if (this != &other) {
         m_data = other.variables();
     }
+    return *this;
+}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
+template <typename... OVARTYPES, details::proxy_domain OPDOMAIN,
+          details::proxy_access OPACCESS, details::proxy_type OPTYPE>
+VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>&
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::operator=(
+    const proxy<schema<OVARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other) {
+
+    m_data = other.variables();
     return *this;
 }
 

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -69,6 +69,12 @@ public:
     VECMEM_HOST_AND_DEVICE proxy(const PARENT& parent,
                                  typename PARENT::size_type index);
 
+    /// Default copy constructor
+    proxy(const proxy&) = default;
+
+    /// Default move constructor
+    proxy(proxy&&) = default;
+
     /// Copy constructor
     ///
     /// @tparam OPDOMAIN The domain of the other proxy
@@ -77,10 +83,10 @@ public:
     ///
     /// @param other The proxy to copy
     ///
-    template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
-              details::proxy_type OPTYPE>
+    template <typename... OVARTYPES, details::proxy_domain OPDOMAIN,
+              details::proxy_access OPACCESS, details::proxy_type OPTYPE>
     VECMEM_HOST_AND_DEVICE proxy(
-        const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
+        const proxy<schema<OVARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
 
     /// Construct a proxy from a list of variables
     ///
@@ -93,21 +99,31 @@ public:
         typename details::proxy_var_type<VARTYPES, proxy_domain, access_type,
                                          proxy_type>::type... data);
 
-    /// Assignment operator
-    ///
-    /// @tparam OPDOMAIN The domain of the other proxy
-    /// @tparam OPACCESS The access mode of the other proxy
-    /// @tparam OPTYPE   The type of the other proxy
+    /// Copy assignment operator from an identical type
     ///
     /// @param other The proxy to copy
     ///
     /// @return A reference to the proxy object
     ///
-    template <details::proxy_domain OPDOMAIN, details::proxy_access OPACCESS,
-              details::proxy_type OPTYPE>
+    VECMEM_HOST_AND_DEVICE
+    proxy& operator=(const proxy& other);
+
+    /// Copy assignment operator from a different type
+    ///
+    /// @tparam OVARTYPES The variable types of the other proxy
+    /// @tparam OPDOMAIN  The domain of the other proxy
+    /// @tparam OPACCESS  The access mode of the other proxy
+    /// @tparam OPTYPE    The type of the other proxy
+    ///
+    /// @param other The proxy to copy
+    ///
+    /// @return A reference to the proxy object
+    ///
+    template <typename... OVARTYPES, details::proxy_domain OPDOMAIN,
+              details::proxy_access OPACCESS, details::proxy_type OPTYPE>
     VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>&
     operator=(
-        const proxy<schema<VARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
+        const proxy<schema<OVARTYPES...>, OPDOMAIN, OPACCESS, OPTYPE>& other);
 
     /// @}
 

--- a/tests/core/test_core_edm_host.cpp
+++ b/tests/core/test_core_edm_host.cpp
@@ -213,6 +213,42 @@ TEST_F(core_edm_host_test, const_proxy) {
     }
 }
 
+TEST_F(core_edm_host_test, proxy_assign) {
+
+    // Helper lambda for comparing two containers.
+    auto compare = [](const host_type& h1, const host_type& h2) {
+        EXPECT_EQ(h1.size(), h2.size());
+        for (std::size_t i = 0; i < h1.size(); ++i) {
+            EXPECT_EQ(h1.at(i).scalar(), h2.at(i).scalar());
+            EXPECT_FLOAT_EQ(h1.at(i).vector(), h2.at(i).vector());
+            ASSERT_EQ(h1.at(i).jagged_vector().size(),
+                      h2.at(i).jagged_vector().size());
+            for (std::size_t j = 0; j < h1.at(i).jagged_vector().size(); ++j) {
+                EXPECT_DOUBLE_EQ(h1.at(i).jagged_vector().at(j),
+                                 h2.at(i).jagged_vector().at(j));
+            }
+        }
+    };
+
+    // Construct the host containers.
+    host_type orig = create();
+
+    // Make a copy using push_back-s.
+    host_type copy1{m_resource};
+    for (std::size_t i = 0; i < orig.size(); ++i) {
+        copy1.push_back(orig.at(i));
+    }
+    compare(orig, copy1);
+
+    // Make a copy using assignment.
+    host_type copy2{m_resource};
+    copy2.resize(orig.size());
+    for (std::size_t i = 0; i < orig.size(); ++i) {
+        copy2.at(i) = orig.at(i);
+    }
+    compare(orig, copy2);
+}
+
 namespace {
 using simple_schema = vecmem::edm::schema<vecmem::edm::type::scalar<int>,
                                           vecmem::edm::type::vector<float>>;


### PR DESCRIPTION
While preparing an update for [traccc](https://github.com/acts-project/traccc), I came across a number of issues in our code. :frowning:

First off, making an SoA container with a `detray::bound_track_parameters` element does not work currently. Because the `get_data(...)` calls implemented for `vecmem::edm::host` make compilers not know which `get_data(...)` function to use for such a Detray type. Because Detray happens to implement some super generic `detray::get_data` functions itself.

Originally I used scope-less `get_data(...)` calls on purpose in those functions, to allow users to slide in with their own definitions if needed. But now I rather think it's better to go like this, forwarding specifically to `::vecmem::get_data(...)` calls instead.

The other (much bigger) development of the PR is to make it possible to perform assignments between the elements of SoA containers. Like:

```c++
auto container1 = ...;
auto container2 = ...;
container1.at(...) = container2.at(...);
```

To make it happen a number of fixes needed to be made in both `vecmem::edm::proxy`, `vecmem::tuple` and `vecmem::device_vector`. :thinking: Many of which only came up when I added some explicit tests for this functionality. Since the traccc code started working with much more incorrect vecmem code as well. :stuck_out_tongue:

Basically they all now define constructors and assignment operators explicitly for both receiving a parent of the exact same type, and also a parent that is "a little different". (But still of an acceptable type.) For the latter I started using [std::is_constructible](https://en.cppreference.com/w/cpp/types/is_constructible) and [std::is_assignable](https://en.cppreference.com/w/cpp/types/is_assignable) instead of the quite broken tests that are in place right now.