### PR TITLE
Allow converting a jagged device vector iterator to a const one

### DIFF
--- a/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
+++ b/core/include/vecmem/containers/details/jagged_device_vector_iterator.hpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2024 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -32,6 +32,10 @@ namespace details {
 ///
 template <typename TYPE>
 class jagged_device_vector_iterator {
+
+    // Make other specializations of the class a friend of this class.
+    template <typename OTHERTYPE>
+    friend class jagged_device_vector_iterator;
 
 public:
     /// @name Types describing the underlying data
@@ -102,10 +106,12 @@ public:
     /// Copy constructor
     VECMEM_HOST_AND_DEVICE
     jagged_device_vector_iterator(const jagged_device_vector_iterator& parent);
-    /// Copy constructor
-    template <typename T>
+    /// Copy constructor from a non-const iterator, for a const iterator
+    template <typename OTHERTYPE,
+              std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value,
+                               bool> = true>
     VECMEM_HOST_AND_DEVICE jagged_device_vector_iterator(
-        const jagged_device_vector_iterator<T>& parent);
+        const jagged_device_vector_iterator<OTHERTYPE>& parent);
 
     /// Copy assignment operator
     VECMEM_HOST_AND_DEVICE

--- a/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
+++ b/core/include/vecmem/containers/impl/jagged_device_vector_iterator.ipp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2023 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -58,11 +58,15 @@ jagged_device_vector_iterator<TYPE>::jagged_device_vector_iterator(
     : m_ptr(parent.m_ptr) {}
 
 template <typename TYPE>
-template <typename T>
+template <typename OTHERTYPE,
+          std::enable_if_t<details::is_same_nc<TYPE, OTHERTYPE>::value, bool> >
 VECMEM_HOST_AND_DEVICE
 jagged_device_vector_iterator<TYPE>::jagged_device_vector_iterator(
-    const jagged_device_vector_iterator<T>& parent)
-    : m_ptr(parent.m_ptr) {}
+    const jagged_device_vector_iterator<OTHERTYPE>& parent)
+    // Just like for the constructor taking a vector_view, this looks more
+    // scary than it is. We convert from a non-const type to a constant one
+    // here.
+    : m_ptr{reinterpret_cast<data_pointer>(parent.m_ptr)} {}
 
 template <typename TYPE>
 VECMEM_HOST_AND_DEVICE jagged_device_vector_iterator<TYPE>&

--- a/tests/core/test_core_jagged_vector_view.cpp
+++ b/tests/core/test_core_jagged_vector_view.cpp
@@ -1,7 +1,7 @@
 /*
  * VecMem project, part of the ACTS project (R&D line)
  *
- * (c) 2021-2025 CERN for the benefit of the ACTS project
+ * (c) 2021-2026 CERN for the benefit of the ACTS project
  *
  * Mozilla Public License Version 2.0
  */
@@ -289,4 +289,42 @@ TEST_F(core_jagged_vector_view_test, size_type_consistency) {
                                  unsigned int>,
                   "The device-side size type must be a type for which CUDA, "
                   "HIP and SYCL guarantee atomic operations");
+}
+
+/// Test that a mutable jagged iterator converts to a constant one.
+///
+/// Every standard container allows assigning an @c iterator to a
+/// @c const_iterator, and @c vecmem::jagged_device_vector declares both. The
+/// conversion is a cross-instantiation one though: it reads the private
+/// member of a *different* instantiation of the iterator template, which is
+/// only legal with a friend declaration. Note that a trait check alone would
+/// not exercise this, since @c std::is_constructible never instantiates the
+/// constructor body. See acts-project/vecmem#348.
+TEST_F(core_jagged_vector_view_test, const_iterator_conversion) {
+
+    using iterator = vecmem::jagged_device_vector<int>::iterator;
+    using const_iterator = vecmem::jagged_device_vector<int>::const_iterator;
+
+    // Adding constness must be allowed, removing it must not be.
+    static_assert(std::is_constructible_v<const_iterator, iterator>,
+                  "A constant iterator must be constructible from a mutable "
+                  "one");
+    static_assert(!std::is_constructible_v<iterator, const_iterator>,
+                  "A mutable iterator must not be constructible from a "
+                  "constant one");
+
+    // Actually perform the conversion, which is what forces the constructor
+    // body to be instantiated.
+    const_iterator citr = m_jag.begin();
+    EXPECT_EQ(citr->size(), m_jag.begin()->size());
+    EXPECT_EQ(citr->at(0), m_jag.begin()->at(0));
+
+    // The same conversion, one level further out, through the reverse
+    // iterators.
+    vecmem::jagged_device_vector<int>::const_reverse_iterator critr =
+        m_jag.rbegin();
+    EXPECT_EQ(critr->size(), m_jag.rbegin()->size());
+
+    // The converted iterator must still compare equal to where it came from.
+    EXPECT_TRUE(citr == const_iterator{m_jag.begin()});
 }


### PR DESCRIPTION
Follow-up to the discussion on #366, where @krasznaa invited further proposals.

`vecmem::jagged_device_vector` declares both `iterator` and `const_iterator`, but the ordinary standard container idiom does not compile on main:

```cpp
vecmem::jagged_device_vector<int>::const_iterator citr = jdv.begin();
vecmem::jagged_device_vector<int>::const_reverse_iterator critr = jdv.rbegin();
```

Three things were wrong with the converting constructor:

1. It was declared `template <typename T>` with no constraint at all, so it would accept any instantiation rather than only the const-qualifying one. Now constrained with `details::is_same_nc`, matching the change in #366.
2. It reads `parent.m_ptr` from a different instantiation, which is private in that context. Fixed with a friend declaration, same as #366.
3. `const vector_view<int>*` does not implicitly convert to `const vector_view<const int>*`. The sibling constructor taking a `vector_view` already handles exactly this with a documented `reinterpret_cast`, so I matched it rather than introducing a second approach.

`begin() const` was never affected, because it builds the const iterator straight from the pointer through that sibling constructor. Only the iterator-to-iterator conversion is broken, which is why this went unnoticed.

**On the audit.** Since you mentioned such bugs might exist elsewhere, I went through every member function in the library that takes a different instantiation of its own class template. There are seven. I forced instantiation of six of them in a single translation unit, and exactly two fail: `device_vector`, which this PR's parent fixes, and this one. The other four are correct by construction, since `data::vector_view`, `data::jagged_vector_view` and `details::reverse_iterator` read the other instantiation through public accessors, and `vecmem::tuple` is a `struct` with public members. The seventh, `edm::proxy`, I checked by reading rather than by compiling; it also goes through a public accessor (`variables()`). So with #366 merged, this should be the last of them.

**On the test.** It asserts the conversion is permitted in one direction and rejected in the other, then actually performs it, since a trait check alone would not have caught any of this. I checked that it fails without the fix: reverting the two header changes and keeping the test gives three errors, the `static_assert` on the unconstrained direction plus the two compile errors above.

Locally: full build with no new warnings and 297/297 tests passing, on both GCC 11 and AppleClang 17. clang-format v10.0.1 clean. I do not have a CUDA/HIP/SYCL setup, so the device backends are untested beyond compiling against the changed headers, relying on CI for those.