### PR TITLE
HIP: Add Async Copy

### DIFF
--- a/hip/CMakeLists.txt
+++ b/hip/CMakeLists.txt
@@ -22,6 +22,8 @@ vecmem_add_library( vecmem_hip hip
    # Utilities.
    "include/vecmem/utils/hip/copy.hpp"
    "src/utils/hip/copy.cpp"
+   "include/vecmem/utils/hip/async_copy.hpp"
+   "src/utils/hip/async_copy.cpp"
    "include/vecmem/utils/hip/stream_wrapper.hpp"
    "src/utils/stream_wrapper.cpp"
    "src/utils/get_device_name.hpp"

--- a/hip/include/vecmem/utils/hip/async_copy.hpp
+++ b/hip/include/vecmem/utils/hip/async_copy.hpp
@@ -1,0 +1,56 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/utils/copy.hpp"
+#include "vecmem/utils/hip/stream_wrapper.hpp"
+#include "vecmem/vecmem_hip_export.hpp"
+
+namespace vecmem::hip {
+
+/// Specialisation of @c vecmem::copy for HIP
+///
+/// This specialisation of @c vecmem::copy, unlike @c vecmem::hip::copy,
+/// performs all of its operations asynchronously. Using the HIP stream
+/// that is given to its constructor.
+///
+/// It is up to the user to ensure that copy operations are performed in the
+/// right order, and they would finish before an operation that needs them
+/// is executed.
+///
+class async_copy : public vecmem::copy {
+
+public:
+    /// Constructor with the stream to operate on
+    VECMEM_HIP_EXPORT
+    async_copy(const stream_wrapper& stream);
+    /// Destructor
+    VECMEM_HIP_EXPORT
+    ~async_copy();
+
+protected:
+    /// Perform an asynchronous memory copy using HIP
+    VECMEM_HIP_EXPORT
+    virtual void do_copy(std::size_t size, const void* from, void* to,
+                         type::copy_type cptype) const override final;
+    /// Fill a memory area using HIP asynchronously
+    VECMEM_HIP_EXPORT
+    virtual void do_memset(std::size_t size, void* ptr,
+                           int value) const override final;
+    /// Create an event for synchronization
+    VECMEM_HIP_EXPORT
+    virtual event_type create_event() const override final;
+
+private:
+    /// The stream that the copies are performed on
+    stream_wrapper m_stream;
+
+};  // class async_copy
+
+}  // namespace vecmem::hip

--- a/hip/src/utils/hip/async_copy.cpp
+++ b/hip/src/utils/hip/async_copy.cpp
@@ -1,0 +1,155 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// VecMem include(s).
+#include "vecmem/utils/hip/async_copy.hpp"
+
+#include "../hip_error_handling.hpp"
+#include "vecmem/utils/debug.hpp"
+
+// HIP include(s).
+#include <hip/hip_runtime_api.h>
+
+// System include(s).
+#include <cassert>
+#include <exception>
+#include <string>
+
+namespace {
+
+/// HIP specific implementation of the abstract event interface
+struct hip_event : public vecmem::abstract_event {
+
+    /// Constructor with the created event.
+    hip_event(hipEvent_t event) : m_event(event) {
+        assert(m_event != nullptr);
+    }
+    /// Destructor
+    ~hip_event() {
+        // Check if the user forgot to wait on this asynchronous event.
+        if (m_event != nullptr) {
+            // If so, wait implicitly now.
+            VECMEM_DEBUG_MSG(1, "Asynchronous HIP event was not waited on!");
+            wait();
+#ifdef VECMEM_FAIL_ON_ASYNC_ERRORS
+            // If the user wants to fail on asynchronous errors, do so now.
+            std::terminate();
+#endif  // VECMEM_FAIL_ON_ASYNC_ERRORS
+        }
+    }
+
+    /// Synchronize on the underlying HIP event
+    virtual void wait() override {
+        if (m_event == nullptr) {
+            return;
+        }
+        VECMEM_HIP_ERROR_CHECK(hipEventSynchronize(m_event));
+        ignore();
+    }
+
+    /// Ignore the underlying HIP event
+    virtual void ignore() override {
+        if (m_event == nullptr) {
+            return;
+        }
+        VECMEM_HIP_ERROR_CHECK(hipEventDestroy(m_event));
+        m_event = nullptr;
+    }
+
+    /// The HIP event wrapped by this struct
+    hipEvent_t m_event;
+
+};  // struct hip_event
+
+}  // namespace
+
+namespace vecmem::hip {
+
+/// Helper array for translating between the vecmem and HIP copy type
+/// definitions
+static constexpr hipMemcpyKind copy_type_translator[copy::type::count] = {
+    hipMemcpyHostToDevice, hipMemcpyDeviceToHost, hipMemcpyHostToHost,
+    hipMemcpyDeviceToDevice, hipMemcpyDefault};
+
+/// Helper array for providing a printable name for the copy type
+/// definitions
+static const std::string copy_type_printer[copy::type::count] = {
+    "host to device", "device to host", "host to host", "device to device",
+    "unknown"};
+
+async_copy::async_copy(const stream_wrapper& stream) : m_stream(stream) {}
+
+async_copy::~async_copy() {}
+
+void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
+                         type::copy_type cptype) const {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory copy");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(from_ptr != nullptr);
+    assert(to_ptr != nullptr);
+    assert(static_cast<int>(cptype) >= 0);
+    assert(static_cast<int>(cptype) < static_cast<int>(copy::type::count));
+
+    // Perform the copy.
+    VECMEM_HIP_ERROR_CHECK(hipMemcpyAsync(to_ptr, from_ptr, size,
+                                            copy_type_translator[cptype],
+                                            details::get_stream(m_stream)));
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(1,
+                     "Initiated asynchronous %s memory copy of %lu bytes "
+                     "from %p to %p",
+                     copy_type_printer[cptype].c_str(), size, from_ptr, to_ptr);
+}
+
+void async_copy::do_memset(std::size_t size, void* ptr, int value) const {
+
+    // Check if anything needs to be done.
+    if (size == 0) {
+        VECMEM_DEBUG_MSG(5, "Skipping unnecessary memory filling");
+        return;
+    }
+
+    // Some sanity checks.
+    assert(ptr != nullptr);
+
+    // Perform the operation.
+    VECMEM_HIP_ERROR_CHECK(
+        hipMemsetAsync(ptr, value, size, details::get_stream(m_stream)));
+
+    // Let the user know what happened.
+    VECMEM_DEBUG_MSG(
+        2, "Initiated setting %lu bytes to %i at %p asynchronously with HIP",
+        size, value, ptr);
+}
+
+async_copy::event_type async_copy::create_event() const {
+
+    // Create a HIP event.
+    hipEvent_t hipEvent = nullptr;
+    VECMEM_HIP_ERROR_CHECK(hipEventCreate(&hipEvent));
+
+    // Create a smart pointer around it to make memory management a little
+    // safer.
+    auto event = std::make_unique<::hip_event>(hipEvent);
+
+    // Record it into the copy object's HIP stream.
+    VECMEM_HIP_ERROR_CHECK(
+        hipEventRecord(hipEvent, details::get_stream(m_stream)));
+
+    // Return the smart pointer.
+    return event;
+}
+
+}  // namespace vecmem::hip

--- a/hip/src/utils/hip/async_copy.cpp
+++ b/hip/src/utils/hip/async_copy.cpp
@@ -9,8 +9,8 @@
 // VecMem include(s).
 #include "vecmem/utils/hip/async_copy.hpp"
 
-#include "../hip_error_handling.hpp"
 #include "../get_stream.hpp"
+#include "../hip_error_handling.hpp"
 #include "vecmem/utils/debug.hpp"
 
 // HIP include(s).
@@ -27,9 +27,7 @@ namespace {
 struct hip_event : public vecmem::abstract_event {
 
     /// Constructor with the created event.
-    hip_event(hipEvent_t event) : m_event(event) {
-        assert(m_event != nullptr);
-    }
+    hip_event(hipEvent_t event) : m_event(event) { assert(m_event != nullptr); }
     /// Destructor
     ~hip_event() {
         // Check if the user forgot to wait on this asynchronous event.
@@ -104,8 +102,8 @@ void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
 
     // Perform the copy.
     VECMEM_HIP_ERROR_CHECK(hipMemcpyAsync(to_ptr, from_ptr, size,
-                                            copy_type_translator[cptype],
-                                            details::get_stream(m_stream)));
+                                          copy_type_translator[cptype],
+                                          details::get_stream(m_stream)));
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(1,

--- a/hip/src/utils/hip/async_copy.cpp
+++ b/hip/src/utils/hip/async_copy.cpp
@@ -10,6 +10,7 @@
 #include "vecmem/utils/hip/async_copy.hpp"
 
 #include "../hip_error_handling.hpp"
+#include "../get_stream.hpp"
 #include "vecmem/utils/debug.hpp"
 
 // HIP include(s).

--- a/tests/hip/test_hip_copy.cpp
+++ b/tests/hip/test_hip_copy.cpp
@@ -63,9 +63,7 @@ static ::testing::Environment* const async_hip_copy_env =
 
 /// The configurations to run the tests with. Skip tests with asynchronous
 /// copies on "managed host memory" on Windows. (Using managed memory as
-/// "device memory" does seem to be fine.) There seems to be some issue with
-/// HIP, which results in SEH exceptions when scheduling an asynchronous
-/// copy in such a setup, while a previous asynchronous copy is still running.
+/// "device memory" does seem to be fine.)
 static const auto hip_copy_configs = testing::Values(
     std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_device_resource_ptr,
              hip_host_resource_ptr),

--- a/tests/hip/test_hip_copy.cpp
+++ b/tests/hip/test_hip_copy.cpp
@@ -81,8 +81,7 @@ static const auto hip_copy_configs = testing::Values(
     std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_device_resource_ptr,
              hip_managed_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
-             hip_device_resource_ptr, hip_managed_resource_ptr)
-);
+             hip_device_resource_ptr, hip_managed_resource_ptr));
 
 // Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(hip_copy_tests, copy_tests, hip_copy_configs);

--- a/tests/hip/test_hip_copy.cpp
+++ b/tests/hip/test_hip_copy.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,22 +19,76 @@
 #include <gtest/gtest.h>
 
 // System include(s).
+#include <memory>
 #include <tuple>
 
 // Objects used in the test(s).
 static vecmem::hip::host_memory_resource hip_host_resource;
 static vecmem::memory_resource* hip_host_resource_ptr = &hip_host_resource;
 static vecmem::hip::device_memory_resource hip_device_resource;
-static vecmem::memory_resource* hip_device_resource_ptr = &hip_device_resource;
+static vecmem::memory_resource* hip_device_resource_ptr =
+    &hip_device_resource;
+static vecmem::hip::managed_memory_resource hip_managed_resource;
+static vecmem::memory_resource* hip_managed_resource_ptr =
+    &hip_managed_resource;
 static vecmem::copy hip_host_copy;
 static vecmem::copy* hip_host_copy_ptr = &hip_host_copy;
 static vecmem::hip::copy hip_device_copy;
 static vecmem::copy* hip_device_copy_ptr = &hip_device_copy;
+static std::unique_ptr<vecmem::hip::stream_wrapper> hip_stream;
+static std::unique_ptr<vecmem::hip::async_copy> hip_async_device_copy;
+static vecmem::copy* hip_async_device_copy_ptr = nullptr;
 
-/// The configurations to run the tests with.
-static const auto hip_copy_configs =
-    testing::Values(std::tie(hip_device_copy_ptr, hip_host_copy_ptr,
-                             hip_device_resource_ptr, hip_host_resource_ptr));
+/// Environment taking care of setting up and tearing down the async test types
+class AsyncHIPCopyEnvironment : public ::testing::Environment {
+public:
+    /// Set up the environment
+    void SetUp() override {
+        hip_stream = std::make_unique<vecmem::hip::stream_wrapper>();
+        hip_async_device_copy =
+            std::make_unique<vecmem::hip::async_copy>(*hip_stream);
+        hip_async_device_copy_ptr = hip_async_device_copy.get();
+    }
+    /// Tear down the environment
+    void TearDown() override {
+        hip_async_device_copy.reset();
+        hip_stream.reset();
+        hip_async_device_copy_ptr = nullptr;
+    }
+};
+
+/// Register the environment
+static ::testing::Environment* const async_hip_copy_env =
+    ::testing::AddGlobalTestEnvironment(new AsyncHIPCopyEnvironment{});
+
+/// The configurations to run the tests with. Skip tests with asynchronous
+/// copies on "managed host memory" on Windows. (Using managed memory as
+/// "device memory" does seem to be fine.) There seems to be some issue with
+/// HIP, which results in SEH exceptions when scheduling an asynchronous
+/// copy in such a setup, while a previous asynchronous copy is still running.
+static const auto hip_copy_configs = testing::Values(
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_device_resource_ptr,
+             hip_host_resource_ptr),
+    std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
+             hip_device_resource_ptr, hip_host_resource_ptr),
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr,
+             hip_managed_resource_ptr, hip_host_resource_ptr),
+    std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
+             hip_managed_resource_ptr, hip_host_resource_ptr),
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr,
+             hip_managed_resource_ptr, hip_managed_resource_ptr),
+#ifndef _WIN32
+    std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
+             hip_managed_resource_ptr, hip_managed_resource_ptr),
+#endif
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_device_resource_ptr,
+             hip_managed_resource_ptr)
+#ifndef _WIN32
+        ,
+    std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
+             hip_device_resource_ptr, hip_managed_resource_ptr)
+#endif
+);
 
 // Instantiate the test suite(s).
 INSTANTIATE_TEST_SUITE_P(hip_copy_tests, copy_tests, hip_copy_configs);

--- a/tests/hip/test_hip_copy.cpp
+++ b/tests/hip/test_hip_copy.cpp
@@ -12,7 +12,9 @@
 // VecMem include(s).
 #include "vecmem/memory/hip/device_memory_resource.hpp"
 #include "vecmem/memory/hip/host_memory_resource.hpp"
+#include "vecmem/memory/hip/managed_memory_resource.hpp"
 #include "vecmem/utils/copy.hpp"
+#include "vecmem/utils/hip/async_copy.hpp"
 #include "vecmem/utils/hip/copy.hpp"
 
 // GoogleTest include(s).
@@ -26,8 +28,7 @@
 static vecmem::hip::host_memory_resource hip_host_resource;
 static vecmem::memory_resource* hip_host_resource_ptr = &hip_host_resource;
 static vecmem::hip::device_memory_resource hip_device_resource;
-static vecmem::memory_resource* hip_device_resource_ptr =
-    &hip_device_resource;
+static vecmem::memory_resource* hip_device_resource_ptr = &hip_device_resource;
 static vecmem::hip::managed_memory_resource hip_managed_resource;
 static vecmem::memory_resource* hip_managed_resource_ptr =
     &hip_managed_resource;
@@ -69,20 +70,16 @@ static const auto hip_copy_configs = testing::Values(
              hip_host_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
              hip_device_resource_ptr, hip_host_resource_ptr),
-    std::tie(hip_device_copy_ptr, hip_host_copy_ptr,
-             hip_managed_resource_ptr, hip_host_resource_ptr),
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_managed_resource_ptr,
+             hip_host_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
              hip_managed_resource_ptr, hip_host_resource_ptr),
-    std::tie(hip_device_copy_ptr, hip_host_copy_ptr,
-             hip_managed_resource_ptr, hip_managed_resource_ptr),
-#ifndef _WIN32
+    std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_managed_resource_ptr,
+             hip_managed_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
              hip_managed_resource_ptr, hip_managed_resource_ptr),
-#endif
     std::tie(hip_device_copy_ptr, hip_host_copy_ptr, hip_device_resource_ptr,
-             hip_managed_resource_ptr)
-#ifndef _WIN32
-        ,
+             hip_managed_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
              hip_device_resource_ptr, hip_managed_resource_ptr)
 #endif

--- a/tests/hip/test_hip_copy.cpp
+++ b/tests/hip/test_hip_copy.cpp
@@ -82,7 +82,6 @@ static const auto hip_copy_configs = testing::Values(
              hip_managed_resource_ptr),
     std::tie(hip_async_device_copy_ptr, hip_host_copy_ptr,
              hip_device_resource_ptr, hip_managed_resource_ptr)
-#endif
 );
 
 // Instantiate the test suite(s).


### PR DESCRIPTION
This is a simple duplication of the existing CUDA async copy bits, to HIP. I've also updated the tests to match the CUDA ones.

I've got a branch of the traccc Alpaka code that is now using non-blocking queues (i.e. CUDA/HIP streams), and async copy, but we need the equivalent code for HIP, for it to work there as well.