### PR TITLE
Jagged SoA Sizes, main branch (2025.05.14.)

### DIFF
--- a/core/include/vecmem/utils/copy.hpp
+++ b/core/include/vecmem/utils/copy.hpp
@@ -185,9 +185,14 @@ public:
         edm::host<edm::schema<VARTYPES...>, INTERFACE>& to,
         type::copy_type cptype = type::unknown) const;
 
-    /// Get the (outer) size of a resizable SoA container
+    /// Get the (outer) size of a (resizable) SoA container
     template <typename... VARTYPES>
     typename edm::view<edm::schema<VARTYPES...>>::size_type get_size(
+        const edm::view<edm::schema<VARTYPES...>>& data) const;
+
+    /// Get the (inner) size of a (resizable) SoA container
+    template <typename... VARTYPES>
+    std::vector<data::vector_view<int>::size_type> get_sizes(
         const edm::view<edm::schema<VARTYPES...>>& data) const;
 
     /// @}
@@ -255,6 +260,10 @@ private:
         const edm::view<edm::details::add_const_t<edm::schema<VARTYPES...>>>&
             from,
         edm::view<edm::schema<VARTYPES...>> to, type::copy_type cptype) const;
+    /// Implementation for the variadic @c get_sizes function
+    template <std::size_t INDEX, typename... VARTYPES>
+    std::vector<data::vector_view<int>::size_type> get_sizes_impl(
+        const edm::view<edm::schema<VARTYPES...>>& from) const;
 
 };  // class copy
 

--- a/tests/common/soa_copy_tests.ipp
+++ b/tests/common/soa_copy_tests.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2023-2024 CERN for the benefit of the ACTS project
+ * (c) 2023-2025 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -55,6 +55,14 @@ void soa_copy_tests_base<CONTAINER>::host_to_fixed_device_to_host_direct() {
     // Check the size of the device buffer.
     EXPECT_EQ(input.size(), main_copy().get_size(device_buffer));
 
+    // Exercise the get_sizes(...) function, if there is a jagged vector in the
+    // container.
+    if constexpr (vecmem::edm::details::has_jagged_vector<
+                      typename CONTAINER::schema_type>::value) {
+        EXPECT_EQ(host_copy().get_sizes(input_data),
+                  main_copy().get_sizes(device_buffer));
+    }
+
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};
 
@@ -93,6 +101,17 @@ void soa_copy_tests_base<CONTAINER>::host_to_fixed_device_to_host_optimal() {
     // Copy the data from the host buffer to the device buffer.
     main_copy()(host_buffer1, device_buffer, vecmem::copy::type::host_to_device)
         ->wait();
+
+    // Check the size of the device buffer.
+    EXPECT_EQ(input.size(), main_copy().get_size(device_buffer));
+
+    // Exercise the get_sizes(...) function, if there is a jagged vector in the
+    // container.
+    if constexpr (vecmem::edm::details::has_jagged_vector<
+                      typename CONTAINER::schema_type>::value) {
+        EXPECT_EQ(host_copy().get_sizes(vecmem::get_data(input)),
+                  main_copy().get_sizes(device_buffer));
+    }
 
     // Create a (fixed sized) host buffer, to stage the data back into.
     typename CONTAINER::buffer host_buffer2;
@@ -140,6 +159,14 @@ void soa_copy_tests_base<CONTAINER>::host_to_resizable_device_to_host() {
     // Check the size of the device buffer.
     EXPECT_EQ(input.size(), main_copy().get_size(device_buffer));
 
+    // Exercise the get_sizes(...) function, if there is a jagged vector in the
+    // container.
+    if constexpr (vecmem::edm::details::has_jagged_vector<
+                      typename CONTAINER::schema_type>::value) {
+        EXPECT_EQ(host_copy().get_sizes(input_data),
+                  main_copy().get_sizes(device_buffer));
+    }
+
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};
 
@@ -175,6 +202,14 @@ void soa_copy_tests_base<
     // Check the size of the device buffer.
     EXPECT_EQ(input.size(), main_copy().get_size(device_buffer1));
 
+    // Exercise the get_sizes(...) function, if there is a jagged vector in the
+    // container.
+    if constexpr (vecmem::edm::details::has_jagged_vector<
+                      typename CONTAINER::schema_type>::value) {
+        EXPECT_EQ(host_copy().get_sizes(vecmem::get_data(input)),
+                  main_copy().get_sizes(device_buffer1));
+    }
+
     // Create the (resizable) device buffer.
     typename CONTAINER::buffer device_buffer2;
     vecmem::testing::make_buffer(device_buffer2, main_mr(), host_mr(),
@@ -187,6 +222,14 @@ void soa_copy_tests_base<
 
     // Check the size of the device buffer.
     EXPECT_EQ(input.size(), main_copy().get_size(device_buffer2));
+
+    // Exercise the get_sizes(...) function, if there is a jagged vector in the
+    // container.
+    if constexpr (vecmem::edm::details::has_jagged_vector<
+                      typename CONTAINER::schema_type>::value) {
+        EXPECT_EQ(host_copy().get_sizes(vecmem::get_data(input)),
+                  main_copy().get_sizes(device_buffer2));
+    }
 
     // Create the target host container.
     typename CONTAINER::host target{host_mr()};


### PR DESCRIPTION
This feature has been long missing, I finally added a `vecmem::copy::get_sizes(...)` function for SoA containers.

The code does the trivial thing of just taking the sizes of the first jagged vector that it finds. It's up to the user to make sure that this would make sense for them.