### PR TITLE
Install HIP toolkit CMake code with vecmem

### DIFF
--- a/cmake/vecmem-packaging.cmake
+++ b/cmake/vecmem-packaging.cmake
@@ -27,6 +27,7 @@ install( FILES
 
 # Install the "language helper" files.
 install( FILES
+   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindHIPToolkit.cmake"
    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vecmem-check-language.cmake"
    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vecmem-check-sycl-code-compiles.cmake"
    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/vecmem-check-sycl-source-compiles.cmake"


### PR DESCRIPTION
Currently, the vecmem packaging code does not install the `FindHIPToolkit.cmake` file along with the rest of the CMake code. This means that any code using `find_package(HIPToolkit)` will break when using an installed version of vecmem. This currently breaks the Alpaka HIP-SYCL build in traccc.