### PR TITLE
CUDA/HIP Event Creation Flag Specification, main branch (2026.04.15.)

### DIFF
--- a/cuda/include/vecmem/utils/cuda/async_copy.hpp
+++ b/cuda/include/vecmem/utils/cuda/async_copy.hpp
@@ -33,9 +33,23 @@ namespace vecmem::cuda {
 class async_copy : public vecmem::copy {
 
 public:
-    /// Constructor with the stream to operate on
+    /// Constructor with the CUDA stream to operate on
+    ///
+    /// @param stream The CUDA stream to perform the copies in
+    ///
     VECMEM_CUDA_EXPORT
     explicit async_copy(const stream_wrapper& stream);
+    /// Constructor with a stream and flags to create CUDA events with
+    ///
+    /// For details on the flags, see the documentation
+    /// of @c cudaEventCreateWithFlags(...) on:
+    /// https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html
+    ///
+    /// @param stream The CUDA stream to perform the copies in
+    /// @param event_flags Flag(s) to create internal CUDA events with
+    ///
+    VECMEM_CUDA_EXPORT
+    async_copy(const stream_wrapper& stream, unsigned int event_flags);
     /// Move constructor
     VECMEM_CUDA_EXPORT
     async_copy(async_copy&&) noexcept;

--- a/cuda/src/utils/cuda/async_copy.cpp
+++ b/cuda/src/utils/cuda/async_copy.cpp
@@ -125,8 +125,11 @@ static const std::array<std::string, copy::type::count> copy_type_printer = {
 
 struct async_copy::impl {
 
-    /// Convenience constructor
+    /// Constructor with just a stream
     impl(cudaStream_t stream) : m_stream(stream), m_event_pool() {}
+    /// Constructor with a stream and flags to create CUDA events with
+    impl(cudaStream_t stream, unsigned int event_flags)
+        : m_stream(stream), m_event_pool(event_flags) {}
 
     /// The stream that the copies are performed on
     cudaStream_t m_stream;
@@ -137,6 +140,10 @@ struct async_copy::impl {
 
 async_copy::async_copy(const stream_wrapper& stream)
     : m_impl{std::make_unique<impl>(details::get_stream(stream))} {}
+
+async_copy::async_copy(const stream_wrapper& stream, unsigned int event_flags)
+    : m_impl{std::make_unique<impl>(details::get_stream(stream), event_flags)} {
+}
 
 async_copy::async_copy(async_copy&&) noexcept = default;
 

--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -35,9 +35,8 @@
 
 namespace {
 cudaEvent_t create_event(unsigned int flags) {
+    // "Safely" create a CUDA event with the specified flags.
     cudaEvent_t event;
-    // Disable collecting timing information since the event is used only for
-    // synchronization.
     VECMEM_CUDA_ERROR_CHECK(cudaEventCreateWithFlags(&event, flags));
     return event;
 }

--- a/cuda/src/utils/event_pool.cpp
+++ b/cuda/src/utils/event_pool.cpp
@@ -34,12 +34,11 @@
 #include <stdexcept>
 
 namespace {
-cudaEvent_t create_event() {
+cudaEvent_t create_event(unsigned int flags) {
     cudaEvent_t event;
     // Disable collecting timing information since the event is used only for
     // synchronization.
-    VECMEM_CUDA_ERROR_CHECK(
-        cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+    VECMEM_CUDA_ERROR_CHECK(cudaEventCreateWithFlags(&event, flags));
     return event;
 }
 }  // namespace
@@ -49,11 +48,14 @@ namespace cuda {
 namespace details {
 
 event_pool::event_pool(std::size_t size) {
-    // Create the (initial) events in the pool.
-    m_pool.reserve(size);
-    for (std::size_t i = 0; i < size; ++i) {
-        m_pool.push_back(::create_event());
-    }
+
+    initialize(size);
+}
+
+event_pool::event_pool(unsigned int event_flags, std::size_t size)
+    : m_event_flags(event_flags) {
+
+    initialize(size);
 }
 
 event_pool::~event_pool() {
@@ -71,7 +73,7 @@ cudaEvent_t event_pool::create() {
 
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
-        m_pool.push_back(::create_event());
+        m_pool.push_back(::create_event(m_event_flags));
     }
 
     // Return an (unused) event from the pool.
@@ -94,6 +96,15 @@ void event_pool::free(cudaEvent_t event) {
     // Put this event back at the end of the pool. So that the element pointed
     // at by m_used_events would always be available for use.
     std::swap(*it, m_pool[--m_used_events]);
+}
+
+void event_pool::initialize(std::size_t size) {
+    // Create the (initial) events in the pool.
+    assert(m_pool.size() == 0);
+    m_pool.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        m_pool.push_back(::create_event(m_event_flags));
+    }
 }
 
 }  // namespace details

--- a/cuda/src/utils/event_pool.hpp
+++ b/cuda/src/utils/event_pool.hpp
@@ -32,6 +32,9 @@ class event_pool {
 public:
     /// Constructor with the number of events to initially allocate
     explicit event_pool(std::size_t size = 8u);
+    /// Constructor with flags to create CUDA events with and the number of
+    /// events to initially allocate
+    event_pool(unsigned int event_flags, std::size_t size = 8u);
     /// Destructor
     ~event_pool();
 
@@ -41,6 +44,11 @@ public:
     void free(cudaEvent_t event);
 
 private:
+    /// Initialize the internal state of the pool
+    void initialize(std::size_t size);
+
+    /// Flags to create CUDA events with
+    unsigned int m_event_flags = cudaEventDisableTiming;
     /// The pool of events
     std::vector<cudaEvent_t> m_pool;
     /// The number of currently used events

--- a/hip/include/vecmem/utils/hip/async_copy.hpp
+++ b/hip/include/vecmem/utils/hip/async_copy.hpp
@@ -33,9 +33,23 @@ namespace vecmem::hip {
 class async_copy : public vecmem::copy {
 
 public:
-    /// Constructor with the stream to operate on
+    /// Constructor with the HIP stream to operate on
+    ///
+    /// @param stream The HIP stream to perform the copies in
+    ///
     VECMEM_HIP_EXPORT
     async_copy(const stream_wrapper& stream);
+    /// Constructor with a stream and flags to create HIP events with
+    ///
+    /// For details on the flags, see the documentation
+    /// of @c hipEventCreateWithFlags(...) on:
+    /// https://rocm.docs.amd.com/projects/HIP/en/develop/doxygen/html/group___event.html
+    ///
+    /// @param stream The HIP stream to perform the copies in
+    /// @param event_flags Flag(s) to create internal HIP events with
+    ///
+    VECMEM_HIP_EXPORT
+    async_copy(const stream_wrapper& stream, unsigned int event_flags);
     /// Move constructor
     VECMEM_HIP_EXPORT
     async_copy(async_copy&&) noexcept;

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -35,9 +35,8 @@
 
 namespace {
 hipEvent_t create_event(unsigned int flags) {
+    // "Safely" create a HIP event with the specified flags.
     hipEvent_t event;
-    // Disable collecting timing information since the event is used only for
-    // synchronization.
     VECMEM_HIP_ERROR_CHECK(hipEventCreateWithFlags(&event, flags));
     return event;
 }

--- a/hip/src/utils/event_pool.cpp
+++ b/hip/src/utils/event_pool.cpp
@@ -34,12 +34,11 @@
 #include <stdexcept>
 
 namespace {
-hipEvent_t create_event() {
+hipEvent_t create_event(unsigned int flags) {
     hipEvent_t event;
     // Disable collecting timing information since the event is used only for
     // synchronization.
-    VECMEM_HIP_ERROR_CHECK(
-        hipEventCreateWithFlags(&event, hipEventDisableTiming));
+    VECMEM_HIP_ERROR_CHECK(hipEventCreateWithFlags(&event, flags));
     return event;
 }
 }  // namespace
@@ -49,11 +48,14 @@ namespace hip {
 namespace details {
 
 event_pool::event_pool(std::size_t size) {
-    // Create the (initial) events in the pool.
-    m_pool.reserve(size);
-    for (std::size_t i = 0; i < size; ++i) {
-        m_pool.push_back(::create_event());
-    }
+
+    initialize(size);
+}
+
+event_pool::event_pool(unsigned int event_flags, std::size_t size)
+    : m_event_flags(event_flags) {
+
+    initialize(size);
 }
 
 event_pool::~event_pool() {
@@ -71,7 +73,7 @@ hipEvent_t event_pool::create() {
 
     // Create a new event if we don't have any available in the pool.
     if (m_pool.size() <= m_used_events) {
-        m_pool.push_back(::create_event());
+        m_pool.push_back(::create_event(m_event_flags));
     }
 
     // Return an (unused) event from the pool.
@@ -94,6 +96,15 @@ void event_pool::free(hipEvent_t event) {
     // Put this event back at the end of the pool. So that the element pointed
     // at by m_used_events would always be available for use.
     std::swap(*it, m_pool[--m_used_events]);
+}
+
+void event_pool::initialize(std::size_t size) {
+    // Create the (initial) events in the pool.
+    assert(m_pool.size() == 0);
+    m_pool.reserve(size);
+    for (std::size_t i = 0; i < size; ++i) {
+        m_pool.push_back(::create_event(m_event_flags));
+    }
 }
 
 }  // namespace details

--- a/hip/src/utils/event_pool.hpp
+++ b/hip/src/utils/event_pool.hpp
@@ -32,6 +32,9 @@ class event_pool {
 public:
     /// Constructor with the number of events to initially allocate
     explicit event_pool(std::size_t size = 8u);
+    /// Constructor with flags to create HIP events with and the number of
+    /// events to initially allocate
+    event_pool(unsigned int event_flags, std::size_t size = 8u);
     /// Destructor
     ~event_pool();
 
@@ -41,6 +44,11 @@ public:
     void free(hipEvent_t event);
 
 private:
+    /// Initialize the internal state of the pool
+    void initialize(std::size_t size);
+
+    /// Flags to create HIP events with
+    unsigned int m_event_flags = hipEventDisableTiming;
     /// The pool of events
     std::vector<hipEvent_t> m_pool;
     /// The number of currently used events

--- a/hip/src/utils/hip/async_copy.cpp
+++ b/hip/src/utils/hip/async_copy.cpp
@@ -124,8 +124,11 @@ static const std::array<std::string, copy::type::count> copy_type_printer = {
 
 struct async_copy::impl {
 
-    /// Convenience constructor
+    /// Constructor with just a stream
     impl(hipStream_t stream) : m_stream(stream), m_event_pool() {}
+    /// Constructor with a stream and flags to create HIP events with
+    impl(hipStream_t stream, unsigned int event_flags)
+        : m_stream(stream), m_event_pool(event_flags) {}
 
     /// The stream that the copies are performed on
     hipStream_t m_stream;
@@ -136,6 +139,10 @@ struct async_copy::impl {
 
 async_copy::async_copy(const stream_wrapper& stream)
     : m_impl{std::make_unique<impl>(details::get_stream(stream))} {}
+
+async_copy::async_copy(const stream_wrapper& stream, unsigned int event_flags)
+    : m_impl{std::make_unique<impl>(details::get_stream(stream), event_flags)} {
+}
 
 async_copy::async_copy(async_copy&&) noexcept = default;
 


### PR DESCRIPTION
Building on the improvements introduced by @m-fila earlier, I made it possible to specify event flags for `vecmem::cuda::async_copy` and `vecmem::hip::async_copy`.

This should practically never be necessary, but client code **may** want to experiment with using different types of CUDA/HIP events behind the scenes.