### PR TITLE
Add methods for non-blocking event completion

### DIFF
--- a/core/include/vecmem/utils/abstract_event.hpp
+++ b/core/include/vecmem/utils/abstract_event.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022-2025 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/utils/abstract_event.hpp
+++ b/core/include/vecmem/utils/abstract_event.hpp
@@ -27,6 +27,9 @@ struct abstract_event {
     /// complete
     virtual void wait() = 0;
 
+    /// Function checking whether the event is complete without blocking.
+    virtual bool is_ready() const = 0;
+
     /// Function telling the object not to wait for the underlying event
     virtual void ignore() = 0;
 

--- a/core/include/vecmem/utils/async_size.hpp
+++ b/core/include/vecmem/utils/async_size.hpp
@@ -48,6 +48,13 @@ public:
     ///
     const_reference get() const;
 
+    /// Access the async/future value without waiting for completion
+    /// Completion must be ensured by the user
+    ///
+    /// @return Reference to the value
+    ///
+    const_reference unsafe_get() const;
+
     /// @name Function(s) implemented from @c vecmem::abstract_event
     /// @{
 

--- a/core/include/vecmem/utils/async_size.hpp
+++ b/core/include/vecmem/utils/async_size.hpp
@@ -62,6 +62,12 @@ public:
     /// complete
     void wait() override;
 
+    /// Function checking whether the event is complete without blocking
+    ///
+    /// @return true if the event is complete, false otherwise
+    ///
+    bool is_ready() const override;
+
     /// Function telling the object not to wait for the underlying event
     void ignore() override;
 

--- a/core/include/vecmem/utils/async_size.hpp
+++ b/core/include/vecmem/utils/async_size.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/utils/async_sizes.hpp
+++ b/core/include/vecmem/utils/async_sizes.hpp
@@ -48,6 +48,13 @@ public:
     ///
     const_reference get() const;
 
+    /// Access the async/future value without waiting for completion
+    /// Completion must be ensured by the user
+    ///
+    /// @return Reference to the value
+    ///
+    const_reference unsafe_get() const;
+
     /// @name Function(s) implemented from @c vecmem::abstract_event
     /// @{
 

--- a/core/include/vecmem/utils/async_sizes.hpp
+++ b/core/include/vecmem/utils/async_sizes.hpp
@@ -62,6 +62,12 @@ public:
     /// complete
     void wait() override;
 
+    /// Function checking whether the event is complete without blocking
+    ///
+    /// @return true if the event is complete, false otherwise
+    ///
+    bool is_ready() const override;
+
     /// Function telling the object not to wait for the underlying event
     void ignore() override;
 

--- a/core/include/vecmem/utils/async_sizes.hpp
+++ b/core/include/vecmem/utils/async_sizes.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/utils/impl/async_size.ipp
+++ b/core/include/vecmem/utils/impl/async_size.ipp
@@ -22,6 +22,14 @@ auto async_size<SIZE_TYPE>::get() const -> const_reference {
 }
 
 template <typename SIZE_TYPE>
+auto async_size<SIZE_TYPE>::unsafe_get() const -> const_reference {
+
+    // Access the value assuming the event is complete
+    m_event->ignore();
+    return (*m_size);
+}
+
+template <typename SIZE_TYPE>
 void async_size<SIZE_TYPE>::wait() {
 
     m_event->wait();

--- a/core/include/vecmem/utils/impl/async_size.ipp
+++ b/core/include/vecmem/utils/impl/async_size.ipp
@@ -36,6 +36,12 @@ void async_size<SIZE_TYPE>::wait() {
 }
 
 template <typename SIZE_TYPE>
+bool async_size<SIZE_TYPE>::is_ready() const {
+
+    return m_event->is_ready();
+}
+
+template <typename SIZE_TYPE>
 void async_size<SIZE_TYPE>::ignore() {
 
     m_event->ignore();

--- a/core/include/vecmem/utils/impl/async_size.ipp
+++ b/core/include/vecmem/utils/impl/async_size.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/include/vecmem/utils/impl/async_size.ipp
+++ b/core/include/vecmem/utils/impl/async_size.ipp
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+// System includes.
+#include <cassert>
+
 namespace vecmem {
 
 template <typename SIZE_TYPE>
@@ -25,6 +28,7 @@ template <typename SIZE_TYPE>
 auto async_size<SIZE_TYPE>::unsafe_get() const -> const_reference {
 
     // Access the value assuming the event is complete
+    assert(m_event->is_ready());
     m_event->ignore();
     return (*m_size);
 }

--- a/core/include/vecmem/utils/impl/async_sizes.ipp
+++ b/core/include/vecmem/utils/impl/async_sizes.ipp
@@ -22,6 +22,14 @@ auto async_sizes<SIZE_TYPE>::get() const -> const_reference {
 }
 
 template <typename SIZE_TYPE>
+auto async_sizes<SIZE_TYPE>::unsafe_get() const -> const_reference {
+
+    // Access the value assuming the event is complete
+    m_event->ignore();
+    return m_sizes;
+}
+
+template <typename SIZE_TYPE>
 void async_sizes<SIZE_TYPE>::wait() {
 
     m_event->wait();

--- a/core/include/vecmem/utils/impl/async_sizes.ipp
+++ b/core/include/vecmem/utils/impl/async_sizes.ipp
@@ -36,6 +36,12 @@ void async_sizes<SIZE_TYPE>::wait() {
 }
 
 template <typename SIZE_TYPE>
+bool async_sizes<SIZE_TYPE>::is_ready() const {
+
+    return m_event->is_ready();
+}
+
+template <typename SIZE_TYPE>
 void async_sizes<SIZE_TYPE>::ignore() {
 
     m_event->ignore();

--- a/core/include/vecmem/utils/impl/async_sizes.ipp
+++ b/core/include/vecmem/utils/impl/async_sizes.ipp
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+// System includes.
+#include <cassert>
+
 namespace vecmem {
 
 template <typename SIZE_TYPE>
@@ -25,6 +28,7 @@ template <typename SIZE_TYPE>
 auto async_sizes<SIZE_TYPE>::unsafe_get() const -> const_reference {
 
     // Access the value assuming the event is complete
+    assert(m_event->is_ready());
     m_event->ignore();
     return m_sizes;
 }

--- a/core/include/vecmem/utils/impl/async_sizes.ipp
+++ b/core/include/vecmem/utils/impl/async_sizes.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2025 CERN for the benefit of the ACTS project
+ * (c) 2025-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/core/src/utils/copy.cpp
+++ b/core/src/utils/copy.cpp
@@ -20,6 +20,7 @@ struct noop_event final : public vecmem::abstract_event {
     void wait() override {
         // No-op
     }
+    bool is_ready() const override { return true; }  // always ready
     void ignore() override {
         // No-op
     }

--- a/cuda/src/utils/cuda/async_copy.cpp
+++ b/cuda/src/utils/cuda/async_copy.cpp
@@ -77,6 +77,19 @@ struct cuda_event : public vecmem::abstract_event {
         cuda_event::ignore();
     }
 
+    /// Check the underlying CUDA event without blocking
+    bool is_ready() const override {
+        if (m_event == nullptr) {
+            return true;
+        }
+        const auto status = cudaEventQuery(m_event);
+        if (status == cudaErrorNotReady) {
+            return false;
+        }
+        VECMEM_CUDA_ERROR_CHECK(status);
+        return true;
+    }
+
     /// Ignore the underlying CUDA event
     void ignore() override {
         if (m_event == nullptr) {

--- a/hip/src/utils/hip/async_copy.cpp
+++ b/hip/src/utils/hip/async_copy.cpp
@@ -76,6 +76,19 @@ struct hip_event : public vecmem::abstract_event {
         hip_event::ignore();
     }
 
+    /// Check the underlying HIP event without blocking
+    bool is_ready() const override {
+        if (m_event == nullptr) {
+            return true;
+        }
+        const auto status = hipEventQuery(m_event);
+        if (status == hipErrorNotReady) {
+            return false;
+        }
+        VECMEM_HIP_ERROR_CHECK(status);
+        return true;
+    }
+
     /// Ignore the underlying HIP event
     void ignore() override {
         if (m_event == nullptr) {

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/sycl/src/utils/sycl/async_copy.sycl
+++ b/sycl/src/utils/sycl/async_copy.sycl
@@ -47,6 +47,21 @@ struct sycl_event : public vecmem::abstract_event {
         sycl_event::ignore();
     }
 
+    /// Check the underlying SYCL event without blocking
+    bool is_ready() const override {
+        if (m_events.empty()) {
+            return true;
+        }
+        for (const ::sycl::event& event : m_events) {
+            const auto status =
+                event.get_info<::sycl::info::event::command_execution_status>();
+            if (status != ::sycl::info::event_command_status::complete) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /// Ignore the underlying SYCL event
     void ignore() override { m_events.clear(); }
 

--- a/tests/common/copy_tests.ipp
+++ b/tests/common/copy_tests.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2024-2025 CERN for the benefit of the ACTS project
+ * (c) 2024-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */

--- a/tests/common/copy_tests.ipp
+++ b/tests/common/copy_tests.ipp
@@ -13,6 +13,9 @@
 #include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
 
+// System include(s).
+#include <thread>
+
 // GoogleTest include(s).
 #include <gtest/gtest.h>
 
@@ -635,4 +638,30 @@ TEST_P(copy_tests, memset) {
             EXPECT_EQ(std::get<2>(value), 0.);
         }
     }
+}
+
+/// Test event completion query
+TEST_P(copy_tests, event_query) {
+
+    // Create a small device buffer and set it up.
+    const auto expected_size = 16;
+    auto device_buffer =
+        vecmem::data::vector_buffer<int>(expected_size, main_mr());
+    auto event = main_copy().setup(device_buffer);
+    ASSERT_NE(event, nullptr);
+
+    // Readiness query must be callable at any time.
+    EXPECT_NO_THROW(std::ignore = event->is_ready());
+
+    // Waiting must always make the event ready.
+    EXPECT_NO_THROW(event->wait());
+    EXPECT_TRUE(event->is_ready());
+
+    // Obtain a value from async_size without waiting.
+    auto size = main_copy().get_size(device_buffer, host_mr());
+    while (!size.is_ready()) {
+        std::this_thread::yield();
+    }
+    EXPECT_EQ(expected_size, size.unsafe_get());
+    EXPECT_EQ(expected_size, size.get());
 }


### PR DESCRIPTION
This change complements the existing blocking/waiting interface of `event` by introducing a non-blocking query mechanism.

Adding `is_ready` method to query completion status of events. In case of synchronous, noop-events it always returns `true`, for asynchronous events it calls corresponding "query" function from the underlying library.


Also, adding `unsafe_get` to `async_size` and `async_sizes` to get the value without waiting on an event in cases when user can guarantee it was already synchronized by some other means (such as querying, synchronizing the whole stream, device).
I was also thinking about adding (or replacing `unsafe_get` with) something like `bool try_get(reference)` which would be "safe" at the cost of always making an extra query