### PR TITLE
SonarCloud Inspired Changes, main branch (2025.03.31.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,13 +31,13 @@ class jagged_vector_buffer : public jagged_vector_view<TYPE> {
 
 public:
     /// The base type used by this class
-    typedef jagged_vector_view<TYPE> base_type;
+    using base_type = jagged_vector_view<TYPE>;
     /// Use the base class's @c size_type
-    typedef typename base_type::size_type size_type;
+    using size_type = typename base_type::size_type;
     /// Use the base class's @c value_type
-    typedef typename base_type::value_type value_type;
+    using value_type = typename base_type::value_type;
     /// Pointer type to the jagged array
-    typedef typename base_type::pointer pointer;
+    using pointer = typename base_type::pointer;
 
     /// @name Checks on the type of the array element
     /// @{
@@ -95,10 +95,10 @@ public:
                          buffer_type type = buffer_type::fixed_size);
 
     /// Move constructor
-    jagged_vector_buffer(jagged_vector_buffer&&) = default;
+    jagged_vector_buffer(jagged_vector_buffer&&) noexcept = default;
 
     /// Move assignment
-    jagged_vector_buffer& operator=(jagged_vector_buffer&&) = default;
+    jagged_vector_buffer& operator=(jagged_vector_buffer&&) noexcept = default;
 
 private:
     /// Data object for the @c vecmem::data::vector_view array

--- a/core/include/vecmem/containers/data/jagged_vector_data.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_data.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -33,9 +33,9 @@ public:
     /// Type of the base class
     using base_type = jagged_vector_view<T>;
     /// Use the base class's @c size_type
-    typedef typename base_type::size_type size_type;
+    using size_type = typename base_type::size_type;
     /// Use the base class's @c value_type
-    typedef typename base_type::value_type value_type;
+    using value_type = typename base_type::value_type;
 
     /// Default constructor
     jagged_vector_data();
@@ -50,10 +50,10 @@ public:
      */
     jagged_vector_data(size_type size, memory_resource& mem);
     /// Move constructor
-    jagged_vector_data(jagged_vector_data&&) = default;
+    jagged_vector_data(jagged_vector_data&&) noexcept = default;
 
     /// Move assignment
-    jagged_vector_data& operator=(jagged_vector_data&&) = default;
+    jagged_vector_data& operator=(jagged_vector_data&&) noexcept = default;
 
 private:
     /// Data object owning the allocated memory

--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,18 +44,16 @@ template <typename T>
 class jagged_vector_view {
 
     /// We cannot use boolean types.
-    static_assert(!std::is_same<typename std::remove_cv<T>::type, bool>::value,
+    static_assert(!std::is_same<std::remove_cv_t<T>, bool>::value,
                   "bool is not supported in VecMem containers");
 
 public:
     /// Size type used in the class
-    typedef std::size_t size_type;
+    using size_type = std::size_t;
     /// Value type of the jagged array
-    typedef vector_view<T> value_type;
+    using value_type = vector_view<T>;
     /// Pointer type to the jagged array
-    typedef value_type* pointer;
-    /// Constant pointer type to the jagged array
-    typedef const value_type* const_pointer;
+    using pointer = std::add_pointer_t<value_type>;
 
     /**
      * Default constructor
@@ -115,14 +113,11 @@ public:
     VECMEM_HOST_AND_DEVICE
     size_type capacity() const;
 
-    /// Get a pointer to the vector elements (non-const)
+    /// Get a pointer to the vector elements
     VECMEM_HOST_AND_DEVICE
-    pointer ptr();
-    /// Get a pointer to the vector elements (const)
-    VECMEM_HOST_AND_DEVICE
-    const_pointer ptr() const;
+    pointer ptr() const;
 
-    /// Access the host accessible non-const array describing the inner vectors
+    /// Access the host accessible array describing the inner vectors
     ///
     /// This may or may not return the same pointer as @c ptr(). If the
     /// underlying data is stored in host-accessible memory, then the two will
@@ -135,16 +130,9 @@ public:
     ///         vectors
     ///
     VECMEM_HOST_AND_DEVICE
-    pointer host_ptr();
-    /// Access the host accessible const array describing the inner vectors
-    ///
-    /// @return A host-accessible pointer to the array describing the inner
-    ///         vectors
-    ///
-    VECMEM_HOST_AND_DEVICE
-    const_pointer host_ptr() const;
+    pointer host_ptr() const;
 
-protected:
+private:
     /**
      * The number of rows in this jagged vector.
      */

--- a/core/include/vecmem/containers/data/vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/vector_buffer.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,13 +30,13 @@ class vector_buffer : public vector_view<TYPE> {
 
 public:
     /// The base type used by this class
-    typedef vector_view<TYPE> base_type;
+    using base_type = vector_view<TYPE>;
     /// Size type definition coming from the base class
-    typedef typename base_type::size_type size_type;
+    using size_type = typename base_type::size_type;
     /// Size pointer type definition coming from the base class
-    typedef typename base_type::size_pointer size_pointer;
+    using size_pointer = typename base_type::size_pointer;
     /// Pointer type definition coming from the base class
-    typedef typename base_type::pointer pointer;
+    using pointer = typename base_type::pointer;
 
     /// @name Checks on the type of the array element
     /// @{
@@ -54,10 +54,10 @@ public:
     vector_buffer(size_type capacity, memory_resource& resource,
                   buffer_type type = buffer_type::fixed_size);
     /// Move constructor
-    vector_buffer(vector_buffer&&) = default;
+    vector_buffer(vector_buffer&&) noexcept = default;
 
     /// Move assignment
-    vector_buffer& operator=(vector_buffer&&) = default;
+    vector_buffer& operator=(vector_buffer&&) noexcept = default;
 
 private:
     /// Data object owning the allocated memory

--- a/core/include/vecmem/containers/data/vector_view.hpp
+++ b/core/include/vecmem/containers/data/vector_view.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,18 +44,14 @@ class vector_view {
 
 public:
     /// Size type used in the class
-    typedef unsigned int size_type;
+    using size_type = unsigned int;
     /// Pointer type to the size of the array
-    typedef
-        typename std::conditional<std::is_const<TYPE>::value, const size_type*,
-                                  size_type*>::type size_pointer;
-    /// Constant pointer type to the size of the array
-    typedef const typename std::remove_const<size_pointer>::type
-        const_size_pointer;
+    using size_pointer =
+        std::conditional_t<std::is_const<TYPE>::value,
+                           std::add_pointer_t<std::add_const_t<size_type>>,
+                           std::add_pointer_t<size_type>>;
     /// Pointer type to the array
-    typedef TYPE* pointer;
-    /// Constant pointer to the array
-    typedef const typename std::remove_const<pointer>::type const_pointer;
+    using pointer = std::add_pointer_t<TYPE>;
 
     /// Default constructor
     vector_view() = default;
@@ -91,20 +87,18 @@ public:
 
     /// Equality check. Two objects are only equal if they point at the same
     /// memory.
-    template <
-        typename OTHERTYPE,
-        std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
-                                      std::remove_cv_t<OTHERTYPE> >::value,
-                         bool> = true>
+    template <typename OTHERTYPE,
+              std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                            std::remove_cv_t<OTHERTYPE>>::value,
+                               bool> = true>
     VECMEM_HOST_AND_DEVICE bool operator==(
         const vector_view<OTHERTYPE>& rhs) const;
 
     /// Inequality check. Simply based on @c operator==.
-    template <
-        typename OTHERTYPE,
-        std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
-                                      std::remove_cv_t<OTHERTYPE> >::value,
-                         bool> = true>
+    template <typename OTHERTYPE,
+              std::enable_if_t<std::is_same<std::remove_cv_t<TYPE>,
+                                            std::remove_cv_t<OTHERTYPE>>::value,
+                               bool> = true>
     VECMEM_HOST_AND_DEVICE bool operator!=(
         const vector_view<OTHERTYPE>& rhs) const;
 
@@ -115,21 +109,15 @@ public:
     VECMEM_HOST_AND_DEVICE
     size_type capacity() const;
 
-    /// Get a pointer to the size of the vector (non-const)
+    /// Get a pointer to the size of the vector
     VECMEM_HOST_AND_DEVICE
-    size_pointer size_ptr();
-    /// Get a pointer to the size of the vector (const)
-    VECMEM_HOST_AND_DEVICE
-    const_size_pointer size_ptr() const;
+    size_pointer size_ptr() const;
 
-    /// Get a pointer to the vector elements (non-const)
+    /// Get a pointer to the vector elements
     VECMEM_HOST_AND_DEVICE
-    pointer ptr();
-    /// Get a pointer to the vector elements (const)
-    VECMEM_HOST_AND_DEVICE
-    const_pointer ptr() const;
+    pointer ptr() const;
 
-protected:
+private:
     /// Maximum capacity of the array
     size_type m_capacity;
     /// Pointer to the size of the array in memory

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -44,35 +44,36 @@ public:
     /// @{
 
     /// Type of the array elements
-    typedef TYPE value_type;
+    using value_type = TYPE;
     /// Size type for the array
-    typedef unsigned int size_type;
+    using size_type = unsigned int;
     /// Pointer difference type
-    typedef std::ptrdiff_t difference_type;
+    using difference_type = std::ptrdiff_t;
 
     /// Pointer type to the size of the array
-    typedef
+    using size_pointer =
         typename std::conditional<std::is_const<TYPE>::value, const size_type*,
-                                  size_type*>::type size_pointer;
+                                  size_type*>::type;
 
     /// Value reference type
-    typedef value_type& reference;
+    using reference = std::add_lvalue_reference_t<value_type>;
     /// Constant value reference type
-    typedef const value_type& const_reference;
+    using const_reference =
+        std::add_lvalue_reference_t<std::add_const_t<value_type>>;
     /// Value pointer type
-    typedef value_type* pointer;
+    using pointer = std::add_pointer_t<value_type>;
     /// Constant value pointer type
-    typedef const value_type* const_pointer;
+    using const_pointer = std::add_pointer_t<std::add_const_t<value_type>>;
 
     /// Forward iterator type
-    typedef pointer iterator;
+    using iterator = pointer;
     /// Constant forward iterator type
-    typedef const_pointer const_iterator;
+    using const_iterator = const_pointer;
     /// Reverse iterator type
-    typedef vecmem::details::reverse_iterator<iterator> reverse_iterator;
+    using reverse_iterator = vecmem::details::reverse_iterator<iterator>;
     /// Constant reverse iterator type
-    typedef vecmem::details::reverse_iterator<const_iterator>
-        const_reverse_iterator;
+    using const_reverse_iterator =
+        vecmem::details::reverse_iterator<const_iterator>;
 
     /// @}
 

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -107,11 +107,12 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
                 resource, capacities.size(), total_elements);
     }
 
-    // Point the base class at the newly allocated memory.
-    base_type::m_ptr =
+    // Set up the base object.
+    base_type::operator=(base_type{
+        capacities.size(),
         ((host_access_resource != nullptr) ? m_outer_memory.get()
-                                           : m_outer_host_memory.get());
-    base_type::m_host_ptr = m_outer_host_memory.get();
+                                           : m_outer_host_memory.get()),
+        m_outer_host_memory.get()});
 
     // Set up the vecmem::vector_view objects in the host accessible memory.
     std::ptrdiff_t ptrdiff = 0;

--- a/core/include/vecmem/containers/impl/jagged_vector_data.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_data.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -47,9 +47,9 @@ template <typename T>
 jagged_vector_data<T>::jagged_vector_data(size_type size, memory_resource& mem)
     : base_type(size, nullptr),
       m_memory(::allocate_jagged_memory<T>(size, mem)) {
-    // Point the base class at the newly allocated memory.
-    base_type::m_ptr = m_memory.get();
-    base_type::m_host_ptr = m_memory.get();
+
+    // Set up the base object.
+    base_type::operator=(base_type{size, m_memory.get(), m_memory.get()});
 
     /*
      * Construct vecmem::data::vector_view objects in the allocated area.
@@ -61,7 +61,7 @@ jagged_vector_data<T>::jagged_vector_data(size_type size, memory_resource& mem)
          * We use the memory allocated earlier and construct device vector
          * objects there.
          */
-        new (base_type::m_ptr + i) vector_view<T>();
+        new (base_type::host_ptr() + i) vector_view<T>();
     }
 }
 

--- a/core/include/vecmem/containers/impl/jagged_vector_view.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_view.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -80,43 +80,26 @@ VECMEM_HOST_AND_DEVICE bool jagged_vector_view<T>::operator!=(
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::size_type
-jagged_vector_view<T>::size() const {
+VECMEM_HOST_AND_DEVICE auto jagged_vector_view<T>::size() const -> size_type {
 
     return m_size;
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::size_type
-jagged_vector_view<T>::capacity() const {
+VECMEM_HOST_AND_DEVICE auto jagged_vector_view<T>::capacity() const
+    -> size_type {
 
     return m_size;
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::pointer
-jagged_vector_view<T>::ptr() {
+VECMEM_HOST_AND_DEVICE auto jagged_vector_view<T>::ptr() const -> pointer {
 
     return m_ptr;
 }
 
 template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::const_pointer
-jagged_vector_view<T>::ptr() const {
-
-    return m_ptr;
-}
-
-template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::pointer
-jagged_vector_view<T>::host_ptr() {
-
-    return m_host_ptr;
-}
-
-template <typename T>
-VECMEM_HOST_AND_DEVICE typename jagged_vector_view<T>::const_pointer
-jagged_vector_view<T>::host_ptr() const {
+VECMEM_HOST_AND_DEVICE auto jagged_vector_view<T>::host_ptr() const -> pointer {
 
     return m_host_ptr;
 }

--- a/core/include/vecmem/containers/impl/vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/vector_buffer.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2024 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -34,10 +34,16 @@ vector_buffer<TYPE>::vector_buffer(size_type capacity,
         return;
     }
 
-    std::tie(m_memory, base_type::m_size, base_type::m_ptr) =
+    // Allocate the memory of the buffer.
+    size_pointer size = nullptr;
+    pointer ptr = nullptr;
+    std::tie(m_memory, size, ptr) =
         details::aligned_multiple_placement<std::remove_pointer_t<size_pointer>,
                                             std::remove_pointer_t<pointer>>(
             resource, type == buffer_type::fixed_size ? 0 : 1, capacity);
+
+    // Set up the base object.
+    base_type::operator=(base_type{capacity, size, ptr});
 }
 
 }  // namespace data

--- a/core/include/vecmem/containers/impl/vector_view.ipp
+++ b/core/include/vecmem/containers/impl/vector_view.ipp
@@ -1,13 +1,10 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
-
-// System include(s).
-#include <cassert>
 
 namespace vecmem {
 namespace data {
@@ -84,26 +81,14 @@ VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::capacity() const -> size_type {
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size_ptr() -> size_pointer {
-
-    return m_size;
-}
-
-template <typename TYPE>
 VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::size_ptr() const
-    -> const_size_pointer {
+    -> size_pointer {
 
     return m_size;
 }
 
 template <typename TYPE>
-VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::ptr() -> pointer {
-
-    return m_ptr;
-}
-
-template <typename TYPE>
-VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::ptr() const -> const_pointer {
+VECMEM_HOST_AND_DEVICE auto vector_view<TYPE>::ptr() const -> pointer {
 
     return m_ptr;
 }

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -51,25 +51,26 @@ public:
     /// @{
 
     /// Type of the "outer" array elements
-    typedef device_vector<T> value_type;
+    using value_type = device_vector<T>;
     /// Size type for the array
-    typedef std::size_t size_type;
+    using size_type = std::size_t;
     /// Pointer difference type
-    typedef std::ptrdiff_t difference_type;
+    using difference_type = std::ptrdiff_t;
 
     /// Value reference type
-    typedef device_vector<T> reference;
+    using reference = device_vector<T>;
     /// Constant value reference type
-    typedef device_vector<const T> const_reference;
+    using const_reference = device_vector<std::add_const_t<T> >;
 
     /// Forward iterator type
-    typedef details::jagged_device_vector_iterator<T> iterator;
+    using iterator = details::jagged_device_vector_iterator<T>;
     /// Constant forward iterator type
-    typedef details::jagged_device_vector_iterator<const T> const_iterator;
+    using const_iterator =
+        details::jagged_device_vector_iterator<std::add_const_t<T> >;
     /// Reverse iterator type
-    typedef details::reverse_iterator<iterator> reverse_iterator;
+    using reverse_iterator = details::reverse_iterator<iterator>;
     /// Constant reverse iterator type
-    typedef details::reverse_iterator<const_iterator> const_reverse_iterator;
+    using const_reverse_iterator = details::reverse_iterator<const_iterator>;
 
     /// @}
 


### PR DESCRIPTION
Implemented many of SonarCloud's suggestions for the (base) containers.

Simplified the view types by not using `const` and non-`const` accessor functions separately anymore. Making the types more similar to the implementation of [std::span](https://en.cppreference.com/w/cpp/container/span).
  - Previously the `const_pointer` types were incorrectly defined. `vecmem::vector_view<T>::const_pointer` was not `const T*`, but rather `T* const`. This is why the code worked at all. 🤔 It turns out that having separate `const` and non-`const` accessor functions on the views is not meaningful in the end. With the final nail in the coffin being lambdas. 🤔 Since the following just didn't work once I fixed the previously incorrectly defined types:

```c++
vecmem::vector_view<int> view;
[view]() {
   int* ptr = view.ptr();
}();
```

(Since captured objects are **always** `const`. So not allowing access to the non-const pointer through a const view object makes the use of these views **very** inconvenient with SYCL.)

Stopped using protected variables in the view types. Making the derived classes set up their base objects through operator=(...).