### PR TITLE
Jagged Vector Buffer Fix, main branch (2025.04.01.)

### DIFF
--- a/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_buffer.hpp
@@ -86,10 +86,11 @@ public:
     /// @param type The type (resizable or not) of the buffer
     ///
     template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>,
               std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
                                    std::is_unsigned<SIZE_TYPE>::value,
                                bool> = true>
-    jagged_vector_buffer(const std::vector<SIZE_TYPE>& capacities,
+    jagged_vector_buffer(const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
                          memory_resource& resource,
                          memory_resource* host_access_resource = nullptr,
                          buffer_type type = buffer_type::fixed_size);

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -69,13 +69,14 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
                            type) {}
 
 template <typename TYPE>
-template <typename SIZE_TYPE,
+template <typename SIZE_TYPE, typename SIZE_ALLOC,
           std::enable_if_t<std::is_integral<SIZE_TYPE>::value &&
                                std::is_unsigned<SIZE_TYPE>::value,
                            bool> >
 jagged_vector_buffer<TYPE>::jagged_vector_buffer(
-    const std::vector<SIZE_TYPE>& capacities, memory_resource& resource,
-    memory_resource* host_access_resource, buffer_type type)
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+    memory_resource& resource, memory_resource* host_access_resource,
+    buffer_type type)
     : base_type(capacities.size(), nullptr),
       m_outer_memory(::allocate_jagged_buffer_outer_memory<TYPE>(
           (host_access_resource == nullptr ? 0 : capacities.size()), resource)),

--- a/core/include/vecmem/edm/buffer.hpp
+++ b/core/include/vecmem/edm/buffer.hpp
@@ -215,26 +215,32 @@ public:
     /// @param type       The type of the buffer (fixed or variable size)
     ///
     template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>,
               std::enable_if_t<std::is_integral_v<SIZE_TYPE> &&
                                    std::is_unsigned_v<SIZE_TYPE>,
                                bool> = true>
     VECMEM_HOST buffer(
-        const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
-        memory_resource* host_mr = nullptr,
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+        memory_resource& mr, memory_resource* host_mr = nullptr,
         vecmem::data::buffer_type type = vecmem::data::buffer_type::fixed_size);
 
 private:
     /// Set up a fixed sized buffer
-    template <typename SIZE_TYPE = std::size_t, std::size_t... INDICES>
-    VECMEM_HOST void setup_fixed(const std::vector<SIZE_TYPE>& capacities,
-                                 memory_resource& mr, memory_resource* host_mr,
-                                 std::index_sequence<INDICES...>);
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>,
+              std::size_t... INDICES>
+    VECMEM_HOST void setup_fixed(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+        memory_resource& mr, memory_resource* host_mr,
+        std::index_sequence<INDICES...>);
     /// Set up a resizable buffer
-    template <typename SIZE_TYPE = std::size_t, std::size_t... INDICES>
-    VECMEM_HOST void setup_resizable(const std::vector<SIZE_TYPE>& capacities,
-                                     memory_resource& mr,
-                                     memory_resource* host_mr,
-                                     std::index_sequence<INDICES...>);
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>,
+              std::size_t... INDICES>
+    VECMEM_HOST void setup_resizable(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+        memory_resource& mr, memory_resource* host_mr,
+        std::index_sequence<INDICES...>);
 
     /// The full allocated block of (device) memory
     memory_type m_memory;

--- a/core/include/vecmem/edm/details/buffer_traits.hpp
+++ b/core/include/vecmem/edm/details/buffer_traits.hpp
@@ -31,88 +31,101 @@ template <typename TYPE>
 struct buffer_alloc;
 
 template <typename TYPE>
-struct buffer_alloc<type::scalar<TYPE> > {
+struct buffer_alloc<type::scalar<TYPE>> {
     /// The number of @c TYPE elements to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static std::size_t payload_size(const std::vector<SIZE_TYPE>&) {
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static std::size_t payload_size(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>&) {
         return 1u;
     }
     /// The number of "layout meta-objects" to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static std::size_t layout_size(const std::vector<SIZE_TYPE>&) {
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static std::size_t layout_size(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>&) {
         return 0u;
     }
     /// Construct a view for a scalar variable.
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static typename view_type<type::scalar<TYPE> >::type make_view(
-        const std::vector<SIZE_TYPE>&, unsigned int*,
-        typename view_type<type::scalar<TYPE> >::layout_ptr,
-        typename view_type<type::scalar<TYPE> >::layout_ptr,
-        typename view_type<type::scalar<TYPE> >::payload_ptr ptr) {
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static typename view_type<type::scalar<TYPE>>::type make_view(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>&, unsigned int*,
+        typename view_type<type::scalar<TYPE>>::layout_ptr,
+        typename view_type<type::scalar<TYPE>>::layout_ptr,
+        typename view_type<type::scalar<TYPE>>::payload_ptr ptr) {
         return ptr;
     }
 };  // struct buffer_alloc
 
 template <typename TYPE>
-struct buffer_alloc<type::vector<TYPE> > {
+struct buffer_alloc<type::vector<TYPE>> {
     /// The number of @c TYPE elements to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
     VECMEM_HOST static std::size_t payload_size(
-        const std::vector<SIZE_TYPE>& sizes) {
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& sizes) {
         return sizes.size();
     }
     /// The number of "layout meta-objects" to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static std::size_t layout_size(const std::vector<SIZE_TYPE>&) {
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static std::size_t layout_size(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>&) {
         return 0u;
     }
     /// Construct a view for a vector variable.
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static typename view_type<type::vector<TYPE> >::type make_view(
-        const std::vector<SIZE_TYPE>& capacity, unsigned int* size,
-        typename view_type<type::vector<TYPE> >::layout_ptr,
-        typename view_type<type::vector<TYPE> >::layout_ptr,
-        typename view_type<type::vector<TYPE> >::payload_ptr ptr) {
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static typename view_type<type::vector<TYPE>>::type make_view(
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacity, unsigned int* size,
+        typename view_type<type::vector<TYPE>>::layout_ptr,
+        typename view_type<type::vector<TYPE>>::layout_ptr,
+        typename view_type<type::vector<TYPE>>::payload_ptr ptr) {
         return {static_cast<
-                    typename view_type<type::vector<TYPE> >::type::size_type>(
+                    typename view_type<type::vector<TYPE>>::type::size_type>(
                     capacity.size()),
                 size, ptr};
     }
 };  // struct buffer_alloc
 
 template <typename TYPE>
-struct buffer_alloc<type::jagged_vector<TYPE> > {
+struct buffer_alloc<type::jagged_vector<TYPE>> {
     /// The number of @c TYPE elements to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
     VECMEM_HOST static std::size_t payload_size(
-        const std::vector<SIZE_TYPE>& sizes) {
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& sizes) {
         return std::accumulate(sizes.begin(), sizes.end(),
                                static_cast<std::size_t>(0));
     }
     /// The number of "layout meta-objects" to allocate for the payload
-    template <typename SIZE_TYPE = std::size_t>
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
     VECMEM_HOST static std::size_t layout_size(
-        const std::vector<SIZE_TYPE>& sizes) {
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& sizes) {
         return sizes.size();
     }
     /// Construct a view for a jagged vector variable.
-    template <typename SIZE_TYPE = std::size_t>
-    VECMEM_HOST static typename view_type<type::jagged_vector<TYPE> >::type
+    template <typename SIZE_TYPE = std::size_t,
+              typename SIZE_ALLOC = std::allocator<SIZE_TYPE>>
+    VECMEM_HOST static typename view_type<type::jagged_vector<TYPE>>::type
     make_view(
-        const std::vector<SIZE_TYPE>& capacities, unsigned int* sizes,
-        typename view_type<type::jagged_vector<TYPE> >::layout_ptr layout,
-        typename view_type<type::jagged_vector<TYPE> >::layout_ptr host_layout,
-        typename view_type<type::jagged_vector<TYPE> >::payload_ptr ptr) {
+        const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+        unsigned int* sizes,
+        typename view_type<type::jagged_vector<TYPE>>::layout_ptr layout,
+        typename view_type<type::jagged_vector<TYPE>>::layout_ptr host_layout,
+        typename view_type<type::jagged_vector<TYPE>>::payload_ptr ptr) {
 
         // Set up the "layout objects" for use by the view.
-        typename view_type<type::jagged_vector<TYPE> >::layout_ptr used_layout =
+        typename view_type<type::jagged_vector<TYPE>>::layout_ptr used_layout =
             (host_layout != nullptr ? host_layout : layout);
         std::ptrdiff_t ptrdiff = 0;
         for (std::size_t i = 0; i < capacities.size(); ++i) {
             new (used_layout + i)
-                typename view_type<type::jagged_vector<TYPE> >::layout_type(
+                typename view_type<type::jagged_vector<TYPE>>::layout_type(
                     static_cast<typename view_type<
-                        type::jagged_vector<TYPE> >::layout_type::size_type>(
+                        type::jagged_vector<TYPE>>::layout_type::size_type>(
                         capacities[i]),
                     (sizes != nullptr ? &(sizes[i]) : nullptr), ptr + ptrdiff);
             ptrdiff += capacities[i];
@@ -120,7 +133,7 @@ struct buffer_alloc<type::jagged_vector<TYPE> > {
 
         // Create the jagged vector view.
         return {static_cast<
-                    typename view_type<type::vector<TYPE> >::type::size_type>(
+                    typename view_type<type::vector<TYPE>>::type::size_type>(
                     capacities.size()),
                 layout, host_layout};
     }
@@ -129,9 +142,10 @@ struct buffer_alloc<type::jagged_vector<TYPE> > {
 /// @}
 
 /// Function constructing fixed size view objects for @c vecmem::edm::buffer
-template <typename SIZE_TYPE, typename... TYPES, std::size_t... INDICES>
+template <typename SIZE_TYPE, typename SIZE_ALLOC, typename... TYPES,
+          std::size_t... INDICES>
 VECMEM_HOST auto make_buffer_views(
-    const std::vector<SIZE_TYPE>& sizes,
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& sizes,
     const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
     const std::tuple<typename view_type<TYPES>::layout_ptr...>& host_layouts,
     const std::tuple<typename view_type<TYPES>::payload_ptr...>& payloads,
@@ -143,9 +157,10 @@ VECMEM_HOST auto make_buffer_views(
 }
 
 /// Function constructing resizable view objects for @c vecmem::edm::buffer
-template <typename SIZE_TYPE, typename... TYPES, std::size_t... INDICES>
+template <typename SIZE_TYPE, typename SIZE_ALLOC, typename... TYPES,
+          std::size_t... INDICES>
 VECMEM_HOST auto make_buffer_views(
-    const std::vector<SIZE_TYPE>& capacities,
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
     const std::tuple<typename view_type<TYPES>::size_ptr...>& sizes,
     const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
     const std::tuple<typename view_type<TYPES>::layout_ptr...>& host_layouts,
@@ -212,13 +227,13 @@ VECMEM_HOST constexpr void* find_last_pointer(
 
 /// Function creating a view for the layout of a buffer.
 template <typename... TYPES>
-VECMEM_HOST constexpr typename view<schema<TYPES...> >::memory_view_type
+VECMEM_HOST constexpr typename view<schema<TYPES...>>::memory_view_type
 find_layout_view(
     const std::tuple<typename view_type<TYPES>::layout_ptr...>& layouts,
     const std::array<std::size_t, sizeof...(TYPES)>& sizes) {
 
     // The result type.
-    using result_type = typename view<schema<TYPES...> >::memory_view_type;
+    using result_type = typename view<schema<TYPES...>>::memory_view_type;
 
     // Find the first non-zero pointer.
     auto ptr = static_cast<typename result_type::pointer>(
@@ -233,13 +248,13 @@ find_layout_view(
 
 /// Function creating a view of the payload of a buffer
 template <typename... TYPES>
-VECMEM_HOST constexpr typename view<schema<TYPES...> >::memory_view_type
+VECMEM_HOST constexpr typename view<schema<TYPES...>>::memory_view_type
 find_payload_view(
     const std::tuple<typename view_type<TYPES>::payload_ptr...>& payloads,
     const std::array<std::size_t, sizeof...(TYPES)>& sizes) {
 
     // The result type.
-    using result_type = typename view<schema<TYPES...> >::memory_view_type;
+    using result_type = typename view<schema<TYPES...>>::memory_view_type;
 
     // Find the first non-zero pointer.
     auto ptr = static_cast<typename result_type::pointer>(

--- a/core/include/vecmem/edm/impl/buffer.ipp
+++ b/core/include/vecmem/edm/impl/buffer.ipp
@@ -50,12 +50,13 @@ VECMEM_HOST buffer<schema<VARTYPES...>>::buffer(size_type capacity,
 
 template <typename... VARTYPES>
 template <
-    typename SIZE_TYPE,
+    typename SIZE_TYPE, typename SIZE_ALLOC,
     std::enable_if_t<
         std::is_integral_v<SIZE_TYPE> && std::is_unsigned_v<SIZE_TYPE>, bool>>
 VECMEM_HOST buffer<schema<VARTYPES...>>::buffer(
-    const std::vector<SIZE_TYPE>& capacities, memory_resource& main_mr,
-    memory_resource* host_mr, vecmem::data::buffer_type type)
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
+    memory_resource& main_mr, memory_resource* host_mr,
+    vecmem::data::buffer_type type)
     : view_type(static_cast<size_type>(capacities.size())) {
 
     // Make sure that this constructor is only used for a container that has
@@ -80,9 +81,9 @@ VECMEM_HOST buffer<schema<VARTYPES...>>::buffer(
 }
 
 template <typename... VARTYPES>
-template <typename SIZE_TYPE, std::size_t... INDICES>
+template <typename SIZE_TYPE, typename SIZE_ALLOC, std::size_t... INDICES>
 VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_fixed(
-    const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities, memory_resource& mr,
     memory_resource* host_mr, std::index_sequence<INDICES...>) {
 
     // Sanity check.
@@ -132,15 +133,16 @@ VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_fixed(
     }
 
     // Initialize the views from all the raw pointers.
-    view_type::m_views = details::make_buffer_views<SIZE_TYPE, VARTYPES...>(
-        capacities, layout_ptrs, host_layout_ptrs, payload_ptrs,
-        std::index_sequence_for<VARTYPES...>{});
+    view_type::m_views =
+        details::make_buffer_views<SIZE_TYPE, SIZE_ALLOC, VARTYPES...>(
+            capacities, layout_ptrs, host_layout_ptrs, payload_ptrs,
+            std::index_sequence_for<VARTYPES...>{});
 }
 
 template <typename... VARTYPES>
-template <typename SIZE_TYPE, std::size_t... INDICES>
+template <typename SIZE_TYPE, typename SIZE_ALLOC, std::size_t... INDICES>
 VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_resizable(
-    const std::vector<SIZE_TYPE>& capacities, memory_resource& mr,
+    const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities, memory_resource& mr,
     memory_resource* host_mr, std::index_sequence<INDICES...>) {
 
     // Sanity check(s).
@@ -237,9 +239,10 @@ VECMEM_HOST void buffer<schema<VARTYPES...>>::setup_resizable(
     }
 
     // Initialize the views from all the raw pointers.
-    view_type::m_views = details::make_buffer_views<SIZE_TYPE, VARTYPES...>(
-        capacities, sizes_ptrs, layout_ptrs, host_layout_ptrs, payload_ptrs,
-        std::index_sequence_for<VARTYPES...>{});
+    view_type::m_views =
+        details::make_buffer_views<SIZE_TYPE, SIZE_ALLOC, VARTYPES...>(
+            capacities, sizes_ptrs, layout_ptrs, host_layout_ptrs, payload_ptrs,
+            std::index_sequence_for<VARTYPES...>{});
 }
 
 }  // namespace edm

--- a/tests/core/test_core_edm_buffer.cpp
+++ b/tests/core/test_core_edm_buffer.cpp
@@ -72,8 +72,11 @@ TEST_F(core_edm_buffer_test, construct) {
     // Test the creation of fixed sized and resizable "jagged buffers".
     vecmem::edm::buffer<jagged_schema> buffer3{
         CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::fixed_size};
+    const vecmem::vector<unsigned int> vecmem_capacities({10, 100, 1000},
+                                                         &m_resource);
     vecmem::edm::buffer<jagged_schema> buffer4{
-        CAPACITIES, m_resource, nullptr, vecmem::data::buffer_type::resizable};
+        vecmem_capacities, m_resource, nullptr,
+        vecmem::data::buffer_type::resizable};
 }
 
 TEST_F(core_edm_buffer_test, get_data) {

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -217,7 +217,7 @@ TEST_F(core_jagged_vector_view_test, sizeless) {
 
     // Create a resizable buffer for a jagged vector.
     vecmem::data::jagged_vector_buffer<int> output_data(
-        std::vector<std::size_t>(3, 0), m_mem, nullptr,
+        vecmem::vector<std::size_t>(3, 0, &m_mem), m_mem, nullptr,
         vecmem::data::buffer_type::resizable);
     copy.setup(output_data)->wait();
 


### PR DESCRIPTION
@stephenswat found in https://github.com/acts-project/traccc/pull/908 that currently it's not possible to create a `vecmem::data::jagged_vector_buffer` object with `vecmem::vector` for its size(s). This PR is meant to fix this.