### PR TITLE
Proxy Device Copy Fix, main branch (2025.08.06.)

### DIFF
--- a/core/include/vecmem/edm/details/proxy_traits.hpp
+++ b/core/include/vecmem/edm/details/proxy_traits.hpp
@@ -474,7 +474,8 @@ private:
 /// @param src Source tuple to copy from
 ///
 template <typename T>
-void proxy_tuple_copy(tuple<T>& dst, const tuple<T>& src) {
+VECMEM_HOST_AND_DEVICE void proxy_tuple_copy(tuple<T>& dst,
+                                             const tuple<T>& src) {
     dst.m_head = src.m_head;
 }
 
@@ -488,7 +489,8 @@ void proxy_tuple_copy(tuple<T>& dst, const tuple<T>& src) {
 ///
 template <typename T, typename... Ts,
           std::enable_if_t<(sizeof...(Ts) > 0), bool> = true>
-void proxy_tuple_copy(tuple<T, Ts...>& dst, const tuple<T, Ts...>& src) {
+VECMEM_HOST_AND_DEVICE void proxy_tuple_copy(tuple<T, Ts...>& dst,
+                                             const tuple<T, Ts...>& src) {
     dst.m_head = src.m_head;
     proxy_tuple_copy(dst.m_tail, src.m_tail);
 }


### PR DESCRIPTION
Added missing `VECMEM_HOST_AND_DEVICE` declarations to `vecmem::edm::details::proxy_tuple_copy`.  These were unfortunately left off in #325. And as I found in https://github.com/acts-project/traccc/pull/1112, HIP is not happy about them missing. 😦 

CUDA, probably because of `--expt-relaxed-constexpr`, or maybe just a general aggressive template inlining, didn't complain about this. 🤔