### PR TITLE
Jagged Vector Copy Fix, main branch (2025.05.30.)

### DIFF
--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -223,8 +223,12 @@ data::jagged_vector_buffer<std::remove_cv_t<TYPE>> copy::to(
     memory_resource* host_access_resource, type::copy_type cptype) const {
 
     // Create the result buffer object.
+    const data::buffer_type btype =
+        (((data.capacity() > 0u) && (data.host_ptr()[0].size_ptr() != nullptr))
+             ? data::buffer_type::resizable
+             : data::buffer_type::fixed_size);
     data::jagged_vector_buffer<std::remove_cv_t<TYPE>> result(
-        data::get_capacities(data), resource, host_access_resource);
+        data::get_capacities(data), resource, host_access_resource, btype);
     assert(result.size() == data.size());
 
     // Copy the description of the "inner vectors" if necessary.


### PR DESCRIPTION
In #334 I found that `vecmem::copy::to(...)` was not really implemented correctly for jagged vectors in multiple ways. I fixed one shortcoming in #334, but the code was still not copying resizable containers correctly. (This is also the issue that @beomki-yeo ran into in https://github.com/acts-project/traccc/pull/943.)

Added some explicit tests for this behaviour, now that I know that it was broken so far.