### PR TITLE
EDM Proxy Concept, main branch (2025.12.17.)

### DIFF
--- a/core/include/vecmem/edm/proxy.hpp
+++ b/core/include/vecmem/edm/proxy.hpp
@@ -12,6 +12,9 @@
 #include "vecmem/utils/tuple.hpp"
 #include "vecmem/utils/types.hpp"
 
+// System include(s).
+#include <type_traits>
+
 namespace vecmem {
 namespace edm {
 
@@ -168,6 +171,17 @@ private:
     tuple_type m_data;
 
 };  // class proxy
+
+#ifdef __cpp_concepts
+namespace concepts {
+/// Concept for a type being of a proxy type
+template <typename T>
+concept proxy =
+    (std::is_same_v<typename T::proxy_domain, details::proxy_domain> &&
+     std::is_same_v<typename T::access_type, details::proxy_access> &&
+     std::is_same_v<typename T::proxy_type, details::proxy_type>);
+}  // namespace concepts
+#endif  // __cpp_concepts
 
 }  // namespace edm
 }  // namespace vecmem


### PR DESCRIPTION
Introduced `vecmem::edm::concepts::proxy`. So that client code using C\+\+20(\+) would be able to write code that specifically operates on top of proxy objects.

This was triggered by a debug session with @niermann999 about 2 weeks ago, where a container was passed to a function that was expecting to get a single proxy object. With the compiler errors being very unhelpful about where the issue was.

I didn't yet decide how to best test the code in the CI, so let's leave it as a draft for the moment...