### PR TITLE
SonarCloud CUDA Fixes, main branch (2025.05.13.)

### DIFF
--- a/cuda/src/utils/cuda_wrappers.hpp
+++ b/cuda/src/utils/cuda_wrappers.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021 CERN for the benefit of the ACTS project
+ * (c) 2021-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -12,9 +12,7 @@
 // CUDA include(s).
 #include <cuda_runtime_api.h>
 
-namespace vecmem {
-namespace cuda {
-namespace details {
+namespace vecmem::cuda::details {
 
 /**
  * @brief Get current CUDA device number.
@@ -30,6 +28,4 @@ int get_device();
 /// Get concrete @c cudaStream_t object out of our wrapper
 cudaStream_t get_stream(const stream_wrapper& stream);
 
-}  // namespace details
-}  // namespace cuda
-}  // namespace vecmem
+}  // namespace vecmem::cuda::details

--- a/cuda/src/utils/get_device_name.hpp
+++ b/cuda/src/utils/get_device_name.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022 CERN for the benefit of the ACTS project
+ * (c) 2022-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -10,9 +10,7 @@
 // System include(s).
 #include <string>
 
-namespace vecmem {
-namespace cuda {
-namespace details {
+namespace vecmem::cuda::details {
 
 /// Get a "fully qualified" name for a given CUDA device
 ///
@@ -24,6 +22,4 @@ namespace details {
 ///
 std::string get_device_name(int device);
 
-}  // namespace details
-}  // namespace cuda
-}  // namespace vecmem
+}  // namespace vecmem::cuda::details

--- a/cuda/src/utils/select_device.hpp
+++ b/cuda/src/utils/select_device.hpp
@@ -33,11 +33,21 @@ public:
      */
     explicit select_device(int device);
 
+    /// Don't allow copying the class
+    select_device(const select_device&) = delete;
+    /// Don't allow moving the class
+    select_device(select_device&&) = delete;
+
     /**
      * @brief Deconstructs the object, returning to the device that was
      * selected before constructing this object.
      */
     ~select_device();
+
+    /// Don't allow copy assigning the class
+    select_device& operator=(const select_device&) = delete;
+    /// Don't allow move assigning the class
+    select_device& operator=(select_device&&) = delete;
 
     /**
      * @brief Identifier for the device being seleced


### PR DESCRIPTION
Got rid of the final [SonarCloud](https://sonarcloud.io) complaints for `vecmem::cuda`.