### PR TITLE
SYCL Assertion Handling Fix, main branch (2025.05.21.)

### DIFF
--- a/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
+++ b/cmake/sycl/Platform/Linux-IntelLLVM-SYCL.cmake
@@ -1,6 +1,6 @@
 # VecMem project, part of the ACTS project (R&D line)
 #
-# (c) 2021-2024 CERN for the benefit of the ACTS project
+# (c) 2021-2025 CERN for the benefit of the ACTS project
 #
 # Mozilla Public License Version 2.0
 
@@ -15,6 +15,11 @@ if( LinuxIntelLLVM_AVAILABLE AND IntelLLVM_AVAILABLE )
    # configuration.
    __linux_compiler_intel_llvm( SYCL )
    __compiler_intel_llvm( SYCL )
+   # Set some options by hand.
+   set( CMAKE_SYCL_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN
+      "-fvisibility-inlines-hidden" )
+   string( APPEND CMAKE_SYCL_FLAGS_RELEASE_INIT " -DNDEBUG" )
+   string( APPEND CMAKE_SYCL_FLAGS_RELWITHDEBINFO_INIT " -DNDEBUG" )
 else()
    # We have a somewhat older version of CMake. Use the configuration for the
    # older Intel compilers.
@@ -25,6 +30,11 @@ else()
    if( LinuxIntel_AVAILABLE AND Intel_AVAILABLE )
       __linux_compiler_intel( SYCL )
       __compiler_intel( SYCL )
+      # Set some options by hand.
+      set( CMAKE_SYCL_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN
+         "-fvisibility-inlines-hidden" )
+      string( APPEND CMAKE_SYCL_FLAGS_RELEASE_INIT " -DNDEBUG" )
+      string( APPEND CMAKE_SYCL_FLAGS_RELWITHDEBINFO_INIT " -DNDEBUG" )
    else()
       message( WARNING "No Intel compiler configuration found in CMake! "
          "Setting fragile defaults by hand..." )


### PR DESCRIPTION
Triggered by issues encountered in [detray](https://github.com/acts-project/detray) and [traccc](https://github.com/acts-project/traccc) because of the new assertions added by @niermann999 recently, I finally decided to fix a long standing issue in our SYCL builds.

I've known for a long time that the CMake setup used for the SYCL build was not applying `-DNDEBUG` correctly in `RelWithDebInfo` builds. Since I was seeing assertions in such builds since forever. But so far I just looked at this as a happy accident, as it helped me find issues. But now those assertions are preventing me from some developments. 😦

The issue turned out to be that while CMake's internal function that set up GNU compilers (https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Compiler/GNU.cmake?ref_type=heads) adds `-DNDEBUG` itself, the module handling Intel compilers (https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Compiler/IntelLLVM.cmake?ref_type=heads) is not doing this in the same way. Instead, for the Intel compiler `-DNDEBUG` is added in the "front-end" configuration files.
  - https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Compiler/IntelLLVM-CXX.cmake?ref_type=heads#L25
  - https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Compiler/IntelLLVM-C.cmake?ref_type=heads#L23

So now I added this flag for `Release` and `RelWithDebInfo` builds explicitly in our code as well. 🤔 I checked, I believe that for the other known SYCL compilers the setup (at least in this respect) was correct already.

At the same time also added knowledge about `-fvisibility-inlines-hidden`, since the CMake code is doing the same.
  - https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/Compiler/IntelLLVM-CXX.cmake?ref_type=heads#L23