### PR TITLE
SonarCloud Fixes For vecmem::sycl, main branch (2025.04.26.)

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -25,6 +25,8 @@ vecmem_add_library( vecmem_sycl sycl
    "include/vecmem/memory/sycl/shared_memory_resource.hpp"
    "src/memory/shared_memory_resource.sycl"
    # Utilities.
+   "include/vecmem/utils/sycl/details/queue_holder.hpp"
+   "src/utils/sycl/queue_holder.sycl"
    "include/vecmem/utils/sycl/copy.hpp"
    "src/utils/sycl/copy.sycl"
    "include/vecmem/utils/sycl/async_copy.hpp"

--- a/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
+++ b/sycl/include/vecmem/memory/sycl/details/memory_resource_base.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -8,7 +8,7 @@
 
 // Local include(s).
 #include "vecmem/memory/memory_resource.hpp"
-#include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/utils/sycl/details/queue_holder.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
 /// @brief Namespace for types that should not be used directly by clients
@@ -19,19 +19,11 @@ namespace vecmem::sycl::details {
 /// This class is used as base by all of the oneAPI/SYCL memory resource
 /// classes. It holds functionality that those classes all need.
 ///
-class memory_resource_base : public memory_resource {
+class memory_resource_base : public memory_resource, public queue_holder {
 
 public:
-    /// Constructor on top of a user-provided queue
-    VECMEM_SYCL_EXPORT
-    memory_resource_base(const queue_wrapper& queue = {});
-    /// Destructor
-    VECMEM_SYCL_EXPORT
-    ~memory_resource_base();
-
-protected:
-    /// The queue that the allocations are made for/on
-    queue_wrapper m_queue;
+    /// Inherit the constructor(s) from @c vecmem::sycl::details::queue_holder
+    using queue_holder::queue_holder;
 
 private:
     /// @name Function(s) implemented from @c vecmem::memory_resource
@@ -39,13 +31,12 @@ private:
 
     /// Function performing the memory de-allocation
     VECMEM_SYCL_EXPORT
-    virtual void do_deallocate(void* ptr, std::size_t nbytes,
-                               std::size_t alignment) override final;
+    void do_deallocate(void* ptr, std::size_t nbytes,
+                       std::size_t alignment) final;
 
     /// Function comparing two memory resource instances
     VECMEM_SYCL_EXPORT
-    virtual bool do_is_equal(
-        const memory_resource& other) const noexcept override final;
+    bool do_is_equal(const memory_resource& other) const noexcept final;
 
     /// @}
 

--- a/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/device_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -19,12 +19,8 @@ namespace vecmem::sycl {
 class device_memory_resource final : public details::memory_resource_base {
 
 public:
-    /// Constructor on top of a user-provided queue
-    VECMEM_SYCL_EXPORT
-    device_memory_resource(const queue_wrapper& queue = {});
-    /// Destructor
-    VECMEM_SYCL_EXPORT
-    ~device_memory_resource();
+    /// Inherit the base class's constructor(s)
+    using details::memory_resource_base::memory_resource_base;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -32,8 +28,7 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    virtual void* do_allocate(std::size_t nbytes,
-                              std::size_t alignment) override final;
+    void* do_allocate(std::size_t nbytes, std::size_t alignment) override;
 
     /// @}
 

--- a/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/host_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,12 +18,8 @@ namespace vecmem::sycl {
 class host_memory_resource final : public details::memory_resource_base {
 
 public:
-    /// Constructor on top of a user-provided queue
-    VECMEM_SYCL_EXPORT
-    host_memory_resource(const queue_wrapper& queue = {});
-    /// Destructor
-    VECMEM_SYCL_EXPORT
-    ~host_memory_resource();
+    /// Inherit the base class's constructor(s)
+    using details::memory_resource_base::memory_resource_base;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -31,8 +27,7 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    virtual void* do_allocate(std::size_t nbytes,
-                              std::size_t alignment) override final;
+    void* do_allocate(std::size_t nbytes, std::size_t alignment) override;
 
     /// @}
 

--- a/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
+++ b/sycl/include/vecmem/memory/sycl/shared_memory_resource.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -18,12 +18,8 @@ namespace vecmem::sycl {
 class shared_memory_resource final : public details::memory_resource_base {
 
 public:
-    /// Constructor on top of a user-provided queue
-    VECMEM_SYCL_EXPORT
-    shared_memory_resource(const queue_wrapper& queue = {});
-    /// Destructor
-    VECMEM_SYCL_EXPORT
-    ~shared_memory_resource();
+    /// Inherit the base class's constructor(s)
+    using details::memory_resource_base::memory_resource_base;
 
 private:
     /// @name Function(s) implementing @c vecmem::memory_resource
@@ -31,8 +27,7 @@ private:
 
     /// Function performing the memory allocation
     VECMEM_SYCL_EXPORT
-    virtual void* do_allocate(std::size_t nbytes,
-                              std::size_t alignment) override final;
+    void* do_allocate(std::size_t nbytes, std::size_t alignment) override;
 
     /// @}
 

--- a/sycl/include/vecmem/utils/sycl/async_copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/async_copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,17 +9,13 @@
 
 // VecMem include(s).
 #include "vecmem/utils/copy.hpp"
-#include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/utils/sycl/details/queue_holder.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
 // System include(s).
 #include <memory>
 
 namespace vecmem::sycl {
-namespace details {
-/// Object holding on to internal data for @c vecmem::sycl::async_copy
-struct async_copy_data;
-}  // namespace details
 
 /// Specialisation of @c vecmem::copy for SYCL
 ///
@@ -32,32 +28,32 @@ struct async_copy_data;
 /// asynchronously, requiring users to introduce synchronisation points
 /// explicitly into their code as needed.
 ///
-class async_copy : public vecmem::copy {
+class async_copy final : public vecmem::copy, public details::queue_holder {
 
 public:
     /// Constructor on top of a user-provided queue
     VECMEM_SYCL_EXPORT
-    async_copy(const queue_wrapper& queue);
+    explicit async_copy(const queue_wrapper& queue);
     /// Destructor
     VECMEM_SYCL_EXPORT
     ~async_copy();
 
-protected:
+private:
     /// Perform a memory copy using SYCL
     VECMEM_SYCL_EXPORT
-    virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override final;
+    void do_copy(std::size_t size, const void* from, void* to,
+                 type::copy_type cptype) const override;
     /// Fill a memory area using SYCL
     VECMEM_SYCL_EXPORT
-    virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override final;
+    void do_memset(std::size_t size, void* ptr, int value) const override;
     /// Create an event for synchronization
     VECMEM_SYCL_EXPORT
-    virtual event_type create_event() const override final;
+    event_type create_event() const override;
 
-private:
+    /// Type holding on to internal data for @c vecmem::sycl::async_copy
+    struct impl;
     /// Internal data for the object
-    std::unique_ptr<details::async_copy_data> m_data;
+    std::unique_ptr<impl> m_impl;
 
 };  // class async_copy
 

--- a/sycl/include/vecmem/utils/sycl/copy.hpp
+++ b/sycl/include/vecmem/utils/sycl/copy.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,17 +9,10 @@
 
 // VecMem include(s).
 #include "vecmem/utils/copy.hpp"
-#include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/utils/sycl/details/queue_holder.hpp"
 #include "vecmem/vecmem_sycl_export.hpp"
 
-// System include(s).
-#include <memory>
-
 namespace vecmem::sycl {
-namespace details {
-/// Object holding on to internal data for @c vecmem::sycl::copy
-struct copy_data;
-}  // namespace details
 
 /// Specialisation of @c vecmem::copy for SYCL
 ///
@@ -28,29 +21,20 @@ struct copy_data;
 /// @c ::sycl::queue object. So this object needs to point to a valid
 /// queue object itself.
 ///
-class copy : public vecmem::copy {
+class copy final : public vecmem::copy, public details::queue_holder {
 
 public:
-    /// Constructor on top of a user-provided queue
-    VECMEM_SYCL_EXPORT
-    copy(const queue_wrapper& queue);
-    /// Destructor
-    VECMEM_SYCL_EXPORT
-    ~copy();
-
-protected:
-    /// Perform a memory copy using SYCL
-    VECMEM_SYCL_EXPORT
-    virtual void do_copy(std::size_t size, const void* from, void* to,
-                         type::copy_type cptype) const override final;
-    /// Fill a memory area using SYCL
-    VECMEM_SYCL_EXPORT
-    virtual void do_memset(std::size_t size, void* ptr,
-                           int value) const override final;
+    /// Inherit the constructor(s) from @c vecmem::sycl::details::queue_holder
+    using details::queue_holder::queue_holder;
 
 private:
-    /// Internal data for the object
-    std::unique_ptr<details::copy_data> m_data;
+    /// Perform a memory copy using SYCL
+    VECMEM_SYCL_EXPORT
+    void do_copy(std::size_t size, const void* from, void* to,
+                 type::copy_type cptype) const override;
+    /// Fill a memory area using SYCL
+    VECMEM_SYCL_EXPORT
+    void do_memset(std::size_t size, void* ptr, int value) const override;
 
 };  // class copy
 

--- a/sycl/include/vecmem/utils/sycl/details/queue_holder.hpp
+++ b/sycl/include/vecmem/utils/sycl/details/queue_holder.hpp
@@ -1,0 +1,42 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/utils/sycl/queue_wrapper.hpp"
+#include "vecmem/vecmem_sycl_export.hpp"
+
+// System include(s).
+#include <memory>
+
+namespace vecmem::sycl::details {
+
+/// Base class for all user-facing, @c sycl::queue using classes
+class queue_holder {
+
+public:
+    /// Constructor on top of a user-provided queue
+    VECMEM_SYCL_EXPORT
+    explicit queue_holder(const queue_wrapper& queue = {});
+    /// Destructor
+    VECMEM_SYCL_EXPORT
+    ~queue_holder();
+
+protected:
+    /// Get the held queue
+    queue_wrapper& queue() const;
+
+private:
+    /// Type holding on to internal data for
+    /// @c vecmem::sycl::details::queue_holder
+    struct impl;
+    /// Internal data for the object
+    std::unique_ptr<impl> m_impl;
+
+};  // queue_holder
+
+}  // namespace vecmem::sycl::details

--- a/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
+++ b/sycl/include/vecmem/utils/sycl/queue_wrapper.hpp
@@ -38,7 +38,7 @@ public:
     queue_wrapper(const queue_wrapper& parent);
     /// Move constructor
     VECMEM_SYCL_EXPORT
-    queue_wrapper(queue_wrapper&& parent);
+    queue_wrapper(queue_wrapper&& parent) noexcept;
 
     /// Destructor
     VECMEM_SYCL_EXPORT
@@ -49,7 +49,7 @@ public:
     queue_wrapper& operator=(const queue_wrapper& rhs);
     /// Move assignment
     VECMEM_SYCL_EXPORT
-    queue_wrapper& operator=(queue_wrapper&& rhs);
+    queue_wrapper& operator=(queue_wrapper&& rhs) noexcept;
 
     /// Access a typeless pointer to the managed @c ::sycl::queue object
     VECMEM_SYCL_EXPORT

--- a/sycl/src/memory/device_memory_resource.sycl
+++ b/sycl/src/memory/device_memory_resource.sycl
@@ -18,11 +18,6 @@
 
 namespace vecmem::sycl {
 
-device_memory_resource::device_memory_resource(const queue_wrapper& queue)
-    : memory_resource_base(queue) {}
-
-device_memory_resource::~device_memory_resource() = default;
-
 void* device_memory_resource::do_allocate(std::size_t nbytes,
                                           std::size_t alignment) {
 
@@ -32,7 +27,7 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
 
     // Allocate the memory.
     void* result = ::sycl::aligned_alloc_device(alignment, nbytes,
-                                                details::get_queue(m_queue));
+                                                details::get_queue(queue()));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {
@@ -43,7 +38,7 @@ void* device_memory_resource::do_allocate(std::size_t nbytes,
     VECMEM_DEBUG_MSG(
         2, "Allocated %ld bytes of (%ld aligned) device memory on \"%s\" at %p",
         nbytes, alignment,
-        details::get_queue(m_queue)
+        details::get_queue(queue())
             .get_device()
             .get_info<::sycl::info::device::name>()
             .c_str(),

--- a/sycl/src/memory/host_memory_resource.sycl
+++ b/sycl/src/memory/host_memory_resource.sycl
@@ -18,11 +18,6 @@
 
 namespace vecmem::sycl {
 
-host_memory_resource::host_memory_resource(const queue_wrapper& queue)
-    : memory_resource_base(queue) {}
-
-host_memory_resource::~host_memory_resource() = default;
-
 void* host_memory_resource::do_allocate(std::size_t nbytes,
                                         std::size_t alignment) {
 
@@ -32,7 +27,7 @@ void* host_memory_resource::do_allocate(std::size_t nbytes,
 
     // Allocate the memory.
     void* result = ::sycl::aligned_alloc_host(alignment, nbytes,
-                                              details::get_queue(m_queue));
+                                              details::get_queue(queue()));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {

--- a/sycl/src/memory/memory_resource_base.sycl
+++ b/sycl/src/memory/memory_resource_base.sycl
@@ -18,11 +18,6 @@
 
 namespace vecmem::sycl::details {
 
-memory_resource_base::memory_resource_base(const queue_wrapper& queue)
-    : m_queue(queue) {}
-
-memory_resource_base::~memory_resource_base() = default;
-
 void memory_resource_base::do_deallocate(void* ptr, std::size_t size,
                                          std::size_t) {
 
@@ -33,18 +28,17 @@ void memory_resource_base::do_deallocate(void* ptr, std::size_t size,
 
     // Free the memory.
     VECMEM_DEBUG_MSG(2, "De-allocating memory at %p", ptr);
-    ::sycl::free(ptr, get_queue(m_queue));
+    ::sycl::free(ptr, get_queue(queue()));
 }
 
 bool memory_resource_base::do_is_equal(
     const memory_resource& other) const noexcept {
 
     // Try to cast the other object to this exact type.
-    const memory_resource_base* p =
-        dynamic_cast<const memory_resource_base*>(&other);
+    auto p = dynamic_cast<const memory_resource_base*>(&other);
 
     // The two are equal if they have equal queues.
-    return ((p != nullptr) && (get_queue(p->m_queue) == get_queue(m_queue)));
+    return ((p != nullptr) && (get_queue(p->queue()) == get_queue(queue())));
 }
 
 }  // namespace vecmem::sycl::details

--- a/sycl/src/memory/shared_memory_resource.sycl
+++ b/sycl/src/memory/shared_memory_resource.sycl
@@ -18,11 +18,6 @@
 
 namespace vecmem::sycl {
 
-shared_memory_resource::shared_memory_resource(const queue_wrapper& queue)
-    : memory_resource_base(queue) {}
-
-shared_memory_resource::~shared_memory_resource() = default;
-
 void* shared_memory_resource::do_allocate(std::size_t nbytes,
                                           std::size_t alignment) {
 
@@ -32,7 +27,7 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
 
     // Allocate the memory.
     void* result = ::sycl::aligned_alloc_shared(alignment, nbytes,
-                                                details::get_queue(m_queue));
+                                                details::get_queue(queue()));
 
     // Check that the allocation succeeded.
     if (result == nullptr) {
@@ -43,7 +38,7 @@ void* shared_memory_resource::do_allocate(std::size_t nbytes,
     VECMEM_DEBUG_MSG(
         2, "Allocated %ld bytes of (%ld aligned) shared memory on \"%s\" at %p",
         nbytes, alignment,
-        details::get_queue(m_queue)
+        details::get_queue(queue())
             .get_device()
             .get_info<::sycl::info::device::name>()
             .c_str(),

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -25,14 +25,15 @@ namespace {
 struct sycl_event : public vecmem::abstract_event {
 
     /// Constructor with a SYCL event
-    sycl_event(const std::vector<::sycl::event>& events) : m_events(events) {}
+    explicit sycl_event(const std::vector<::sycl::event>& events)
+        : m_events(events) {}
     /// Destructor
     ~sycl_event() {
         // Check if the user forgot to wait on this asynchronous event.
         if (!m_events.empty()) {
             // If so, wait implicitly now.
             VECMEM_DEBUG_MSG(1, "Asynchronous SYCL event was not waited on!");
-            wait();
+            sycl_event::wait();
 #ifdef VECMEM_FAIL_ON_ASYNC_ERRORS
             // If the user wants to fail on asynchronous errors, do so now.
             std::terminate();
@@ -41,13 +42,13 @@ struct sycl_event : public vecmem::abstract_event {
     }
 
     /// Synchronize on the underlying SYCL event
-    virtual void wait() override {
+    void wait() override {
         ::sycl::event::wait_and_throw(m_events);
-        ignore();
+        sycl_event::ignore();
     }
 
     /// Ignore the underlying SYCL event
-    virtual void ignore() override { m_events.clear(); }
+    void ignore() override { m_events.clear(); }
 
     /// The managed SYCL event
     std::vector<::sycl::event> m_events;
@@ -57,19 +58,16 @@ struct sycl_event : public vecmem::abstract_event {
 }  // namespace
 
 namespace vecmem::sycl {
-namespace details {
 
-struct async_copy_data {
-    queue_wrapper m_queue;
+struct async_copy::impl {
+    /// SYCL (copy) events currently in flight
     std::vector<::sycl::event> m_events;
 };
 
-}  // namespace details
-
 async_copy::async_copy(const queue_wrapper& queue)
-    : m_data(new details::async_copy_data{queue, {}}) {}
+    : details::queue_holder(queue), m_impl{std::make_unique<impl>()} {}
 
-async_copy::~async_copy() {}
+async_copy::~async_copy() = default;
 
 void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                          type::copy_type) const {
@@ -83,10 +81,11 @@ void async_copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
     // Some sanity checks.
     assert(from_ptr != nullptr);
     assert(to_ptr != nullptr);
+    assert(m_impl);
 
     // Perform the copy.
-    m_data->m_events.push_back(
-        details::get_queue(m_data->m_queue).memcpy(to_ptr, from_ptr, size));
+    m_impl->m_events.push_back(
+        details::get_queue(queue()).memcpy(to_ptr, from_ptr, size));
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(1, "Performed memory copy of %lu bytes from %p to %p",
@@ -103,11 +102,12 @@ void async_copy::do_memset(std::size_t size, void* ptr, int value) const {
 
     // Some sanity checks.
     assert(ptr != nullptr);
+    assert(m_impl);
 
     // Perform the operation.
 #if defined(VECMEM_HAVE_SYCL_MEMSET)
-    m_data->m_events.push_back(
-        details::get_queue(m_data->m_queue).memset(ptr, value, size));
+    m_impl->m_events.push_back(
+        details::get_queue(queue()).memset(ptr, value, size));
 #else
     // We can not perform this operation asynchronously, since the data used
     // in the copy only exists as long as this function is executing. So we
@@ -115,7 +115,7 @@ void async_copy::do_memset(std::size_t size, void* ptr, int value) const {
     std::vector<int> dummy(size / sizeof(int) + 1);
     std::fill_n(reinterpret_cast<unsigned char*>(dummy.data()), size,
                 static_cast<unsigned char>(value));
-    details::get_queue(m_data->m_queue)
+    details::get_queue(queue())
         .memcpy(ptr, dummy.data(), size)
         .wait_and_throw();
 #endif  // VECMEM_HAVE_SYCL_MEMSET
@@ -128,9 +128,9 @@ void async_copy::do_memset(std::size_t size, void* ptr, int value) const {
 copy::event_type async_copy::create_event() const {
 
     // Construct an event object out of all of the events collected.
-    auto result = std::make_unique<::sycl_event>(m_data->m_events);
+    auto result = std::make_unique<::sycl_event>(m_impl->m_events);
     // Forget about the events in this object.
-    m_data->m_events.clear();
+    m_impl->m_events.clear();
     // Return the event object.
     return result;
 }

--- a/sycl/src/utils/sycl/copy.sycl
+++ b/sycl/src/utils/sycl/copy.sycl
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -9,28 +9,18 @@
 // SYCL include(s).
 #include <sycl/sycl.hpp>
 
-// VecMem include(s).
+// Local include(s).
 #include "get_queue.hpp"
-#include "vecmem/utils/debug.hpp"
 #include "vecmem/utils/sycl/copy.hpp"
+
+// Project include(s).
+#include "vecmem/utils/debug.hpp"
 
 // System include(s).
 #include <algorithm>
 #include <vector>
 
 namespace vecmem::sycl {
-namespace details {
-
-struct copy_data {
-    queue_wrapper m_queue;
-};
-
-}  // namespace details
-
-copy::copy(const queue_wrapper& queue)
-    : m_data(new details::copy_data{queue}) {}
-
-copy::~copy() {}
 
 void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
                    type::copy_type) const {
@@ -46,9 +36,7 @@ void copy::do_copy(std::size_t size, const void* from_ptr, void* to_ptr,
     assert(to_ptr != nullptr);
 
     // Perform the copy.
-    details::get_queue(m_data->m_queue)
-        .memcpy(to_ptr, from_ptr, size)
-        .wait_and_throw();
+    details::get_queue(queue()).memcpy(to_ptr, from_ptr, size).wait_and_throw();
 
     // Let the user know what happened.
     VECMEM_DEBUG_MSG(1, "Performed memory copy of %lu bytes from %p to %p",
@@ -68,14 +56,12 @@ void copy::do_memset(std::size_t size, void* ptr, int value) const {
 
     // Perform the operation.
 #if defined(VECMEM_HAVE_SYCL_MEMSET)
-    details::get_queue(m_data->m_queue)
-        .memset(ptr, value, size)
-        .wait_and_throw();
+    details::get_queue(queue()).memset(ptr, value, size).wait_and_throw();
 #else
     std::vector<int> dummy(size / sizeof(int) + 1);
     std::fill_n(reinterpret_cast<unsigned char*>(dummy.data()), size,
                 static_cast<unsigned char>(value));
-    details::get_queue(m_data->m_queue)
+    details::get_queue(queue())
         .memcpy(ptr, dummy.data(), size)
         .wait_and_throw();
 #endif  // VECMEM_HAVE_SYCL_MEMSET

--- a/sycl/src/utils/sycl/queue_holder.sycl
+++ b/sycl/src/utils/sycl/queue_holder.sycl
@@ -1,0 +1,32 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+
+// Local include(s).
+#include "vecmem/utils/sycl/details/queue_holder.hpp"
+
+// System include(s).
+#include <cassert>
+
+namespace vecmem::sycl::details {
+
+struct queue_holder::impl {
+    /// SYCL queue to perform memory operations with
+    queue_wrapper m_queue;
+};
+
+queue_holder::queue_holder(const queue_wrapper& queue)
+    : m_impl{new impl{queue}} {}
+
+queue_holder::~queue_holder() = default;
+
+queue_wrapper& queue_holder::queue() const {
+
+    assert(m_impl);
+    return m_impl->m_queue;
+}
+
+}  // namespace vecmem::sycl::details

--- a/sycl/src/utils/sycl/queue_wrapper.sycl
+++ b/sycl/src/utils/sycl/queue_wrapper.sycl
@@ -54,7 +54,7 @@ queue_wrapper::queue_wrapper(const queue_wrapper& parent)
     *m_impl = *(parent.m_impl);
 }
 
-queue_wrapper::queue_wrapper(queue_wrapper&& parent) = default;
+queue_wrapper::queue_wrapper(queue_wrapper&& parent) noexcept = default;
 
 queue_wrapper::~queue_wrapper() = default;
 
@@ -69,7 +69,7 @@ queue_wrapper& queue_wrapper::operator=(const queue_wrapper& rhs) {
     return *this;
 }
 
-queue_wrapper& queue_wrapper::operator=(queue_wrapper&& rhs) = default;
+queue_wrapper& queue_wrapper::operator=(queue_wrapper&& rhs) noexcept = default;
 
 void* queue_wrapper::queue() {
 


### PR DESCRIPTION
Following on from the previous PRs, this one tries to clean up `vecmem::sycl` a bit.

Here I did a bit of re-organization as well. Created a new base class (`vecmem::sycl::details::queue_holder`) that would serve as the base class for all user-facing classes that need a `::sycl::queue`. (Which is most of them.) This is to reduce the code duplication a little.