### PR TITLE
AdaptiveCpp Support, main branch (2026.04.24.)

### DIFF
--- a/core/include/vecmem/memory/device_atomic_ref.hpp
+++ b/core/include/vecmem/memory/device_atomic_ref.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2022-2024 CERN for the benefit of the ACTS project
+ * (c) 2022-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -13,7 +13,8 @@
 // System include(s).
 #include <atomic>
 
-#if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+#if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION) || \
+    defined(__ADAPTIVECPP__)
 #if defined(VECMEM_HAVE_SYCL_ATOMIC_REF)
 
 // Local include(s).


### PR DESCRIPTION
[AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp) uses a different set of macros than [oneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/overview.html) does. This update makes sure that the "generic device code" that we have in [traccc](https://github.com/acts-project/traccc), would work correctly with AdapriveCpp.