### PR TITLE
Zero Copy Fix, main branch (2025.05.06.)

### DIFF
--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -102,6 +102,11 @@ copy::event_type copy::operator()(
     // Figure out the size of the buffer.
     const typename data::vector_view<std::add_const_t<TYPE>>::size_type size =
         get_size(from_view);
+
+    // If the size is zero, don't do an actual copy.
+    if (size == 0u) {
+        return vecmem::copy::create_event();
+    }
 
     // Make the target vector the correct size.
     to_vec.resize(size);


### PR DESCRIPTION
As reported by @Debottam (hopefully I found the correct username...) on Mattermost, client code is getting into problems after including #311.

Just by looking at the code, I could only find this one place where `vecmem::copy` is not protected against zero sized copies. :thinking: So I'd still like to get some feedback from Debo on how exactly he encountered the CUDA error. :thinking: