### PR TITLE
Disable collecting timing information for cuda and hip events 

### DIFF
--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -41,7 +41,8 @@ event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
 
     // Create the (initial) events in the pool.
     for (cudaEvent_t& e : m_pool) {
-        VECMEM_CUDA_ERROR_CHECK(cudaEventCreate(&e));
+        VECMEM_CUDA_ERROR_CHECK(
+            cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
     }
 }
 
@@ -61,7 +62,8 @@ cudaEvent_t event_pool::create() {
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
         cudaEvent_t e;
-        VECMEM_CUDA_ERROR_CHECK(cudaEventCreate(&e));
+        VECMEM_CUDA_ERROR_CHECK(
+            cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
         m_pool.push_back(e);
     }
 

--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -48,7 +48,7 @@ namespace vecmem {
 namespace cuda {
 namespace details {
 
-event_pool::event_pool(std::size_t size) : m_pool(), m_used_events(0) {
+event_pool::event_pool(std::size_t size) {
     // Create the (initial) events in the pool.
     m_pool.reserve(size);
     for (std::size_t i = 0; i < size; ++i) {

--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -34,11 +34,13 @@
 #include <stdexcept>
 
 namespace {
-void create_event(cudaEvent_t& event) {
+cudaEvent_t create_event() {
+    cudaEvent_t event;
     // Disable collecting timing information since the event is used only for
     // synchronization.
     VECMEM_CUDA_ERROR_CHECK(
         cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+    return event;
 }
 }  // namespace
 
@@ -46,11 +48,11 @@ namespace vecmem {
 namespace cuda {
 namespace details {
 
-event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
-
+event_pool::event_pool(std::size_t size) : m_pool(), m_used_events(0) {
     // Create the (initial) events in the pool.
-    for (cudaEvent_t& e : m_pool) {
-        ::create_event(e);
+    m_pool.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        m_pool.push_back(::create_event());
     }
 }
 
@@ -69,9 +71,7 @@ cudaEvent_t event_pool::create() {
 
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
-        cudaEvent_t e;
-        ::create_event(e);
-        m_pool.push_back(e);
+        m_pool.push_back(::create_event());
     }
 
     // Return an (unused) event from the pool.

--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -33,6 +33,15 @@
 #include <cassert>
 #include <stdexcept>
 
+namespace {
+void create_event(cudaEvent_t& event) {
+    // Disable collecting timing information since the event is used only for
+    // synchronization.
+    VECMEM_CUDA_ERROR_CHECK(
+        cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+}
+}  // namespace
+
 namespace vecmem {
 namespace cuda {
 namespace details {
@@ -41,8 +50,7 @@ event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
 
     // Create the (initial) events in the pool.
     for (cudaEvent_t& e : m_pool) {
-        VECMEM_CUDA_ERROR_CHECK(
-            cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
+        ::create_event(e);
     }
 }
 
@@ -62,8 +70,7 @@ cudaEvent_t event_pool::create() {
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
         cudaEvent_t e;
-        VECMEM_CUDA_ERROR_CHECK(
-            cudaEventCreateWithFlags(&e, cudaEventDisableTiming));
+        ::create_event(e);
         m_pool.push_back(e);
     }
 

--- a/cuda/src/utils/event_pool.hpp
+++ b/cuda/src/utils/event_pool.hpp
@@ -44,7 +44,7 @@ private:
     /// The pool of events
     std::vector<cudaEvent_t> m_pool;
     /// The number of currently used events
-    std::size_t m_used_events;
+    std::size_t m_used_events = 0;
 
 };  // class event_pool
 

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -33,6 +33,15 @@
 #include <cassert>
 #include <stdexcept>
 
+namespace {
+void create_event(hipEvent_t& event) {
+    // Disable collecting timing information since the event is used only for
+    // synchronization.
+    VECMEM_HIP_ERROR_CHECK(
+        hipEventCreateWithFlags(&event, hipEventDisableTiming));
+}
+}  // namespace
+
 namespace vecmem {
 namespace hip {
 namespace details {
@@ -41,8 +50,7 @@ event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
 
     // Create the (initial) events in the pool.
     for (hipEvent_t& e : m_pool) {
-        VECMEM_HIP_ERROR_CHECK(
-            hipEventCreateWithFlags(&e, hipEventDisableTiming));
+        ::create_event(e);
     }
 }
 
@@ -62,8 +70,7 @@ hipEvent_t event_pool::create() {
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
         hipEvent_t e;
-        VECMEM_HIP_ERROR_CHECK(
-            hipEventCreateWithFlags(&e, hipEventDisableTiming));
+        ::create_event(e);
         m_pool.push_back(e);
     }
 

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -48,7 +48,7 @@ namespace vecmem {
 namespace hip {
 namespace details {
 
-event_pool::event_pool(std::size_t size) : m_pool(), m_used_events(0) {
+event_pool::event_pool(std::size_t size) {
     // Create the (initial) events in the pool.
     m_pool.reserve(size);
     for (std::size_t i = 0; i < size; ++i) {

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -41,7 +41,8 @@ event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
 
     // Create the (initial) events in the pool.
     for (hipEvent_t& e : m_pool) {
-        VECMEM_HIP_ERROR_CHECK(hipEventCreate(&e));
+        VECMEM_HIP_ERROR_CHECK(
+            hipEventCreateWithFlags(&e, hipEventDisableTiming));
     }
 }
 
@@ -61,7 +62,8 @@ hipEvent_t event_pool::create() {
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
         hipEvent_t e;
-        VECMEM_HIP_ERROR_CHECK(hipEventCreate(&e));
+        VECMEM_HIP_ERROR_CHECK(
+            hipEventCreateWithFlags(&e, hipEventDisableTiming));
         m_pool.push_back(e);
     }
 

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -34,11 +34,13 @@
 #include <stdexcept>
 
 namespace {
-void create_event(hipEvent_t& event) {
+hipEvent_t create_event() {
+    hipEvent_t event;
     // Disable collecting timing information since the event is used only for
     // synchronization.
     VECMEM_HIP_ERROR_CHECK(
         hipEventCreateWithFlags(&event, hipEventDisableTiming));
+    return event;
 }
 }  // namespace
 
@@ -46,11 +48,11 @@ namespace vecmem {
 namespace hip {
 namespace details {
 
-event_pool::event_pool(std::size_t size) : m_pool(size), m_used_events(0) {
-
+event_pool::event_pool(std::size_t size) : m_pool(), m_used_events(0) {
     // Create the (initial) events in the pool.
-    for (hipEvent_t& e : m_pool) {
-        ::create_event(e);
+    m_pool.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        m_pool.push_back(::create_event());
     }
 }
 
@@ -69,9 +71,7 @@ hipEvent_t event_pool::create() {
 
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
-        hipEvent_t e;
-        ::create_event(e);
-        m_pool.push_back(e);
+        m_pool.push_back(::create_event());
     }
 
     // Return an (unused) event from the pool.

--- a/hip/src/utils/event_pool.hpp
+++ b/hip/src/utils/event_pool.hpp
@@ -44,7 +44,7 @@ private:
     /// The pool of events
     std::vector<hipEvent_t> m_pool;
     /// The number of currently used events
-    std::size_t m_used_events;
+    std::size_t m_used_events = 0;
 
 };  // class event_pool
 


### PR DESCRIPTION
The CUDA and HIP events in vecmem are used only for synchronization, not for timing, and are never leaked to the outside. Both [CUDA](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html#group__CUDART__EVENT_1g7b317e07ff385d85aa656204b971a042) and [HIP](https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/group___event.html#gae86a5acb1b22b61bc9ecb9c28fc71b75) documentation mentions that if not needed collecting timing information can be disabled to possibly give better performance

Having said that, I don't see noticeable performance improvement for traccc main branch with CUDA 12.8 on neither Nvidia RTX 3060 nor L40S.