### PR TITLE
Device-Capable Static Vector, main branch (2025.05.06.)

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -160,6 +160,8 @@ vecmem_add_library( vecmem_core core
    "src/utils/copy.cpp"
    "include/vecmem/utils/debug.hpp"
    "src/utils/memory_monitor.cpp"
+   "include/vecmem/utils/memmove.hpp"
+   "include/vecmem/utils/impl/memmove.ipp"
    "include/vecmem/utils/memory_monitor.hpp"
    "include/vecmem/utils/tuple.hpp"
    "include/vecmem/utils/impl/tuple.ipp"

--- a/core/include/vecmem/utils/impl/memmove.ipp
+++ b/core/include/vecmem/utils/impl/memmove.ipp
@@ -1,0 +1,39 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+namespace vecmem {
+namespace details {
+
+VECMEM_HOST_AND_DEVICE
+inline void memmove(void* dest, const void* src, std::size_t bytes) {
+
+    // Check for some trivial cases.
+    if ((dest == src) || (bytes == 0)) {
+        return;
+    }
+
+    // Cast the char pointers.
+    char* dest_char = static_cast<char*>(dest);
+    const char* src_char = static_cast<const char*>(src);
+
+    if ((dest_char < src_char) || (dest_char >= (src_char + bytes))) {
+        // Non-overlapping, or overlapping such that a forward copy does the
+        // correct thing.
+        for (std::size_t i = 0; i < bytes; ++i) {
+            dest_char[i] = src_char[i];
+        }
+    } else {
+        // Overlapping such that a backward copy would do the correct thing.
+        for (std::size_t i = bytes; i > 0; --i) {
+            dest_char[i - 1] = src_char[i - 1];
+        }
+    }
+}
+
+}  // namespace details
+}  // namespace vecmem

--- a/core/include/vecmem/utils/memmove.hpp
+++ b/core/include/vecmem/utils/memmove.hpp
@@ -1,0 +1,35 @@
+/* VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2025 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// Local include(s).
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <cstddef>
+
+namespace vecmem {
+namespace details {
+
+/// Hand-written implementation of a memmove function
+///
+/// It is not super efficient, but:
+///  - It work in device code;
+///  - For the small arrays that it would be used for, should be good enough.
+///
+/// @param dest Pointer to the destination memory
+/// @param src Pointer to the source memory
+/// @param bytes Number of bytes to move
+///
+VECMEM_HOST_AND_DEVICE
+inline void memmove(void* dest, const void* src, std::size_t bytes);
+
+}  // namespace details
+}  // namespace vecmem
+
+// Include the implementation.
+#include "vecmem/utils/impl/memmove.ipp"

--- a/tests/common/jagged_soa_container.hpp
+++ b/tests/common/jagged_soa_container.hpp
@@ -1,12 +1,13 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
 #pragma once
 
 // Local include(s).
+#include "vecmem/containers/static_vector.hpp"
 #include "vecmem/edm/container.hpp"
 #include "vecmem/utils/types.hpp"
 
@@ -20,6 +21,9 @@ class jagged_soa_interface : public BASE {
 public:
     /// Inherit the base class's constructor(s)
     using BASE::BASE;
+
+    /// Inherit the base class's assignment operator(s)
+    using BASE::operator=;
 
     /// Global "count" of something (non-const)
     VECMEM_HOST_AND_DEVICE
@@ -63,6 +67,13 @@ public:
     VECMEM_HOST_AND_DEVICE
     const auto& index() const { return BASE::template get<5>(); }
 
+    /// "Static indices" of something (non-const)
+    VECMEM_HOST_AND_DEVICE
+    auto& static_indices() { return BASE::template get<6>(); }
+    /// "Static indices" of something (const)
+    VECMEM_HOST_AND_DEVICE
+    const auto& static_indices() const { return BASE::template get<6>(); }
+
 };  // class jagged_interface
 
 /// "Jagged" container for the tests
@@ -70,7 +81,8 @@ using jagged_soa_container =
     edm::container<jagged_soa_interface, edm::type::scalar<int>,
                    edm::type::vector<float>, edm::type::jagged_vector<double>,
                    edm::type::scalar<float>, edm::type::jagged_vector<int>,
-                   edm::type::vector<int> >;
+                   edm::type::vector<int>,
+                   edm::type::vector<static_vector<int, 3> > >;
 
 }  // namespace testing
 }  // namespace vecmem

--- a/tests/common/jagged_soa_container_helpers.cpp
+++ b/tests/common/jagged_soa_container_helpers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -38,6 +38,9 @@ void fill(jagged_soa_container::host& obj) {
         for (std::size_t j = 0; j < obj.indices()[i].size(); ++j) {
             obj[i].indices()[j] = static_cast<int>(i + j);
         }
+        for (std::size_t j = 0; j < i % 3; ++j) {
+            obj[i].static_indices().push_back(static_cast<int>(i + j));
+        }
     }
 }
 
@@ -74,6 +77,7 @@ void compare(const jagged_soa_container::const_view& view1,
     };
     compare_jagged(device1.measurements(), device2.measurements());
     compare_jagged(device1.indices(), device2.indices());
+    compare_jagged(device1.static_indices(), device2.static_indices());
 }
 
 void make_buffer(jagged_soa_container::buffer& buffer, memory_resource& main_mr,

--- a/tests/common/jagged_soa_container_helpers.hpp
+++ b/tests/common/jagged_soa_container_helpers.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -31,6 +31,10 @@ inline void fill(unsigned int i, jagged_soa_container::device& obj) {
         for (unsigned int j = 0; j < obj.indices()[i].capacity(); ++j) {
             obj[i].indices().push_back(static_cast<int>(i + j));
         }
+        obj.at(i).static_indices() = {};
+        for (unsigned int j = 0; j < i % 3; ++j) {
+            obj.static_indices().at(i).push_back(static_cast<int>(i + j));
+        }
     }
 }
 
@@ -52,6 +56,9 @@ inline void modify(unsigned int i, jagged_soa_container::device& obj) {
         }
         for (unsigned int j = 0; j < obj.indices()[i].size(); ++j) {
             obj.indices()[i][j] += 10;
+        }
+        for (unsigned int j = 0; j < obj[i].static_indices().size(); ++j) {
+            obj[i].static_indices().at(j) -= 3;
         }
     }
 }

--- a/tests/core/test_core_static_vector.cpp
+++ b/tests/core/test_core_static_vector.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -284,11 +284,7 @@ namespace {
 /// Complex type used in one of the tests.
 struct TestType2 {
     TestType2(int a) : m_a(a + 1), m_b(nullptr) {}
-    ~TestType2() {
-        if (m_b != nullptr) {
-            --(*m_b);
-        }
-    }
+
     int m_a;
     int* m_b;
 };  // struct TestType2
@@ -311,11 +307,4 @@ TEST_F(core_static_vector_test_complex, non_trivial_value) {
         EXPECT_EQ(value.m_a, 11);
         EXPECT_EQ(value.m_b, nullptr);
     }
-
-    // Make sure that the destructor is called on the vector elements.
-    int dummy = 10;
-    v[0].m_b = &dummy;
-    v[5].m_b = &dummy;
-    v.clear();
-    EXPECT_EQ(dummy, 8);
 }

--- a/tests/hip/test_hip_edm_kernels.hip
+++ b/tests/hip/test_hip_edm_kernels.hip
@@ -1,9 +1,12 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
+
+// HIP include(s).
+#include <hip/hip_runtime.h>
 
 // Local include(s).
 #include "../common/jagged_soa_container_helpers.hpp"
@@ -12,9 +15,6 @@
 
 // Project include(s).
 #include "../../hip/src/utils/hip_error_handling.hpp"
-
-// HIP include(s).
-#include <hip/hip_runtime.h>
 
 __global__ void hipSimpleFillKernel(
     vecmem::testing::simple_soa_container::view view) {


### PR DESCRIPTION
Triggered by the discussion on https://github.com/acts-project/traccc/pull/965, and to finally fix #215, this is an attempt to make `vecmem::static_vector` a bit more usable.

That type tried to do a bit more than reasonable. It was trying to support types with custom assignments, non-trivial destructors, etc. But while all that is in principle possible purely in device code, it's technically not possible to do those things when using buffers to send data back and forth between the host and a device.

So I simplified the class in a number of ways. Requiring that it would only use types that are trivially copyable and destructible. Switching to using default copy/move constructors and assignments along the way.

To address #215, I wrote a simple `vecmem::details::memmove` function, which should be "good enough" for this use case. Even if it's probably not super efficient.

I still don't expect that we would use this type too much in [traccc](https://github.com/acts-project/traccc), but now it should at least become technically possible to try it out. :thinking: