### PR TITLE
VSCode SonarQube, main branch (2025.03.28.)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
       "*.hip": "cpp",
       "*.sycl": "cpp",
       "*.ipp": "cpp"
-   }
+   },
+   "sonarlint.connectedMode.project": {
+      "connectionId": "acts-project",
+      "projectKey": "acts-project_vecmem"
+   },
+   "sonarlint.pathToCompileCommands": "${workspaceFolder}/build/compile_commands.json"
 }


### PR DESCRIPTION
Added [VSCode](https://code.visualstudio.com/) settings for using the [SonarQube](https://marketplace.visualstudio.com/items?itemName=SonarSource.sonarlint-vscode) plugin.

This is admittedly a little specific to how I use VSCode lately, but it should also not interfere with people that either don't use VSCode, or don't use this plugin of VSCode. 🤔

The upside of having this set up is to get the linting results in the editor directly.

![image](https://github.com/user-attachments/assets/ffb33405-3389-4c97-9d0f-f0f4362ebe76)

For better or worse... 😛