### PR TITLE
EDM Code Tweaks, main branch (2025.08.13.)

### DIFF
--- a/core/include/vecmem/edm/host.hpp
+++ b/core/include/vecmem/edm/host.hpp
@@ -66,6 +66,10 @@ public:
                              details::proxy_type::standalone>>;
 
     /// @name Constructors and assignment operators
+    ///
+    /// Note that copy and move constructors and assignment operators get
+    /// generated automatically. They don't need to be implemented explicitly.
+    ///
     /// @{
 
     /// Constructor with a mandatory memory resource
@@ -80,6 +84,9 @@ public:
     /// Get the size of the container
     VECMEM_HOST
     size_type size() const;
+    /// Get the (minimum) capacity of the container
+    VECMEM_HOST
+    size_type capacity() const;
     /// Resize the container
     VECMEM_HOST
     void resize(size_type size);

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -25,7 +25,8 @@ VECMEM_HOST host<schema<VARTYPES...>, INTERFACE>::host(
       m_resource{resource} {}
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
-VECMEM_HOST std::size_t host<schema<VARTYPES...>, INTERFACE>::size() const {
+VECMEM_HOST auto host<schema<VARTYPES...>, INTERFACE>::size() const
+    -> size_type {
 
     // Make sure that there are some (jagged) vector types in the container.
     static_assert(
@@ -52,8 +53,7 @@ VECMEM_HOST auto host<schema<VARTYPES...>, INTERFACE>::capacity() const
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
-VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::resize(
-    std::size_t size) {
+VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::resize(size_type size) {
 
     // Make sure that there are some (jagged) vector types in the container.
     static_assert(
@@ -66,8 +66,7 @@ VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::resize(
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
-VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::reserve(
-    std::size_t size) {
+VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::reserve(size_type size) {
 
     // Make sure that there are some (jagged) vector types in the container.
     static_assert(

--- a/core/include/vecmem/edm/impl/host.ipp
+++ b/core/include/vecmem/edm/impl/host.ipp
@@ -38,6 +38,20 @@ VECMEM_HOST std::size_t host<schema<VARTYPES...>, INTERFACE>::size() const {
 }
 
 template <typename... VARTYPES, template <typename> class INTERFACE>
+VECMEM_HOST auto host<schema<VARTYPES...>, INTERFACE>::capacity() const
+    -> size_type {
+
+    // Make sure that there are some (jagged) vector types in the container.
+    static_assert(
+        std::disjunction_v<type::details::is_vector<VARTYPES>...>,
+        "This function requires at least one (jagged) vector variable.");
+
+    // Get the size of the vector(s).
+    return details::get_host_capacity<VARTYPES...>(
+        m_data, std::index_sequence_for<VARTYPES...>{});
+}
+
+template <typename... VARTYPES, template <typename> class INTERFACE>
 VECMEM_HOST void host<schema<VARTYPES...>, INTERFACE>::resize(
     std::size_t size) {
 

--- a/core/include/vecmem/edm/impl/proxy.ipp
+++ b/core/include/vecmem/edm/impl/proxy.ipp
@@ -11,6 +11,14 @@ namespace edm {
 
 template <typename... VARTYPES, details::proxy_domain PDOMAIN,
           details::proxy_access PACCESS, details::proxy_type PTYPE>
+template <details::proxy_type OPTYPE,
+          std::enable_if_t<OPTYPE == details::proxy_type::standalone, bool>>
+VECMEM_HOST_AND_DEVICE
+proxy<schema<VARTYPES...>, PDOMAIN, PACCESS, PTYPE>::proxy()
+    : m_data() {}
+
+template <typename... VARTYPES, details::proxy_domain PDOMAIN,
+          details::proxy_access PACCESS, details::proxy_type PTYPE>
 template <typename PARENT>
 VECMEM_HOST_AND_DEVICE proxy<schema<VARTYPES...>, PDOMAIN, PACCESS,
                              PTYPE>::proxy(PARENT& parent,

--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -49,6 +49,12 @@ public:
     /// @name Constructors and assignment operators
     /// @{
 
+    /// Default constructor (only for standalone proxies)
+    template <details::proxy_type OPTYPE = proxy_type,
+              std::enable_if_t<OPTYPE == details::proxy_type::standalone,
+                               bool> = true>
+    VECMEM_HOST_AND_DEVICE proxy();
+
     /// Constructor of a non-const proxy on top of a parent container
     ///
     /// @tparam PARENT The type of the parent container

--- a/tests/core/test_core_edm_host.cpp
+++ b/tests/core/test_core_edm_host.cpp
@@ -288,8 +288,7 @@ TEST_F(core_edm_host_test, push_back_simple) {
     // Set up a simple type, without any jagged vectors.
     simple_host_type host{m_resource};
 
-    // Add a couple of elements to it. Since simple_interface has an explicit
-    // constructor, the formalism here is fairly simple.
+    // Add a couple of elements to it.
     host.push_back({1, 2.f});
     host.push_back({2, 3.f});
 
@@ -299,6 +298,12 @@ TEST_F(core_edm_host_test, push_back_simple) {
     EXPECT_EQ(host.at(1).scalar(), 2);
     EXPECT_FLOAT_EQ(host.at(0).vector(), 2.f);
     EXPECT_FLOAT_EQ(host.at(1).vector(), 3.f);
+
+    // Add one default element.
+    host.push_back({});
+    EXPECT_EQ(host.size(), 3);
+    // Note that at this point host.scalar() will be in a sort of undefined
+    // state. It should be 0, but I'm not convinced that this is guaranteed.
 }
 
 TEST_F(core_edm_host_test, push_back_jagged) {
@@ -306,9 +311,7 @@ TEST_F(core_edm_host_test, push_back_jagged) {
     // Create an empty host container.
     host_type host{m_resource};
 
-    // Add a couple of elements to it. Since interface has no constructor of
-    // its own, because with jagged vectors that's not so easy to do, one needs
-    // to use double braces in the following expression.
+    // Add a couple of elements to it.
     host.push_back({1, 2.f, vecmem::vector<double>{3., 4., 5.}});
     host.push_back({2, 3.f, vecmem::vector<double>{4., 5., 6.}});
 
@@ -352,4 +355,10 @@ TEST_F(core_edm_host_test, push_back_jagged) {
                              ref_proxy.jagged_vector().at(j));
         }
     }
+
+    // Add one default element.
+    host.push_back({});
+    EXPECT_EQ(host.size(), 3);
+    // The same as before, host.scalar() will be in a sort of undefined state at
+    // this point.
 }

--- a/tests/core/test_core_edm_host.cpp
+++ b/tests/core/test_core_edm_host.cpp
@@ -87,6 +87,24 @@ TEST_F(core_edm_host_test, construct_assign) {
     compare(host1, host3);
 }
 
+TEST_F(core_edm_host_test, size_capacity) {
+
+    // Construct the object to be tested.
+    host_type host = create();
+
+    // Check its starting size and capacity.
+    EXPECT_EQ(host.size(), 5);
+    EXPECT_GE(host.capacity(), 5);
+
+    // Reserve a number of elements, and add one.
+    host.reserve(10);
+    host.push_back({6, 7.f, {8., 9.}});
+
+    // Check the resulting size and capacity.
+    EXPECT_EQ(host.size(), 6);
+    EXPECT_GE(host.capacity(), 10);
+}
+
 TEST_F(core_edm_host_test, get_data) {
 
     // Construct a host container.


### PR DESCRIPTION
Added `vecmem::edm::host::capacity()`, which would've come in handy while doing some performance analysis on https://github.com/acts-project/traccc/pull/1112.

While at it, I also found that the code was using `std::size_t` in a hardcoded way in a few places where it should've been using a typedef instead.