### PR TITLE
Device Vector Cross-Construct, main branch (2026.08.13.)

### DIFF
--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -84,7 +84,7 @@ public:
     device_vector(const device_vector& parent) = default;
     /// Copy constructor
     template <typename OTHERTYPE,
-              std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value,
+              std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
                                bool> = true>
     VECMEM_HOST_AND_DEVICE device_vector(
         const device_vector<OTHERTYPE>& parent);

--- a/core/include/vecmem/containers/device_vector.hpp
+++ b/core/include/vecmem/containers/device_vector.hpp
@@ -35,6 +35,9 @@ class device;
 template <typename TYPE>
 class device_vector {
 
+    // Make other specializations of the class a friend of this class.
+    template <typename OTHERTYPE>
+    friend class device_vector;
     // Make @c vecmem::edm::device a friend of this class.
     template <typename T, template <typename> class I>
     friend class edm::device;

--- a/core/include/vecmem/containers/impl/device_vector.ipp
+++ b/core/include/vecmem/containers/impl/device_vector.ipp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -30,7 +30,7 @@ VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
 
 template <typename TYPE>
 template <typename OTHERTYPE,
-          std::enable_if_t<std::is_convertible<OTHERTYPE, TYPE>::value, bool>>
+          std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value, bool>>
 VECMEM_HOST_AND_DEVICE device_vector<TYPE>::device_vector(
     const device_vector<OTHERTYPE>& parent)
     : m_capacity(parent.m_capacity),

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -1,6 +1,6 @@
 /* VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -40,66 +40,73 @@ struct core_device_container_test : public testing::Test {
 TEST_F(core_device_container_test, construct_copy_assign) {
 
     EXPECT_TRUE(std::is_trivially_default_constructible<
-                vecmem::data::jagged_vector_view<const int> >());
+                vecmem::data::jagged_vector_view<const int>>());
     EXPECT_TRUE(std::is_trivially_constructible<
-                vecmem::data::jagged_vector_view<const int> >());
+                vecmem::data::jagged_vector_view<const int>>());
     EXPECT_TRUE(std::is_trivially_copy_constructible<
-                vecmem::data::jagged_vector_view<const int> >());
+                vecmem::data::jagged_vector_view<const int>>());
     EXPECT_TRUE(std::is_trivially_copyable<
-                vecmem::data::jagged_vector_view<const int> >());
+                vecmem::data::jagged_vector_view<const int>>());
 
     EXPECT_TRUE(std::is_trivially_default_constructible<
-                vecmem::data::jagged_vector_view<int> >());
+                vecmem::data::jagged_vector_view<int>>());
     EXPECT_TRUE(std::is_trivially_constructible<
-                vecmem::data::jagged_vector_view<int> >());
+                vecmem::data::jagged_vector_view<int>>());
     EXPECT_TRUE(std::is_trivially_copy_constructible<
-                vecmem::data::jagged_vector_view<int> >());
+                vecmem::data::jagged_vector_view<int>>());
     EXPECT_TRUE(
-        std::is_trivially_copyable<vecmem::data::jagged_vector_view<int> >());
+        std::is_trivially_copyable<vecmem::data::jagged_vector_view<int>>());
 
     bool helper = std::is_assignable<vecmem::data::jagged_vector_view<int>,
-                                     vecmem::data::jagged_vector_view<int> >();
+                                     vecmem::data::jagged_vector_view<int>>();
     EXPECT_TRUE(helper);
     helper = std::is_assignable<vecmem::data::jagged_vector_view<const int>,
-                                vecmem::data::jagged_vector_view<const int> >();
+                                vecmem::data::jagged_vector_view<const int>>();
     EXPECT_TRUE(helper);
     helper = std::is_assignable<vecmem::data::jagged_vector_view<const int>,
-                                vecmem::data::jagged_vector_view<int> >();
+                                vecmem::data::jagged_vector_view<int>>();
     EXPECT_TRUE(helper);
 
     EXPECT_TRUE(std::is_trivially_default_constructible<
-                vecmem::data::vector_view<const int> >());
+                vecmem::data::vector_view<const int>>());
     EXPECT_TRUE(std::is_trivially_constructible<
-                vecmem::data::vector_view<const int> >());
+                vecmem::data::vector_view<const int>>());
     EXPECT_TRUE(std::is_trivially_copy_constructible<
-                vecmem::data::vector_view<const int> >());
+                vecmem::data::vector_view<const int>>());
     EXPECT_TRUE(
-        std::is_trivially_copyable<vecmem::data::vector_view<const int> >());
+        std::is_trivially_copyable<vecmem::data::vector_view<const int>>());
 
     EXPECT_TRUE(std::is_trivially_default_constructible<
-                vecmem::data::vector_view<int> >());
+                vecmem::data::vector_view<int>>());
     EXPECT_TRUE(
-        std::is_trivially_constructible<vecmem::data::vector_view<int> >());
-    EXPECT_TRUE(std::is_trivially_copy_constructible<
-                vecmem::data::vector_view<int> >());
-    EXPECT_TRUE(std::is_trivially_copyable<vecmem::data::vector_view<int> >());
+        std::is_trivially_constructible<vecmem::data::vector_view<int>>());
+    EXPECT_TRUE(
+        std::is_trivially_copy_constructible<vecmem::data::vector_view<int>>());
+    EXPECT_TRUE(std::is_trivially_copyable<vecmem::data::vector_view<int>>());
 
     helper = std::is_assignable<vecmem::data::vector_view<int>,
-                                vecmem::data::vector_view<int> >();
+                                vecmem::data::vector_view<int>>();
     EXPECT_TRUE(helper);
     helper = std::is_assignable<vecmem::data::vector_view<const int>,
-                                vecmem::data::vector_view<const int> >();
+                                vecmem::data::vector_view<const int>>();
     EXPECT_TRUE(helper);
     helper = std::is_assignable<vecmem::data::vector_view<const int>,
-                                vecmem::data::vector_view<int> >();
+                                vecmem::data::vector_view<int>>();
     EXPECT_TRUE(helper);
 
     EXPECT_TRUE(
-        std::is_default_constructible<vecmem::data::vector_buffer<int> >());
+        std::is_default_constructible<vecmem::data::vector_buffer<int>>());
     EXPECT_TRUE(std::is_default_constructible<
-                vecmem::data::jagged_vector_buffer<int> >());
-    EXPECT_TRUE(std::is_default_constructible<
-                vecmem::data::jagged_vector_data<int> >());
+                vecmem::data::jagged_vector_buffer<int>>());
+    EXPECT_TRUE(
+        std::is_default_constructible<vecmem::data::jagged_vector_data<int>>());
+
+    auto helper2 = std::is_constructible<vecmem::device_vector<const int>,
+                                         vecmem::device_vector<int>>();
+    EXPECT_TRUE(helper2);
+    auto helper3 = std::is_constructible<vecmem::device_vector<int>,
+                                         vecmem::device_vector<const int>>();
+    EXPECT_FALSE(helper3);
 }
 
 /// Test(s) for @c vecmem::data::vector_buffer
@@ -124,16 +131,16 @@ TEST_F(core_device_container_test, vector_buffer) {
 TEST_F(core_device_container_test, jagged_vector_buffer) {
 
     // Create a dummy jagged vector in regular host memory.
-    std::vector<std::vector<int> > host_vector{{},
-                                               {1, 2, 3, 4, 5},
-                                               {6, 7},
-                                               {8, 9, 10, 11},
-                                               {12, 13, 14, 15, 16, 17, 18},
-                                               {},
-                                               {},
-                                               {19, 20},
-                                               {},
-                                               {21}};
+    std::vector<std::vector<int>> host_vector{{},
+                                              {1, 2, 3, 4, 5},
+                                              {6, 7},
+                                              {8, 9, 10, 11},
+                                              {12, 13, 14, 15, 16, 17, 18},
+                                              {},
+                                              {},
+                                              {19, 20},
+                                              {},
+                                              {21}};
     const std::vector<unsigned int> capacities{0u, 5u, 2u, 4u, 7u,
                                                0u, 0u, 2u, 0u, 1u};
     auto host_data = vecmem::get_data(host_vector, &m_resource);

--- a/tests/core/test_core_device_containers.cpp
+++ b/tests/core/test_core_device_containers.cpp
@@ -101,12 +101,16 @@ TEST_F(core_device_container_test, construct_copy_assign) {
     EXPECT_TRUE(
         std::is_default_constructible<vecmem::data::jagged_vector_data<int>>());
 
-    auto helper2 = std::is_constructible<vecmem::device_vector<const int>,
-                                         vecmem::device_vector<int>>();
-    EXPECT_TRUE(helper2);
-    auto helper3 = std::is_constructible<vecmem::device_vector<int>,
-                                         vecmem::device_vector<const int>>();
-    EXPECT_FALSE(helper3);
+    helper = std::is_constructible<vecmem::device_vector<const int>,
+                                   vecmem::device_vector<int>>();
+    EXPECT_TRUE(helper);
+    helper = std::is_constructible<vecmem::device_vector<int>,
+                                   vecmem::device_vector<const int>>();
+    EXPECT_FALSE(helper);
+
+    // Try to actually construct a non-const device vector from a const one.
+    vecmem::device_vector<const int> const_device_vector(
+        vecmem::device_vector<int>({}));
 }
 
 /// Test(s) for @c vecmem::data::vector_buffer


### PR DESCRIPTION
Added a test for constructing `const` device vectors from non-`const` ones. And to cross check, making sure that a non-`const` vector could not be made from a `const` one.

This is to follow up on issue #348. Which I couldn't quite re-produce. :frowning: @niermann999, do you have a case in which you still see this issue showing up?

And pre-commit / clang-format changing a whole lot of lines in the test is not all that great... :frowning: