### PR TITLE
SonarCloud Fixes (mainly) For vecmem::hip, main branch (2025.04.26.)

### DIFF
--- a/core/include/vecmem/utils/debug.hpp
+++ b/core/include/vecmem/utils/debug.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -49,39 +49,44 @@
         VECMEM_PRINTF(__msg, __VA_ARGS__);              \
     } while (false)
 
+/// No-op implementation of the print macro (mainly for SonarCloud's benefit)
+#define __VECMEM_PRINT_MSG_EMPTY \
+    do {                         \
+    } while (false)
+
 /// Print macro for "level 1" debug messages
 #if VECMEM_DEBUG_MSG_LVL >= 1
 #define __VECMEM_PRINT_1(MSG, ...) __VECMEM_PRINT_MSG(MSG, __VA_ARGS__)
 #else
-#define __VECMEM_PRINT_1(MSG, ...)
+#define __VECMEM_PRINT_1(MSG, ...) __VECMEM_PRINT_MSG_EMPTY
 #endif
 
 /// Print macro for "level 2" debug messages
 #if VECMEM_DEBUG_MSG_LVL >= 2
 #define __VECMEM_PRINT_2(MSG, ...) __VECMEM_PRINT_MSG(MSG, __VA_ARGS__)
 #else
-#define __VECMEM_PRINT_2(MSG, ...)
+#define __VECMEM_PRINT_2(MSG, ...) __VECMEM_PRINT_MSG_EMPTY
 #endif
 
 /// Print macro for "level 3" debug messages
 #if VECMEM_DEBUG_MSG_LVL >= 3
 #define __VECMEM_PRINT_3(MSG, ...) __VECMEM_PRINT_MSG(MSG, __VA_ARGS__)
 #else
-#define __VECMEM_PRINT_3(MSG, ...)
+#define __VECMEM_PRINT_3(MSG, ...) __VECMEM_PRINT_MSG_EMPTY
 #endif
 
 /// Print macro for "level 4" debug messages
 #if VECMEM_DEBUG_MSG_LVL >= 4
 #define __VECMEM_PRINT_4(MSG, ...) __VECMEM_PRINT_MSG(MSG, __VA_ARGS__)
 #else
-#define __VECMEM_PRINT_4(MSG, ...)
+#define __VECMEM_PRINT_4(MSG, ...) __VECMEM_PRINT_MSG_EMPTY
 #endif
 
 /// Print macro for "level 5" debug messages
 #if VECMEM_DEBUG_MSG_LVL >= 5
 #define __VECMEM_PRINT_5(MSG, ...) __VECMEM_PRINT_MSG(MSG, __VA_ARGS__)
 #else
-#define __VECMEM_PRINT_5(MSG, ...)
+#define __VECMEM_PRINT_5(MSG, ...) __VECMEM_PRINT_MSG_EMPTY
 #endif
 
 // Implement the main macro(s) a little differently for MSVC and all other

--- a/cuda/src/memory/device_memory_resource.cpp
+++ b/cuda/src/memory/device_memory_resource.cpp
@@ -68,8 +68,8 @@ void device_memory_resource::do_deallocate(void *p, std::size_t bytes,
 
 bool device_memory_resource::do_is_equal(
     const memory_resource &other) const noexcept {
-    const device_memory_resource *c;
-    c = dynamic_cast<const device_memory_resource *>(&other);
+
+    auto c = dynamic_cast<const device_memory_resource *>(&other);
 
     /*
      * The equality check here is ever so slightly more difficult. Not only

--- a/cuda/src/utils/stream_wrapper.cpp
+++ b/cuda/src/utils/stream_wrapper.cpp
@@ -29,9 +29,7 @@ namespace details {
 struct stream_owner {
 
     /// Default constructor
-    stream_owner() : m_stream(nullptr) {
-        VECMEM_CUDA_ERROR_CHECK(cudaStreamCreate(&m_stream));
-    }
+    stream_owner() { VECMEM_CUDA_ERROR_CHECK(cudaStreamCreate(&m_stream)); }
     /// Copy constructor
     stream_owner(const stream_owner&) = delete;
     /// Move constructor
@@ -65,7 +63,7 @@ struct stream_owner {
     }
 
     /// The managed stream
-    cudaStream_t m_stream;
+    cudaStream_t m_stream{nullptr};
 
 };  // struct stream_owner
 

--- a/hip/include/vecmem/memory/hip/device_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/device_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -27,7 +27,7 @@ public:
     device_memory_resource(int device = INVALID_DEVICE);
     /// Destructor
     VECMEM_HIP_EXPORT
-    ~device_memory_resource();
+    ~device_memory_resource() noexcept override;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -35,18 +35,16 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_HIP_EXPORT
-    virtual void* do_allocate(std::size_t nbytes,
-                              std::size_t alignment) override final;
+    void* do_allocate(std::size_t nbytes, std::size_t alignment) override;
 
     /// Function performing the memory de-allocation
     VECMEM_HIP_EXPORT
-    virtual void do_deallocate(void* ptr, std::size_t nbytes,
-                               std::size_t alignment) override final;
+    void do_deallocate(void* ptr, std::size_t nbytes,
+                       std::size_t alignment) override;
 
     /// Function comparing two memory resource instances
     VECMEM_HIP_EXPORT
-    virtual bool do_is_equal(
-        const memory_resource& other) const noexcept override final;
+    bool do_is_equal(const memory_resource& other) const noexcept override;
 
     /// @}
 

--- a/hip/include/vecmem/memory/hip/host_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/host_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -23,7 +23,7 @@ public:
     host_memory_resource();
     /// Destructor
     VECMEM_HIP_EXPORT
-    ~host_memory_resource();
+    ~host_memory_resource() noexcept override;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -31,18 +31,16 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_HIP_EXPORT
-    virtual void* do_allocate(std::size_t nbytes,
-                              std::size_t alignment) override final;
+    void* do_allocate(std::size_t nbytes, std::size_t alignment) override;
 
     /// Function performing the memory de-allocation
     VECMEM_HIP_EXPORT
-    virtual void do_deallocate(void* ptr, std::size_t nbytes,
-                               std::size_t alignment) override final;
+    void do_deallocate(void* ptr, std::size_t nbytes,
+                       std::size_t alignment) override;
 
     /// Function comparing two memory resource instances
     VECMEM_HIP_EXPORT
-    virtual bool do_is_equal(
-        const memory_resource& other) const noexcept override final;
+    bool do_is_equal(const memory_resource& other) const noexcept override;
 
     /// @}
 

--- a/hip/include/vecmem/memory/hip/managed_memory_resource.hpp
+++ b/hip/include/vecmem/memory/hip/managed_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024 CERN for the benefit of the ACTS project
+ * (c) 2024-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -28,7 +28,7 @@ public:
     managed_memory_resource();
     /// Destructor
     VECMEM_HIP_EXPORT
-    ~managed_memory_resource();
+    ~managed_memory_resource() noexcept override;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -36,15 +36,13 @@ private:
 
     /// Allocate HIP managed memory
     VECMEM_HIP_EXPORT
-    virtual void* do_allocate(std::size_t, std::size_t) override final;
+    void* do_allocate(std::size_t, std::size_t) override;
     /// De-allocate a previously allocated managed memory block
     VECMEM_HIP_EXPORT
-    virtual void do_deallocate(void* p, std::size_t,
-                               std::size_t) override final;
+    void do_deallocate(void* p, std::size_t, std::size_t) override;
     /// Compares @c *this for equality with @c other
     VECMEM_HIP_EXPORT
-    virtual bool do_is_equal(
-        const memory_resource& other) const noexcept override final;
+    bool do_is_equal(const memory_resource& other) const noexcept override;
 
     /// @}
 

--- a/hip/include/vecmem/utils/hip/async_copy.hpp
+++ b/hip/include/vecmem/utils/hip/async_copy.hpp
@@ -32,20 +32,19 @@ public:
     async_copy(const stream_wrapper& stream);
     /// Destructor
     VECMEM_HIP_EXPORT
-    ~async_copy();
+    ~async_copy() noexcept;
 
 protected:
     /// Perform an asynchronous memory copy using HIP
     VECMEM_HIP_EXPORT
-    virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override final;
+    void do_copy(std::size_t size, const void* from, void* to,
+                 type::copy_type cptype) const final;
     /// Fill a memory area using HIP asynchronously
     VECMEM_HIP_EXPORT
-    virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override final;
+    void do_memset(std::size_t size, void* ptr, int value) const final;
     /// Create an event for synchronization
     VECMEM_HIP_EXPORT
-    virtual event_type create_event() const override final;
+    event_type create_event() const final;
 
 private:
     /// The stream that the copies are performed on

--- a/hip/include/vecmem/utils/hip/copy.hpp
+++ b/hip/include/vecmem/utils/hip/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,11 +18,10 @@ class VECMEM_HIP_EXPORT copy : public vecmem::copy {
 
 protected:
     /// Perform a memory copy using HIP
-    virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override final;
+    void do_copy(std::size_t size, const void* from, void* to,
+                 type::copy_type cptype) const final;
     /// Fill a memory area using HIP
-    virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override final;
+    void do_memset(std::size_t size, void* ptr, int value) const final;
 
 };  // class copy
 

--- a/hip/include/vecmem/utils/hip/stream_wrapper.hpp
+++ b/hip/include/vecmem/utils/hip/stream_wrapper.hpp
@@ -41,7 +41,7 @@ public:
     stream_wrapper(const stream_wrapper& parent);
     /// Move constructor
     VECMEM_HIP_EXPORT
-    stream_wrapper(stream_wrapper&& parent);
+    stream_wrapper(stream_wrapper&& parent) noexcept;
 
     /// Destructor
     VECMEM_HIP_EXPORT
@@ -52,7 +52,7 @@ public:
     stream_wrapper& operator=(const stream_wrapper& rhs);
     /// Move assignment
     VECMEM_HIP_EXPORT
-    stream_wrapper& operator=(stream_wrapper&& rhs);
+    stream_wrapper& operator=(stream_wrapper&& rhs) noexcept;
 
     /// Access a typeless pointer to the managed @c hipStream_t object
     VECMEM_HIP_EXPORT

--- a/hip/src/memory/device_memory_resource.cpp
+++ b/hip/src/memory/device_memory_resource.cpp
@@ -25,7 +25,7 @@ namespace vecmem::hip {
 device_memory_resource::device_memory_resource(int device)
     : m_device(device == INVALID_DEVICE ? details::get_device() : device) {}
 
-device_memory_resource::~device_memory_resource() = default;
+device_memory_resource::~device_memory_resource() noexcept = default;
 
 void* device_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 
@@ -62,8 +62,7 @@ bool device_memory_resource::do_is_equal(
     const memory_resource& other) const noexcept {
 
     // Try to cast the other object to this exact type.
-    const device_memory_resource* p =
-        dynamic_cast<const device_memory_resource*>(&other);
+    auto p = dynamic_cast<const device_memory_resource*>(&other);
 
     // The two are equal if they operate on the same device.
     return ((p != nullptr) && (p->m_device == m_device));

--- a/hip/src/memory/host_memory_resource.cpp
+++ b/hip/src/memory/host_memory_resource.cpp
@@ -22,7 +22,7 @@ namespace vecmem::hip {
 
 host_memory_resource::host_memory_resource() = default;
 
-host_memory_resource::~host_memory_resource() = default;
+host_memory_resource::~host_memory_resource() noexcept = default;
 
 void* host_memory_resource::do_allocate(std::size_t nbytes, std::size_t) {
 

--- a/hip/src/memory/managed_memory_resource.cpp
+++ b/hip/src/memory/managed_memory_resource.cpp
@@ -23,7 +23,7 @@ namespace vecmem::hip {
 
 managed_memory_resource::managed_memory_resource() = default;
 
-managed_memory_resource::~managed_memory_resource() = default;
+managed_memory_resource::~managed_memory_resource() noexcept = default;
 
 void *managed_memory_resource::do_allocate(std::size_t bytes, std::size_t) {
 

--- a/hip/src/utils/hip/copy.cpp
+++ b/hip/src/utils/hip/copy.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2022 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -16,6 +16,7 @@
 #include <hip/hip_runtime_api.h>
 
 // System include(s).
+#include <array>
 #include <cassert>
 #include <string>
 
@@ -23,12 +24,13 @@ namespace vecmem::hip {
 
 /// Helper array for translating between the vecmem and HIP copy type
 /// definitions
-static constexpr hipMemcpyKind copy_type_translator[copy::type::count] = {
-    hipMemcpyHostToDevice, hipMemcpyDeviceToHost, hipMemcpyHostToHost,
-    hipMemcpyDeviceToDevice, hipMemcpyDefault};
+static constexpr std::array<hipMemcpyKind, copy::type::count>
+    copy_type_translator = {hipMemcpyHostToDevice, hipMemcpyDeviceToHost,
+                            hipMemcpyHostToHost, hipMemcpyDeviceToDevice,
+                            hipMemcpyDefault};
 
 /// Helper array for providing a printable name for the copy type definitions
-static const std::string copy_type_printer[copy::type::count] = {
+static const std::array<std::string, copy::type::count> copy_type_printer = {
     "host to device", "device to host", "host to host", "device to device",
     "unknown"};
 

--- a/hip/src/utils/hip_error_handling.cpp
+++ b/hip/src/utils/hip_error_handling.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,12 +13,18 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace vecmem {
-namespace hip {
+namespace vecmem::hip {
+
+/// Specific exception for HIP errors thrown by this library
+struct runtime_error : public std::runtime_error {
+    /// Inherit the base class's constructor(s)
+    using std::runtime_error::runtime_error;
+};
+
 namespace details {
 
-void throw_error(hipError_t errorCode, const char* expression, const char* file,
-                 int line) {
+[[noreturn]] void throw_error(hipError_t errorCode, const char* expression,
+                              const char* file, int line) {
 
     // Create a nice error message.
     std::ostringstream errorMsg;
@@ -26,9 +32,8 @@ void throw_error(hipError_t errorCode, const char* expression, const char* file,
              << " (" << hipGetErrorString(errorCode) << ")";
 
     // Now throw a runtime error with this message.
-    throw std::runtime_error(errorMsg.str());
+    throw runtime_error(errorMsg.str());
 }
 
 }  // namespace details
-}  // namespace hip
-}  // namespace vecmem
+}  // namespace vecmem::hip

--- a/hip/src/utils/hip_error_handling.hpp
+++ b/hip/src/utils/hip_error_handling.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,8 +31,8 @@ namespace hip {
 namespace details {
 
 /// Function used to print and throw a user-readable error if something breaks
-void throw_error(hipError_t errorCode, const char* expression, const char* file,
-                 int line);
+[[noreturn]] void throw_error(hipError_t errorCode, const char* expression,
+                              const char* file, int line);
 
 }  // namespace details
 }  // namespace hip

--- a/hip/src/utils/run_on_device.hpp
+++ b/hip/src/utils/run_on_device.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -20,11 +20,11 @@ class run_on_device {
 
 public:
     /// Constructor, with the device that code should run on
-    run_on_device(int device) : m_device(device) {}
+    explicit run_on_device(int device) : m_device(device) {}
 
     /// Operator executing "something" on the specified device.
     template <typename EXECUTABLE>
-    void operator()(EXECUTABLE exe) {
+    void operator()(EXECUTABLE exe) const {
 
         // Switch to the device in a RAII mode.
         select_device helper(m_device);

--- a/hip/src/utils/select_device.hpp
+++ b/hip/src/utils/select_device.hpp
@@ -31,7 +31,7 @@ public:
      *
      * @param[in] device The HIP device number to switch to.
      */
-    select_device(int device);
+    explicit select_device(int device);
 
     /**
      * @brief Deconstructs the object, returning to the device that was


### PR DESCRIPTION
Continuing with the spring cleanup, I tried to silence some more reports coming from SonarCloud. Including a small change in the debug printouts, which now puts some no-op operations in place where nothing is meant to be printed. (As SonarCloud didn't like not having any code in some places when debug messages are turned off.)