### PR TITLE
In-Order SYCL Queues, main branch (2026.01.06.)

### DIFF
--- a/sycl/src/utils/sycl/queue_wrapper.sycl
+++ b/sycl/src/utils/sycl/queue_wrapper.sycl
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -26,7 +26,8 @@ struct queue_wrapper::impl {
 
 queue_wrapper::queue_wrapper() : m_impl{std::make_unique<impl>()} {
 
-    m_impl->m_managedQueue = std::make_shared<::sycl::queue>();
+    ::sycl::property_list queue_properties{::sycl::property::queue::in_order{}};
+    m_impl->m_managedQueue = std::make_shared<::sycl::queue>(queue_properties);
     m_impl->m_queue = m_impl->m_managedQueue.get();
     VECMEM_DEBUG_MSG(1,
                      "Created an \"owning wrapper\" around a queue on "


### PR DESCRIPTION
Made `vecmem::sycl::queue_wrapper` create `in_order` queues.

These are generally safer/easier to program for in a heterogeneous, non-SYCL-specific way. And they've been available in oneAPI since a very long time. I bumped into this as an issue in https://github.com/acts-project/traccc/pull/1225. Since I don't want to add `wait()` calls to the CUDA backend in that PR, it's finally time to switch to in-order queues in our code. (Should have done this a long time ago already.)

Pinging @flg for good measure. :wink: