### PR TITLE
Make jagged container size types consistent with non-jagged ones

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -172,6 +172,7 @@ vecmem_add_library( vecmem_core core
    "include/vecmem/utils/tuple.hpp"
    "include/vecmem/utils/impl/tuple.ipp"
    "include/vecmem/utils/type_traits.hpp"
+   "include/vecmem/utils/details/narrow_size.hpp"
    "include/vecmem/utils/types.hpp"
    "src/utils/integer_math.hpp" )
 

--- a/core/include/vecmem/containers/data/jagged_vector_view.hpp
+++ b/core/include/vecmem/containers/data/jagged_vector_view.hpp
@@ -50,7 +50,7 @@ class jagged_vector_view {
 
 public:
     /// Size type used in the class
-    using size_type = std::size_t;
+    using size_type = unsigned int;
     /// Value type of the jagged array
     using value_type = vector_view<T>;
     /// Pointer type to the jagged array

--- a/core/include/vecmem/containers/impl/jagged_vector.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector.ipp
@@ -7,6 +7,9 @@
  */
 #pragma once
 
+// VecMem include(s).
+#include "vecmem/utils/details/narrow_size.hpp"
+
 // System include(s).
 #include <cassert>
 
@@ -21,7 +24,8 @@ data::jagged_vector_data<TYPE> get_data(jagged_vector<TYPE>& vec,
 
     // Construct the object to be returned.
     data::jagged_vector_data<TYPE> result(
-        size,
+        details::narrow_size<
+            typename data::jagged_vector_data<TYPE>::size_type>(size),
         (resource != nullptr ? *resource : *(vec.get_allocator().resource())));
 
     // Helper local type definition(s).
@@ -50,7 +54,10 @@ data::jagged_vector_data<TYPE> get_data(
     const std::size_t size = vec.size();
 
     // Construct the object to be returned.
-    data::jagged_vector_data<TYPE> result(size, *resource);
+    data::jagged_vector_data<TYPE> result(
+        details::narrow_size<
+            typename data::jagged_vector_data<TYPE>::size_type>(size),
+        *resource);
 
     // Helper local type definition(s).
     typedef typename data::jagged_vector_data<TYPE>::value_type value_type;
@@ -75,7 +82,8 @@ data::jagged_vector_data<const TYPE> get_data(const jagged_vector<TYPE>& vec,
 
     // Construct the object to be returned.
     data::jagged_vector_data<const TYPE> result(
-        size,
+        details::narrow_size<
+            typename data::jagged_vector_data<const TYPE>::size_type>(size),
         (resource != nullptr ? *resource : *(vec.get_allocator().resource())));
 
     // Helper local type definition(s).
@@ -105,7 +113,10 @@ data::jagged_vector_data<const TYPE> get_data(
     const std::size_t size = vec.size();
 
     // Construct the object to be returned.
-    data::jagged_vector_data<const TYPE> result(size, *resource);
+    data::jagged_vector_data<const TYPE> result(
+        details::narrow_size<
+            typename data::jagged_vector_data<const TYPE>::size_type>(size),
+        *resource);
 
     // Helper local type definition(s).
     typedef

--- a/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
+++ b/core/include/vecmem/containers/impl/jagged_vector_buffer.ipp
@@ -9,6 +9,7 @@
 
 // vecmem include(s).
 #include "vecmem/containers/details/aligned_multiple_placement.hpp"
+#include "vecmem/utils/details/narrow_size.hpp"
 
 // System include(s).
 #include <algorithm>
@@ -36,6 +37,7 @@ allocate_jagged_buffer_outer_memory(
             resource, size);
     }
 }
+
 }  // namespace
 
 namespace vecmem {
@@ -66,11 +68,15 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
     const std::vector<SIZE_TYPE, SIZE_ALLOC>& capacities,
     memory_resource& resource, memory_resource* host_access_resource,
     buffer_type type)
-    : base_type(capacities.size(), nullptr),
+    : base_type(vecmem::details::narrow_size<size_type>(capacities.size()),
+                nullptr),
       m_outer_memory(::allocate_jagged_buffer_outer_memory<TYPE>(
-          (host_access_resource == nullptr ? 0 : capacities.size()), resource)),
+          (host_access_resource == nullptr
+               ? 0
+               : vecmem::details::narrow_size<size_type>(capacities.size())),
+          resource)),
       m_outer_host_memory(::allocate_jagged_buffer_outer_memory<TYPE>(
-          capacities.size(),
+          vecmem::details::narrow_size<size_type>(capacities.size()),
           (host_access_resource == nullptr ? resource
                                            : *host_access_resource))) {
 
@@ -99,7 +105,7 @@ jagged_vector_buffer<TYPE>::jagged_vector_buffer(
 
     // Set up the base object.
     base_type::operator=(base_type{
-        capacities.size(),
+        vecmem::details::narrow_size<size_type>(capacities.size()),
         ((host_access_resource != nullptr) ? m_outer_memory.get()
                                            : m_outer_host_memory.get()),
         m_outer_host_memory.get()});

--- a/core/include/vecmem/containers/jagged_device_vector.hpp
+++ b/core/include/vecmem/containers/jagged_device_vector.hpp
@@ -53,7 +53,7 @@ public:
     /// Type of the "outer" array elements
     using value_type = device_vector<T>;
     /// Size type for the array
-    using size_type = std::size_t;
+    using size_type = unsigned int;
     /// Pointer difference type
     using difference_type = std::ptrdiff_t;
 

--- a/core/include/vecmem/edm/details/data_traits.hpp
+++ b/core/include/vecmem/edm/details/data_traits.hpp
@@ -6,6 +6,9 @@
  */
 #pragma once
 
+// VecMem include(s).
+#include "vecmem/utils/details/narrow_size.hpp"
+
 // Local include(s).
 #include "vecmem/containers/data/jagged_vector_data.hpp"
 #include "vecmem/edm/details/schema_traits.hpp"
@@ -49,7 +52,9 @@ template <typename TYPE>
 struct data_alloc<type::jagged_vector<TYPE>> {
     static typename data_type<type::jagged_vector<TYPE>>::type make(
         std::size_t size, memory_resource& mr) {
-        return {size, mr};
+        using data_t = typename data_type<type::jagged_vector<TYPE>>::type;
+        return {vecmem::details::narrow_size<typename data_t::size_type>(size),
+                mr};
     }
 };  // struct data_alloc
 

--- a/core/include/vecmem/utils/details/narrow_size.hpp
+++ b/core/include/vecmem/utils/details/narrow_size.hpp
@@ -1,0 +1,61 @@
+/*
+ * VecMem project, part of the ACTS project (R&D line)
+ *
+ * (c) 2026 CERN for the benefit of the ACTS project
+ *
+ * Mozilla Public License Version 2.0
+ */
+#pragma once
+
+// VecMem include(s).
+#include "vecmem/utils/types.hpp"
+
+// System include(s).
+#include <cassert>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+namespace vecmem::details {
+
+/// Narrow a host-side element count to a device-side size type.
+///
+/// The device-side containers deliberately use a 32-bit @c size_type rather
+/// than @c std::size_t. Resizable vectors and buffers update their size with
+/// atomic operations on the device, and CUDA, HIP and SYCL only guarantee
+/// atomic support for 32-bit integer types. See acts-project/vecmem#96.
+///
+/// Sizes therefore have to be narrowed when they cross from the host into a
+/// device-side object. That narrowing is intentional, but it should be
+/// explicit at every call site rather than implicit, so that it is visible in
+/// review and so that the build stays free of @c -Wconversion and
+/// @c -Wnarrowing diagnostics. A container with more elements than the
+/// device-side size type can represent is not a supported configuration, and
+/// is caught by an assertion in debug builds.
+///
+/// Only ever called from host code: sizes are computed on the host and
+/// baked into the view/buffer before it is handed to a device. Keeping it
+/// host-only avoids pulling @c std::numeric_limits, which is not marked as
+/// device-callable, into device compilation.
+///
+/// @tparam SIZE_TYPE  The device-side size type to narrow to
+/// @tparam INPUT_TYPE The host-side size type to narrow from
+/// @param  size       The host-side size
+/// @return The same value, represented in the device-side size type
+///
+template <typename SIZE_TYPE, typename INPUT_TYPE>
+VECMEM_HOST constexpr SIZE_TYPE narrow_size(INPUT_TYPE size) {
+
+    static_assert(
+        std::is_integral_v<SIZE_TYPE> && std::is_unsigned_v<SIZE_TYPE>,
+        "The device-side size type must be an unsigned integer type");
+    static_assert(
+        std::is_integral_v<INPUT_TYPE> && std::is_unsigned_v<INPUT_TYPE>,
+        "Only unsigned sizes can be narrowed with this helper");
+
+    assert(static_cast<std::size_t>(size) <=
+           static_cast<std::size_t>(std::numeric_limits<SIZE_TYPE>::max()));
+    return static_cast<SIZE_TYPE>(size);
+}
+
+}  // namespace vecmem::details

--- a/core/include/vecmem/utils/impl/copy.ipp
+++ b/core/include/vecmem/utils/impl/copy.ipp
@@ -194,7 +194,7 @@ copy::event_type copy::setup(data::jagged_vector_view<TYPE> data) const {
                 typename vecmem::data::jagged_vector_buffer<TYPE>::value_type),
         data.host_ptr(), data.ptr(), type::host_to_device);
     VECMEM_DEBUG_MSG(2,
-                     "Prepared a jagged device vector buffer of size %lu "
+                     "Prepared a jagged device vector buffer of size %u "
                      "for use on a device",
                      data.size());
 

--- a/tests/core/test_core_edm_buffer.cpp
+++ b/tests/core/test_core_edm_buffer.cpp
@@ -15,6 +15,9 @@
 #include <gtest/gtest.h>
 
 // System include(s).
+#include <type_traits>
+
+// System include(s).
 #include <algorithm>
 #include <numeric>
 #include <vector>
@@ -385,7 +388,8 @@ TEST_F(core_edm_buffer_test, device) {
     auto check_fixed_jagged = [&](const auto& v) {
         ASSERT_EQ(v.size(), CAPACITY);
         ASSERT_EQ(v.capacity(), CAPACITY);
-        for (std::size_t i = 0; i < CAPACITY; ++i) {
+        for (typename std::decay_t<decltype(v)>::size_type i = 0; i < CAPACITY;
+             ++i) {
             ASSERT_EQ(v[i].size(), CAPACITIES[i]);
             ASSERT_EQ(v[i].capacity(), CAPACITIES[i]);
         }
@@ -426,7 +430,8 @@ TEST_F(core_edm_buffer_test, device) {
     auto check_resizable_jagged = [&](const auto& v) {
         ASSERT_EQ(v.size(), CAPACITY);
         ASSERT_EQ(v.capacity(), CAPACITY);
-        for (std::size_t i = 0; i < CAPACITY; ++i) {
+        for (typename std::decay_t<decltype(v)>::size_type i = 0; i < CAPACITY;
+             ++i) {
             ASSERT_EQ(v[i].size(), 0u);
             ASSERT_EQ(v[i].capacity(), CAPACITIES[i]);
         }

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -9,6 +9,8 @@
 // VecMem include(s).
 #include "vecmem/containers/data/jagged_vector_data.hpp"
 #include "vecmem/containers/data/jagged_vector_view.hpp"
+#include "vecmem/containers/data/vector_view.hpp"
+#include "vecmem/containers/device_vector.hpp"
 #include "vecmem/containers/jagged_device_vector.hpp"
 #include "vecmem/containers/jagged_vector.hpp"
 #include "vecmem/containers/vector.hpp"
@@ -20,6 +22,7 @@
 
 // System include(s).
 #include <set>
+#include <type_traits>
 
 class core_jagged_vector_view_test : public testing::Test {
 protected:
@@ -143,7 +146,8 @@ TEST_F(core_jagged_vector_view_test, filter) {
 
     // Fill the jagged vector buffer with just the odd elements.
     vecmem::jagged_device_vector device_vec(output_data);
-    for (std::size_t i = 0; i < m_vec.size(); ++i) {
+    using jagged_size_type = decltype(device_vec)::size_type;
+    for (jagged_size_type i = 0; i < device_vec.size(); ++i) {
         for (std::size_t j = 0; j < m_vec.at(i).size(); ++j) {
             if ((m_vec[i][j] % 2) != 0) {
                 device_vec[i].push_back(m_vec[i][j]);
@@ -257,4 +261,32 @@ TEST_F(core_jagged_vector_view_test, sizeless_fixed) {
     EXPECT_EQ(output[0].size(), 0);
     EXPECT_EQ(output[1].size(), 0);
     EXPECT_EQ(output[2].size(), 0);
+}
+
+/// Test that the jagged containers agree with their non-jagged counterparts
+/// on the size type.
+///
+/// This is not merely cosmetic. Device-side resizing increments the size
+/// member atomically, and CUDA, HIP and SYCL only guarantee atomic support
+/// for 32-bit integer types -- not necessarily for @c std::size_t. That is
+/// why @c vecmem::device_vector::size_type is @c unsigned @c int, and the
+/// jagged variants have to match it. See acts-project/vecmem#96.
+TEST_F(core_jagged_vector_view_test, size_type_consistency) {
+
+    static_assert(
+        std::is_same_v<vecmem::jagged_device_vector<int>::size_type,
+                       vecmem::device_vector<int>::size_type>,
+        "vecmem::jagged_device_vector and vecmem::device_vector must use the "
+        "same size type");
+
+    static_assert(
+        std::is_same_v<vecmem::data::jagged_vector_view<int>::size_type,
+                       vecmem::data::vector_view<int>::size_type>,
+        "vecmem::data::jagged_vector_view and vecmem::data::vector_view must "
+        "use the same size type");
+
+    static_assert(std::is_same_v<vecmem::jagged_device_vector<int>::size_type,
+                                 unsigned int>,
+                  "The device-side size type must be a type for which CUDA, "
+                  "HIP and SYCL guarantee atomic operations");
 }


### PR DESCRIPTION
Closes #96.

`vecmem::jagged_device_vector` and `vecmem::data::jagged_vector_view` used
`std::size_t` as their `size_type`, while `vecmem::device_vector` and
`vecmem::data::vector_view` use `unsigned int`.

Changing the two typedefs on their own builds clean and the whole suite passes,
which is misleading, the affected code is in `.ipp` templates that only
instantiate when something uses them. Adding a test that pins the types forces
instantiation, and surfaces the conversions the wider typedef had been hiding:

| Location | Diagnostic |
|---|---|
| `jagged_vector.ipp` — outer size, all four `get_data` overloads | `-Wconversion` |
| `jagged_vector_buffer.ipp:69,71,73` — `capacities.size()` | `-Wconversion` |
| `jagged_vector_buffer.ipp:102` — same, inside a braced initialiser | `-Wnarrowing` |
| `edm/details/data_traits.hpp:52` — braced initialiser | `-Wnarrowing` |

Per @krasznaa's explanation on the issue, 32-bit atomics are guaranteed on
CUDA/HIP/SYCL, `std::size_t` isn't, the narrowing itself is correct, so I've
kept it and made it explicit rather than removing it.
`vecmem::details::narrow_size()` carries that rationale in its documentation and
asserts in debug builds that the value fits; a jagged vector with more than
`UINT_MAX` rows isn't a supported configuration.

Also adds a `static_assert` test that the jagged and non-jagged size types agree,
so they can't drift apart again without the suite noticing.

**Two things I'd welcome direction on:**

1. I used a shared `narrow_size` helper rather than a `static_cast` at each of
   the six sites, on the grounds that the reason for the narrowing is worth
   stating once. Happy to switch to plain casts if you'd prefer less machinery.
2. I've only built and tested the core library, no CUDA/HIP/SYCL setup here, so
   the device backends are untested beyond compiling against the changed headers.
   Relying on CI for those.

Verified with GCC 11 (Linux) and AppleClang 17 (macOS): full build with no new
warnings, 296/296 tests passing, clang-format v10.0.1 clean.